### PR TITLE
Add concurrency block to cancel superseded CI runs (#152)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
## Summary
- Add a workflow-level \`concurrency\` block to \`.github/workflows/ci.yml\` keyed on \`workflow + ref\`.
- Pushing a new commit to a PR now cancels the in-flight run instead of queuing a redundant one.

Closes #152.

## Test plan
- [x] Confirm CI runs on this PR.
- [x] After merge, push twice in quick succession to a PR branch and confirm the older run is cancelled.