### PR TITLE
Fix CI trigger: main → master (#149)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Machwave CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
 
 permissions:


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml` was triggering on pushes to `main`, but the default branch is `master`. Direct pushes to `master` were silently skipping CI.
- Updated the push branch list to `[master]`.

Closes #149.

## Test plan
- [x] Confirm CI runs on this PR (PR trigger).
- [x] After merge, confirm a push to `master` triggers the workflow.