### PR TITLE
Add Dependabot config for pip + github-actions (#154)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - github-actions


### PR DESCRIPTION
## Summary
- Add \`.github/dependabot.yml\` with weekly update schedules for the \`pip\` and \`github-actions\` ecosystems.
- Both groups labelled \`dependencies\`; github-actions also tagged \`github-actions\` for easy filtering.

Closes #154.

## Test plan
- [ ] After merge, confirm Dependabot opens its first round of PRs within ~24h (or trigger manually from the Insights → Dependency graph → Dependabot tab).