### PR TITLE
Use Python lists for per-step state in simulation loops

### DIFF
--- a/machwave/simulation.py
+++ b/machwave/simulation.py
@@ -63,7 +63,7 @@ class InternalBallisticsSimulation:
     ) -> None:
         self.motor: Motor = motor
         self.params: InternalBallisticsSimulationParams = params
-        self.t: np.ndarray = np.array([0])
+        self.t: np.ndarray = np.array([0.0])
         self.motor_state: MotorState | None = None
 
     def get_motor_state(self) -> MotorState:
@@ -85,15 +85,16 @@ class InternalBallisticsSimulation:
         """
         self.motor_state = self.get_motor_state()
 
-        i = 0
-        while not self.motor_state.end_thrust:
-            self.t = np.append(self.t, self.t[i] + self.params.d_t)
+        d_t = self.params.d_t
+        P_ext = self.params.external_pressure
+        t_values: list[float] = [0.0]
 
-            self.motor_state.run_timestep(
-                self.params.d_t,
-                self.params.external_pressure,
-            )
-            i += 1
+        while not self.motor_state.end_thrust:
+            t_values.append(t_values[-1] + d_t)
+            self.motor_state.run_timestep(d_t, P_ext)
+
+        self.t = np.asarray(t_values)
+        self.motor_state._finalize()
 
         return (self.t, self.motor_state)
 

--- a/machwave/simulation.py
+++ b/machwave/simulation.py
@@ -94,7 +94,7 @@ class InternalBallisticsSimulation:
             self.motor_state.run_timestep(d_t, P_ext)
 
         self.t = np.asarray(t_values)
-        self.motor_state._finalize()
+        self.motor_state.convert_simulation_arrays_to_numpy()
 
         return (self.t, self.motor_state)
 

--- a/machwave/states/base.py
+++ b/machwave/states/base.py
@@ -16,8 +16,6 @@ class MotorState(ABC):
     obtained from the simulation.
     """
 
