### PR TITLE
Add OS + Python version matrix to test job (#150)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install gfortran (macOS)
+      - name: Install Fortran compiler (macOS)
         if: runner.os == 'macOS'
-        run: brew install gcc
+        uses: fortran-lang/setup-fortran@v1
+        with:
+          compiler: gcc
       - run: make install-dev
       - run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,5 +71,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install gfortran (macOS)
+        if: runner.os == 'macOS'
+        run: brew install gcc
       - run: make install-dev
       - run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,12 @@ jobs:
       - run: make typecheck
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
@@ -65,6 +70,6 @@ jobs:
           enable-cache: true
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
       - run: make install-dev
       - run: make test


### PR DESCRIPTION
## Summary
- Matrix the `test` job over `{ubuntu-latest, macos-latest, windows-latest}` × `{3.11, 3.12, 3.13}`.
- `fail-fast: false` so a single platform failure doesn't hide the others.
- Aligns CI with `pyproject.toml`'s declared OS/Python support.

Closes #150.

## Test plan
- [x] Confirm the matrix expands to 9 `test` jobs in the run summary.
- [x] Triage any new failures — `rocketcea`, `coolprop`, and `scikit-fmm` are the likely suspects on Windows/macOS.