### PR TITLE
Add built-wheel smoke test to release workflow (#158)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,9 @@ defaults:
     shell: bash
 
 jobs:
-  publish:
-    name: Build and publish to PyPI
+  build:
+    name: Build wheel
     runs-on: ubuntu-latest
-    environment: publish
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -37,6 +36,53 @@ jobs:
 
       - name: Verify tag matches package version
         run: make verify-version
+
+      - name: Upload built distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  smoke-test:
+    name: Smoke test built wheel
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download built distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Install built wheel
+        run: python -m pip install dist/*.whl
+
+      - name: Smoke test
+        run: |
+          python -c "import machwave; print('machwave', machwave.__version__)"
+          python -c "import machwave.simulation, machwave.models, machwave.core, machwave.io, machwave.adapters, machwave.states"
+
+  publish:
+    name: Publish to PyPI
+    needs: smoke-test
+    runs-on: ubuntu-latest
+    environment: publish
+    steps:
+      - name: Download built distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
Reshaped `.github/workflows/publish.yml` so the wheel is exercised before it ships:

- **build** — builds the wheel, verifies tag-matches-version, uploads `dist/` as an artifact.
- **smoke-test** — downloads the artifact, installs the wheel in a fresh env across `{ubuntu, macos, windows}` × `{3.11, 3.12, 3.13}` (matches `pyproject.toml`'s declared support), and runs an import smoke test covering `machwave`, `machwave.simulation`, `.models`, `.core`, `.io`, `.adapters`, `.states`.
- **publish** — now gated on smoke-test; just downloads the prebuilt artifact and uploads to PyPI (no rebuild).
- **build-deploy-docs** — unchanged, still gated on publish.

Closes #158.

## Coordinate with
- Existing branch `116-add-smoke-tests-to-the-ci`. The smoke test here is intentionally minimal (import only); a richer simulation-based smoke test could land separately on top of this scaffolding.

## Test plan
- [ ] Workflow only runs on `release: published`, so it can't be exercised on this PR. Verify on the next dry-run release (or trigger via `workflow_dispatch` if added later).
- [ ] Manual sanity: `make build && python -m pip install dist/*.whl` in a clean venv works locally.

## Setup notes
- The `publish` job still uses the `publish` environment + `id-token: write` for trusted publishing.
- `pypa/gh-action-pypi-publish@release/v1` defaults to uploading `dist/*`, which is where the download-artifact step puts the wheel.