### PR TITLE
Run test in parallel with lint/format/typecheck (#157)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
       - run: make typecheck
 
   test:
-    needs: [format-check, lint, typecheck]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Remove \`needs: [format-check, lint, typecheck]\` from the \`test\` job in \`.github/workflows/ci.yml\`.
- All four jobs now run in parallel; a failed lint still fails the workflow but no longer delays test feedback.

Closes #157.

## Test plan
- [x] Confirm CI on this PR shows \`format-check\`, \`lint\`, \`typecheck\`, and \`test\` starting concurrently.