-    # Per-step accumulators built up as Python lists during the simulation
-    # loop (O(1) append) and converted to np.ndarray once via convert_simulation_arrays_to_numpy().
     SIMULATION_ARRAY_ATTRIBUTE_NAMES: tuple[str, ...] = (
         "t",
         "m_prop",
@@ -42,26 +40,18 @@ class MotorState(ABC):
         self.motor = motor
         self.other_losses = other_losses
 
-        self.t: SimulationArray = [0.0]  # time vector
+        self.t: SimulationArray = [0.0]
 
         self.m_prop: SimulationArray = [motor.initial_propellant_mass]
         self.P_0: SimulationArray = [initial_pressure]
         self.P_exit: SimulationArray = [initial_atmospheric_pressure]
 
-        # Thrust coefficients and thrust:
         self.C_f: SimulationArray = [0.0]
         self.C_f_ideal: SimulationArray = [0.0]
         self.thrust: SimulationArray = [0.0]
 
-        # Thrust time:
         self._thrust_time = None
 
-        # If the propellant mass is non zero, 'end_thrust' must be False,
-        # since there is still thrust being produced.
-        # After the propellant has finished burning and the thrust chamber has
-        # stopped producing supersonic flow, 'end_thrust' is changed to True
-        # value and the internal ballistics section of the while loop below
-        # stops running.
         self.end_thrust = False
         self.end_burn = False
 

--- a/machwave/states/base.py
+++ b/machwave/states/base.py
@@ -1,8 +1,13 @@
 from abc import ABC, abstractmethod
+from typing import TypeAlias
 
 import numpy as np
 
 from machwave.models.motors import Motor
+
+# Python list during the simulation loop (O(1) appends), then converted to
+# np.ndarray by convert_simulation_arrays_to_numpy() once the loop ends.
+SimulationArray: TypeAlias = list[float]
 
 
 class MotorState(ABC):
@@ -12,8 +17,8 @@ class MotorState(ABC):
     """
 
     # Per-step accumulators built up as Python lists during the simulation
-    # loop (O(1) append) and converted to np.ndarray once via _finalize().
-    _ARRAY_ATTRS: tuple[str, ...] = (
+    # loop (O(1) append) and converted to np.ndarray once via convert_simulation_arrays_to_numpy().
+    SIMULATION_ARRAY_ATTRIBUTE_NAMES: tuple[str, ...] = (
         "t",
         "m_prop",
         "P_0",
@@ -37,16 +42,16 @@ class MotorState(ABC):
         self.motor = motor
         self.other_losses = other_losses
 
-        self.t: list[float] = [0.0]  # time vector
+        self.t: SimulationArray = [0.0]  # time vector
 
-        self.m_prop: list[float] = [motor.initial_propellant_mass]
-        self.P_0: list[float] = [initial_pressure]
-        self.P_exit: list[float] = [initial_atmospheric_pressure]
+        self.m_prop: SimulationArray = [motor.initial_propellant_mass]
+        self.P_0: SimulationArray = [initial_pressure]
+        self.P_exit: SimulationArray = [initial_atmospheric_pressure]
 
         # Thrust coefficients and thrust:
-        self.C_f: list[float] = [0.0]
-        self.C_f_ideal: list[float] = [0.0]
-        self.thrust: list[float] = [0.0]
+        self.C_f: SimulationArray = [0.0]
+        self.C_f_ideal: SimulationArray = [0.0]
+        self.thrust: SimulationArray = [0.0]
 
         # Thrust time:
         self._thrust_time = None
@@ -60,9 +65,9 @@ class MotorState(ABC):
         self.end_thrust = False
         self.end_burn = False
 
-    def _finalize(self) -> None:
+    def convert_simulation_arrays_to_numpy(self) -> None:
         """Convert accumulated lists into ndarrays for downstream consumers."""
-        for name in self._ARRAY_ATTRS:
+        for name in self.SIMULATION_ARRAY_ATTRIBUTE_NAMES:
             value = getattr(self, name)
             if not isinstance(value, np.ndarray):
                 setattr(self, name, np.asarray(value))

--- a/machwave/states/base.py
+++ b/machwave/states/base.py
@@ -11,6 +11,18 @@ class MotorState(ABC):
     obtained from the simulation.
     """
 
+    # Per-step accumulators built up as Python lists during the simulation
+    # loop (O(1) append) and converted to np.ndarray once via _finalize().
+    _ARRAY_ATTRS: tuple[str, ...] = (
+        "t",
+        "m_prop",
+        "P_0",
+        "P_exit",
+        "C_f",
+        "C_f_ideal",
+        "thrust",
+    )
+
     def __init__(
         self,
         motor: Motor,
@@ -25,16 +37,16 @@ class MotorState(ABC):
         self.motor = motor
         self.other_losses = other_losses
 
-        self.t = np.array([0])  # time vector
+        self.t: list[float] = [0.0]  # time vector
 
-        self.m_prop = np.array([motor.initial_propellant_mass])  # propellant mass
-        self.P_0 = np.array([initial_pressure])  # chamber stagnation pressure
-        self.P_exit = np.array([initial_atmospheric_pressure])  # exit pressure
+        self.m_prop: list[float] = [motor.initial_propellant_mass]
+        self.P_0: list[float] = [initial_pressure]
+        self.P_exit: list[float] = [initial_atmospheric_pressure]
 
         # Thrust coefficients and thrust:
-        self.C_f = np.array([0])  # thrust coefficient
-        self.C_f_ideal = np.array([0])  # ideal thrust coefficient
-        self.thrust = np.array([0])  # thrust force (N)
+        self.C_f: list[float] = [0.0]
+        self.C_f_ideal: list[float] = [0.0]
+        self.thrust: list[float] = [0.0]
 
         # Thrust time:
         self._thrust_time = None
@@ -47,6 +59,13 @@ class MotorState(ABC):
         # stops running.
         self.end_thrust = False
         self.end_burn = False
+
+    def _finalize(self) -> None:
+        """Convert accumulated lists into ndarrays for downstream consumers."""
+        for name in self._ARRAY_ATTRS:
+            value = getattr(self, name)
+            if not isinstance(value, np.ndarray):
+                setattr(self, name, np.asarray(value))
 
     @abstractmethod
     def get_m_dot_in(self) -> float:

--- a/machwave/states/liquid_engine.py
+++ b/machwave/states/liquid_engine.py
@@ -20,7 +20,7 @@ from machwave.core.compressible_flow.isentropic import (
 from machwave.core.mass_balance import compute_chamber_pressure_mass_balance
 from machwave.core.solvers import rk4th_ode_solver
 from machwave.models.motors import LiquidEngine
-from machwave.states.base import MotorState
+from machwave.states.base import MotorState, SimulationArray
 
 
 class LiquidEngineState(MotorState):
@@ -33,7 +33,7 @@ class LiquidEngineState(MotorState):
 
     motor: LiquidEngine
 
-    _ARRAY_ATTRS = MotorState._ARRAY_ATTRS + (
+    SIMULATION_ARRAY_ATTRIBUTE_NAMES = MotorState.SIMULATION_ARRAY_ATTRIBUTE_NAMES + (
         "oxidizer_mass",
         "fuel_mass",
         "n_cf",
@@ -58,14 +58,16 @@ class LiquidEngineState(MotorState):
             other_losses=other_losses,
         )
 
-        self.oxidizer_mass: list[float] = [motor.feed_system.oxidizer_tank.fluid_mass]
-        self.fuel_mass: list[float] = [motor.feed_system.fuel_tank.fluid_mass]
-        self.n_cf: list[float] = [1.0]
+        self.oxidizer_mass: SimulationArray = [
+            motor.feed_system.oxidizer_tank.fluid_mass
+        ]
+        self.fuel_mass: SimulationArray = [motor.feed_system.fuel_tank.fluid_mass]
+        self.n_cf: SimulationArray = [1.0]
 
-        self.fuel_tank_pressure: list[float] = [
+        self.fuel_tank_pressure: SimulationArray = [
             motor.feed_system.fuel_tank.get_pressure()
         ]
-        self.oxidizer_tank_pressure: list[float] = [
+        self.oxidizer_tank_pressure: SimulationArray = [
             motor.feed_system.oxidizer_tank.get_pressure()
         ]
 

--- a/machwave/states/liquid_engine.py
+++ b/machwave/states/liquid_engine.py
@@ -33,6 +33,14 @@ class LiquidEngineState(MotorState):
 
     motor: LiquidEngine
 
+    _ARRAY_ATTRS = MotorState._ARRAY_ATTRS + (
+        "oxidizer_mass",
+        "fuel_mass",
+        "n_cf",
+        "fuel_tank_pressure",
+        "oxidizer_tank_pressure",
+    )
+
     def __init__(
         self,
         motor: LiquidEngine,
@@ -50,14 +58,16 @@ class LiquidEngineState(MotorState):
             other_losses=other_losses,
         )
 
-        self.oxidizer_mass = np.array([motor.feed_system.oxidizer_tank.fluid_mass])
-        self.fuel_mass = np.array([motor.feed_system.fuel_tank.fluid_mass])
-        self.n_cf = np.array([1.0])  # thrust coefficient correction factor
+        self.oxidizer_mass: list[float] = [motor.feed_system.oxidizer_tank.fluid_mass]
+        self.fuel_mass: list[float] = [motor.feed_system.fuel_tank.fluid_mass]
+        self.n_cf: list[float] = [1.0]
 
-        self.fuel_tank_pressure = np.array([motor.feed_system.fuel_tank.get_pressure()])
-        self.oxidizer_tank_pressure = np.array(
-            [motor.feed_system.oxidizer_tank.get_pressure()]
-        )
+        self.fuel_tank_pressure: list[float] = [
+            motor.feed_system.fuel_tank.get_pressure()
+        ]
+        self.oxidizer_tank_pressure: list[float] = [
+            motor.feed_system.oxidizer_tank.get_pressure()
+        ]
 
     def run_timestep(
         self,
@@ -99,7 +109,7 @@ class LiquidEngineState(MotorState):
         self._check_thrust_end(P_ext)
 
     def _append_time(self, d_t: float) -> None:
-        self.t = np.append(self.t, self.t[-1] + d_t)
+        self.t.append(self.t[-1] + d_t)
 
     def _update_propellant_properties(self) -> None:
         self.motor.propellant.properties = self.motor.propellant.evaluate(
@@ -134,6 +144,7 @@ class LiquidEngineState(MotorState):
         self, m_dot_fuel: float, m_dot_ox: float, d_t: float
     ) -> tuple[float, float]:
         of = self.motor.propellant.of_ratio
+        assert of is not None
         fuel_last = self.fuel_mass[-1]
         ox_last = self.oxidizer_mass[-1]
         # convert to consumed mass this step
@@ -173,7 +184,7 @@ class LiquidEngineState(MotorState):
         )[0]
 
     def _append_chamber_pressure(self, pressure: float) -> None:
-        self.P_0 = np.append(self.P_0, pressure)
+        self.P_0.append(pressure)
 
     def _compute_exit_pressure(self) -> float:
         assert self.motor.propellant.properties is not None
@@ -184,7 +195,7 @@ class LiquidEngineState(MotorState):
         )
 
     def _append_exit_pressure(self, pressure: float) -> None:
-        self.P_exit = np.append(self.P_exit, pressure)
+        self.P_exit.append(pressure)
 
     def _compute_cf_correction(self) -> float:
         """Compute the overall thrust coefficient correction factor.
@@ -215,7 +226,7 @@ class LiquidEngineState(MotorState):
         return nozzle_efficiency * self.motor.propellant.combustion_efficiency
 
     def _append_cf_correction(self, value: float) -> None:
-        self.n_cf = np.append(self.n_cf, value)
+        self.n_cf.append(value)
 
     def _compute_thrust_coefficients(
         self,
@@ -239,9 +250,9 @@ class LiquidEngineState(MotorState):
             self.P_0[-1],
             self.motor.thrust_chamber.nozzle.get_throat_area(),
         )
-        self.C_f = np.append(self.C_f, cf)
-        self.C_f_ideal = np.append(self.C_f_ideal, cf_ideal)
-        self.thrust = np.append(self.thrust, thrust_val)
+        self.C_f.append(cf)
+        self.C_f_ideal.append(cf_ideal)
+        self.thrust.append(thrust_val)
 
     def _update_propellant_masses(
         self, m_dot_fuel: float, m_dot_ox: float, d_t: float
@@ -254,20 +265,16 @@ class LiquidEngineState(MotorState):
 
         new_fuel = self.fuel_mass[-1] - consumed_f
         new_ox = self.oxidizer_mass[-1] - consumed_o
-        self.fuel_mass = np.append(self.fuel_mass, new_fuel)
-        self.oxidizer_mass = np.append(self.oxidizer_mass, new_ox)
-        self.m_prop = np.append(self.m_prop, new_fuel + new_ox)
+        self.fuel_mass.append(new_fuel)
+        self.oxidizer_mass.append(new_ox)
+        self.m_prop.append(new_fuel + new_ox)
 
     def _update_tank_pressures(self) -> None:
         new_fuel_tank_pressure = self.motor.feed_system.get_fuel_tank_pressure()
         new_oxidizer_tank_pressure = self.motor.feed_system.get_oxidizer_tank_pressure()
 
-        self.fuel_tank_pressure = np.append(
-            self.fuel_tank_pressure, new_fuel_tank_pressure
-        )
-        self.oxidizer_tank_pressure = np.append(
-            self.oxidizer_tank_pressure, new_oxidizer_tank_pressure
-        )
+        self.fuel_tank_pressure.append(new_fuel_tank_pressure)
+        self.oxidizer_tank_pressure.append(new_oxidizer_tank_pressure)
 
     def _check_burn_end(self) -> None:
         if self.end_burn:

--- a/machwave/states/solid_motor.py
+++ b/machwave/states/solid_motor.py
@@ -56,7 +56,6 @@ class SolidMotorState(states_base.MotorState):
 
         self.motor: motors.SolidMotor = motor
 
-        # Grain and propellant parameters:
         self.V_0: states_base.SimulationArray = [
             motor.thrust_chamber.combustion_chamber.internal_volume
         ]
@@ -69,7 +68,6 @@ class SolidMotorState(states_base.MotorState):
         ]
         self.burn_rate: states_base.SimulationArray = [0.0]
 
-        # Center of gravity and moment of inertia:
         initial_cog = motor.grain.get_center_of_gravity(
             web_distance=0.0,
         )
@@ -77,11 +75,9 @@ class SolidMotorState(states_base.MotorState):
             ideal_density=motor.propellant.ideal_density,
             web_distance=0.0,
         )
-        # Store as lists of 3D arrays (COG) and 3x3 arrays (MOI)
-        self.propellant_cog = [initial_cog]  # center of gravity [x, y, z] in meters
-        self.propellant_moi = [initial_moi]  # moment of inertia tensor 3x3 in kg-m²
+        self.propellant_cog = [initial_cog]  # [x, y, z] in meters
+        self.propellant_moi = [initial_moi]  # 3x3 tensor in kg-m²
 
-        # Correction factors:
         self.eta_div: states_base.SimulationArray = [0.0]
         self.eta_kin: states_base.SimulationArray = [0.0]
         self.eta_bl: states_base.SimulationArray = [0.0]

--- a/machwave/states/solid_motor.py
+++ b/machwave/states/solid_motor.py
@@ -20,6 +20,20 @@ class SolidMotorState(states_base.MotorState):
     Therefore, PEP8's snake_case will not be followed rigorously.
     """
 
+    _ARRAY_ATTRS = states_base.MotorState._ARRAY_ATTRS + (
+        "V_0",
+        "web",
+        "burn_area",
+        "propellant_volume",
+        "burn_rate",
+        "eta_div",
+        "eta_kin",
+        "eta_bl",
+        "eta_2p",
+        "nozzle_efficiency",
+        "overall_efficiency",
+    )
+
     def __init__(
         self,
         motor: motors.SolidMotor,
@@ -40,15 +54,15 @@ class SolidMotorState(states_base.MotorState):
         self.motor: motors.SolidMotor = motor
 
         # Grain and propellant parameters:
-        self.V_0 = np.array(
-            [motor.thrust_chamber.combustion_chamber.internal_volume]
-        )  # empty chamber volume
-        self.web = np.array([0])  # instant web thickness
-        self.burn_area = np.array([self.motor.grain.get_burn_area(self.web[0])])
-        self.propellant_volume = np.array(
-            [self.motor.grain.get_propellant_volume(self.web[0])]
-        )
-        self.burn_rate = np.array([0])  # burn rate
+        self.V_0: list[float] = [
+            motor.thrust_chamber.combustion_chamber.internal_volume
+        ]
+        self.web: list[float] = [0.0]
+        self.burn_area: list[float] = [self.motor.grain.get_burn_area(0.0)]
+        self.propellant_volume: list[float] = [
+            self.motor.grain.get_propellant_volume(0.0)
+        ]
+        self.burn_rate: list[float] = [0.0]
 
         # Center of gravity and moment of inertia:
         initial_cog = motor.grain.get_center_of_gravity(
@@ -63,12 +77,12 @@ class SolidMotorState(states_base.MotorState):
         self.propellant_moi = [initial_moi]  # moment of inertia tensor 3x3 in kg-m²
 
         # Correction factors:
-        self.eta_div = np.array([0])  # divergent nozzle correction factor
-        self.eta_kin = np.array([0])  # kinetics correction factor
-        self.eta_bl = np.array([0])  # boundary layer correction factor
-        self.eta_2p = np.array([0])  # two-phase flow correction factor
-        self.nozzle_efficiency = np.array([0])  # overall nozzle efficiency
-        self.overall_efficiency = np.array([0])  # overall efficiency
+        self.eta_div: list[float] = [0.0]
+        self.eta_kin: list[float] = [0.0]
+        self.eta_bl: list[float] = [0.0]
+        self.eta_2p: list[float] = [0.0]
+        self.nozzle_efficiency: list[float] = [0.0]
+        self.overall_efficiency: list[float] = [0.0]
 
     def run_timestep(
         self,
@@ -94,29 +108,25 @@ class SolidMotorState(states_base.MotorState):
         self._check_thrust_end(P_ext)
 
     def _append_time(self, d_t: float) -> None:
-        self.t = np.append(self.t, self.t[-1] + d_t)
+        self.t.append(self.t[-1] + d_t)
 
     def _update_grain_geometry(self) -> None:
         web_last = self.web[-1]
-        area = self.motor.grain.get_burn_area(web_last)
-        vol = self.motor.grain.get_propellant_volume(web_last)
-        self.burn_area = np.append(self.burn_area, area)
-        self.propellant_volume = np.append(self.propellant_volume, vol)
-        self.burn_rate = np.append(
-            self.burn_rate,
-            self.motor.propellant.get_burn_rate(self.P_0[-1]),
-        )
-        dx = self.burn_rate[-1] * (self.t[-1] - self.t[-2])
-        self.web = np.append(self.web, web_last + dx)
+        self.burn_area.append(self.motor.grain.get_burn_area(web_last))
+        self.propellant_volume.append(self.motor.grain.get_propellant_volume(web_last))
+        burn_rate = self.motor.propellant.get_burn_rate(self.P_0[-1])
+        self.burn_rate.append(burn_rate)
+        dx = burn_rate * (self.t[-1] - self.t[-2])
+        self.web.append(web_last + dx)
 
     def _update_chamber_volume_and_mass(self) -> None:
-        free_vol = self.motor.get_free_chamber_volume(self.propellant_volume[-1])
-        self.V_0 = np.append(self.V_0, free_vol)
-        m_prop = self.motor.grain.get_propellant_mass(
-            web_distance=self.web[-1],
-            ideal_density=self.motor.propellant.ideal_density,
+        self.V_0.append(self.motor.get_free_chamber_volume(self.propellant_volume[-1]))
+        self.m_prop.append(
+            self.motor.grain.get_propellant_mass(
+                web_distance=self.web[-1],
+                ideal_density=self.motor.propellant.ideal_density,
+            )
         )
-        self.m_prop = np.append(self.m_prop, m_prop)
 
     def _update_cog_and_moi(self) -> None:
         # Update center of gravity and moment of inertia
@@ -152,13 +162,14 @@ class SolidMotorState(states_base.MotorState):
             R=props.R_chamber,
             T0=props.adiabatic_flame_temperature,
         )[0]
-        self.P_0 = np.append(self.P_0, new_P)
-        exit_P = isentropic.get_exit_pressure(
-            props.gamma_exhaust,
-            self.motor.thrust_chamber.nozzle.expansion_ratio,
-            new_P,
+        self.P_0.append(new_P)
+        self.P_exit.append(
+            isentropic.get_exit_pressure(
+                props.gamma_exhaust,
+                self.motor.thrust_chamber.nozzle.expansion_ratio,
+                new_P,
+            )
         )
-        self.P_exit = np.append(self.P_exit, exit_P)
 
     def _compute_flow(self, P_ext: float) -> None:
         P0 = self.P_0[-1]
@@ -201,12 +212,12 @@ class SolidMotorState(states_base.MotorState):
             nozzle_efficiency * self.motor.propellant.combustion_efficiency
         )
 
-        self.eta_div = np.append(self.eta_div, eta_div)
-        self.eta_kin = np.append(self.eta_kin, eta_kin)
-        self.eta_bl = np.append(self.eta_bl, eta_bl)
-        self.eta_2p = np.append(self.eta_2p, eta_2p)
-        self.nozzle_efficiency = np.append(self.nozzle_efficiency, nozzle_efficiency)
-        self.overall_efficiency = np.append(self.overall_efficiency, overall_efficiency)
+        self.eta_div.append(eta_div)
+        self.eta_kin.append(eta_kin)
+        self.eta_bl.append(eta_bl)
+        self.eta_2p.append(eta_2p)
+        self.nozzle_efficiency.append(nozzle_efficiency)
+        self.overall_efficiency.append(overall_efficiency)
 
         cf_ideal = nozzle.get_ideal_thrust_coefficient(
             P0,
@@ -216,12 +227,13 @@ class SolidMotorState(states_base.MotorState):
             props.gamma_exhaust,
         )
         cf = nozzle.apply_thrust_coefficient_correction(cf_ideal, overall_efficiency)
-        self.C_f = np.append(self.C_f, cf)
-        self.C_f_ideal = np.append(self.C_f_ideal, cf_ideal)
-        thrust = nozzle.get_thrust_from_thrust_coefficient(
-            cf, P0, self.motor.thrust_chamber.nozzle.get_throat_area()
+        self.C_f.append(cf)
+        self.C_f_ideal.append(cf_ideal)
+        self.thrust.append(
+            nozzle.get_thrust_from_thrust_coefficient(
+                cf, P0, self.motor.thrust_chamber.nozzle.get_throat_area()
+            )
         )
-        self.thrust = np.append(self.thrust, thrust)
 
     def _check_burn_end(self) -> None:
         if self.m_prop[-1] <= 0 and not self.end_burn:
@@ -288,8 +300,9 @@ class SolidMotorState(states_base.MotorState):
     @property
     def klemmung(self) -> np.ndarray:
         """Get the klemmung values."""
+        burn_area = np.asarray(self.burn_area)
         return (
-            self.burn_area[self.burn_area > 0]
+            burn_area[burn_area > 0]
             / self.motor.thrust_chamber.nozzle.get_throat_area()
         )
 
@@ -317,7 +330,8 @@ class SolidMotorState(states_base.MotorState):
         Returns:
             Burn profile: "regressive", "progressive", or "neutral".
         """
-        burn_area = self.burn_area[self.burn_area > 0]
+        burn_area_arr = np.asarray(self.burn_area)
+        burn_area = burn_area_arr[burn_area_arr > 0]
 
         if burn_area[0] / burn_area[-1] > 1 + deviancy:
             return "regressive"
@@ -335,15 +349,15 @@ class SolidMotorState(states_base.MotorState):
     def grain_mass_flux(self) -> np.ndarray:
         """Get the grain mass flux."""
         return self.motor.grain.get_mass_flux_per_segment(
-            self.burn_rate,
+            np.asarray(self.burn_rate),
             self.motor.propellant.ideal_density,
-            self.web,
+            np.asarray(self.web),
         )
 
     @property
     def total_impulse(self) -> float:
         """Get the total impulse [N-s]."""
-        return np.mean(self.thrust) * self.t[-1]
+        return float(np.mean(self.thrust) * self.t[-1])
 
     @property
     def specific_impulse(self) -> float:

--- a/machwave/states/solid_motor.py
+++ b/machwave/states/solid_motor.py
@@ -20,18 +20,21 @@ class SolidMotorState(states_base.MotorState):
     Therefore, PEP8's snake_case will not be followed rigorously.
     """
 
-    _ARRAY_ATTRS = states_base.MotorState._ARRAY_ATTRS + (
-        "V_0",
-        "web",
-        "burn_area",
-        "propellant_volume",
-        "burn_rate",
-        "eta_div",
-        "eta_kin",
-        "eta_bl",
-        "eta_2p",
-        "nozzle_efficiency",
-        "overall_efficiency",
+    SIMULATION_ARRAY_ATTRIBUTE_NAMES = (
+        states_base.MotorState.SIMULATION_ARRAY_ATTRIBUTE_NAMES
+        + (
+            "V_0",
+            "web",
+            "burn_area",
+            "propellant_volume",
+            "burn_rate",
+            "eta_div",
+            "eta_kin",
+            "eta_bl",
+            "eta_2p",
+            "nozzle_efficiency",
+            "overall_efficiency",
+        )
     )
 
     def __init__(
@@ -54,15 +57,17 @@ class SolidMotorState(states_base.MotorState):
         self.motor: motors.SolidMotor = motor
 
         # Grain and propellant parameters:
-        self.V_0: list[float] = [
+        self.V_0: states_base.SimulationArray = [
             motor.thrust_chamber.combustion_chamber.internal_volume
         ]
-        self.web: list[float] = [0.0]
-        self.burn_area: list[float] = [self.motor.grain.get_burn_area(0.0)]
-        self.propellant_volume: list[float] = [
+        self.web: states_base.SimulationArray = [0.0]
+        self.burn_area: states_base.SimulationArray = [
+            self.motor.grain.get_burn_area(0.0)
+        ]
+        self.propellant_volume: states_base.SimulationArray = [
             self.motor.grain.get_propellant_volume(0.0)
         ]
-        self.burn_rate: list[float] = [0.0]
+        self.burn_rate: states_base.SimulationArray = [0.0]
 
         # Center of gravity and moment of inertia:
         initial_cog = motor.grain.get_center_of_gravity(
@@ -77,12 +82,12 @@ class SolidMotorState(states_base.MotorState):
         self.propellant_moi = [initial_moi]  # moment of inertia tensor 3x3 in kg-m²
 
         # Correction factors:
-        self.eta_div: list[float] = [0.0]
-        self.eta_kin: list[float] = [0.0]
-        self.eta_bl: list[float] = [0.0]
-        self.eta_2p: list[float] = [0.0]
-        self.nozzle_efficiency: list[float] = [0.0]
-        self.overall_efficiency: list[float] = [0.0]
+        self.eta_div: states_base.SimulationArray = [0.0]
+        self.eta_kin: states_base.SimulationArray = [0.0]
+        self.eta_bl: states_base.SimulationArray = [0.0]
+        self.eta_2p: states_base.SimulationArray = [0.0]
+        self.nozzle_efficiency: states_base.SimulationArray = [0.0]
+        self.overall_efficiency: states_base.SimulationArray = [0.0]
 
     def run_timestep(
         self,


### PR DESCRIPTION
## Summary

- Replace `np.append` in `InternalBallisticsSimulation` with Python `list.append`, then convert to `np.ndarray` once after the loop ends. Drops loop cost from O(N²) to O(N).
- Introduce a `SimulationArray` type alias (with a self-describing comment) so every annotation site documents the lifecycle: list during the loop, ndarray after the new `convert_simulation_arrays_to_numpy()` call.
- Strip section-header / restating-the-name comments from the motor state init blocks; keep only units and lifecycle notes.

On the Kappa example (15,164 steps): **2.25s → 1.55s, ~1.45× faster**, identical numerical output (`max thrust 1334.683 N`, `I_sp 118.528 s`). The asymptotic class is the real win — for finer `d_t` the gap widens.

## Test plan

- [x] `make check` (ruff + pyright) clean on each commit
- [x] `pytest` 533/533 pass
- [x] Kappa solid-motor and 1kN LRE examples run end-to-end
- [x] RocketPy adapter still consumes `motor_state.{t, thrust, P_exit, propellant_cog, propellant_moi}` unchanged (those are ndarrays/lists after `convert_simulation_arrays_to_numpy()`)