### PR TITLE
Mangle RocketCEA registrations to prevent cross-simulation leaks

### DIFF
--- a/machwave/services/cea.py
+++ b/machwave/services/cea.py
@@ -4,6 +4,7 @@ for solid propellants, based on the widely accepted NASA's CEA code.
 """
 
 import re
+from uuid import uuid4
 
 from rocketcea.cea_obj import (
     CEA_Obj,
@@ -96,28 +97,36 @@ def create_cea_service(
     Raises:
         ValueError: If configuration is invalid or registration/creation fails.
     """
-    # Register custom propellant (solid/monopropellant)
+    # RocketCEA's add_new_* helpers mutate a process-global Fortran registry, so
+    # two registrations sharing the same name (e.g. Monte Carlo over composition,
+    # parametric trade studies, repeated test runs) silently clobber each other.
+    # When a card_string is supplied we mangle the registered identifier with a
+    # per-call UUID suffix; the user-facing name is unaffected.
+    effective_propellant_name = propellant_name
     if card_string and propellant_name:
+        effective_propellant_name = f"{propellant_name}__{uuid4().hex[:8]}"
         try:
-            add_new_propellant(propellant_name, card_string)
+            add_new_propellant(effective_propellant_name, card_string)
         except Exception as e:
             raise ValueError(
                 f"Failed to register propellant '{propellant_name}': {e}"
             ) from e
 
-    # Register custom oxidizer
+    effective_oxidizer_name = oxidizer_name
     if oxidizer_card_string and oxidizer_name:
+        effective_oxidizer_name = f"{oxidizer_name}__{uuid4().hex[:8]}"
         try:
-            add_new_oxidizer(oxidizer_name, oxidizer_card_string)
+            add_new_oxidizer(effective_oxidizer_name, oxidizer_card_string)
         except Exception as e:
             raise ValueError(
                 f"Failed to register oxidizer '{oxidizer_name}': {e}"
             ) from e
 
-    # Register custom fuel
+    effective_fuel_name = fuel_name
     if fuel_card_string and fuel_name:
+        effective_fuel_name = f"{fuel_name}__{uuid4().hex[:8]}"
         try:
-            add_new_fuel(fuel_name, fuel_card_string)
+            add_new_fuel(effective_fuel_name, fuel_card_string)
         except Exception as e:
             raise ValueError(f"Failed to register fuel '{fuel_name}': {e}") from e
 
@@ -125,7 +134,9 @@ def create_cea_service(
     cea_obj: CEA_Obj
     if oxidizer_name and fuel_name:
         try:
-            cea_obj = CEA_Obj(oxName=oxidizer_name, fuelName=fuel_name)
+            cea_obj = CEA_Obj(
+                oxName=effective_oxidizer_name, fuelName=effective_fuel_name
+            )
         except Exception as e:
             raise ValueError(
                 f"Failed to create CEA object for oxidizer '{oxidizer_name}' "
@@ -133,7 +144,7 @@ def create_cea_service(
             ) from e
     elif propellant_name:
         try:
-            cea_obj = CEA_Obj(propName=propellant_name)
+            cea_obj = CEA_Obj(propName=effective_propellant_name)
         except Exception as e:
             raise ValueError(
                 f"Failed to create CEA object for propellant '{propellant_name}'. "

--- a/machwave/services/cea.py
+++ b/machwave/services/cea.py
@@ -128,6 +128,8 @@ def create_cea_service(
     # Create CEA object
     cea_obj: CEA_Obj
     if oxidizer_name and fuel_name:
+        assert effective_oxidizer_name is not None
+        assert effective_fuel_name is not None
         try:
             cea_obj = CEA_Obj(
                 oxName=effective_oxidizer_name, fuelName=effective_fuel_name
@@ -138,6 +140,7 @@ def create_cea_service(
                 f"and fuel '{fuel_name}'. Ensure they exist or provide card strings: {e}"
             ) from e
     elif propellant_name:
+        assert effective_propellant_name is not None
         try:
             cea_obj = CEA_Obj(propName=effective_propellant_name)
         except Exception as e:

--- a/machwave/services/cea.py
+++ b/machwave/services/cea.py
@@ -97,11 +97,6 @@ def create_cea_service(
     Raises:
         ValueError: If configuration is invalid or registration/creation fails.
     """
-    # RocketCEA's add_new_* helpers mutate a process-global Fortran registry, so
-    # two registrations sharing the same name (e.g. Monte Carlo over composition,
-    # parametric trade studies, repeated test runs) silently clobber each other.
-    # When a card_string is supplied we mangle the registered identifier with a
-    # per-call UUID suffix; the user-facing name is unaffected.
     effective_propellant_name = propellant_name
     if card_string and propellant_name:
         effective_propellant_name = f"{propellant_name}__{uuid4().hex[:8]}"

--- a/tests/test_services/test_cea.py
+++ b/tests/test_services/test_cea.py
@@ -398,6 +398,106 @@ class TestServiceEdgeCases:
         assert isp_high > isp_low, "Higher expansion should give higher Isp"
 
 
+class TestRegistryIsolation:
+    """Repeated calls with the same user-facing propellant name but different
+    cards must not clobber each other in RocketCEA's process-global registry.
+
+    Without name-mangling the second registration silently wins and both
+    services return identical properties.
+    """
+
+    def _kno3_sucrose_card(self, kno3_pct: float) -> str:
+        return generate_card_string(
+            [
+                {
+                    "name": "KNO3",
+                    "formula": {"K": 1.0, "N": 1.0, "O": 3.0},
+                    "weight_percent": kno3_pct,
+                    "heat_of_formation": -118200.0,
+                    "temperature": 298.15,
+                    "density": 2.109,
+                },
+                {
+                    "name": "Sucrose",
+                    "formula": {"C": 12.0, "H": 22.0, "O": 11.0},
+                    "weight_percent": 100.0 - kno3_pct,
+                    "heat_of_formation": -531900.0,
+                    "temperature": 298.15,
+                    "density": 1.587,
+                },
+            ]
+        )
+
+    def test_same_name_different_cards_keep_distinct_properties(self):
+        shared_name = "REGISTRY_ISOLATION_PROBE"
+
+        service_a = create_cea_service(
+            propellant_name=shared_name, card_string=self._kno3_sucrose_card(65.0)
+        )
+        service_b = create_cea_service(
+            propellant_name=shared_name, card_string=self._kno3_sucrose_card(80.0)
+        )
+
+        chamber_pressure = 3e6
+        expansion_ratio = 8.0
+
+        temp_a = service_a.get_adiabatic_flame_temperature(chamber_pressure)
+        temp_b = service_b.get_adiabatic_flame_temperature(chamber_pressure)
+        isp_a, _ = service_a.get_specific_impulse(chamber_pressure, expansion_ratio)
+        isp_b, _ = service_b.get_specific_impulse(chamber_pressure, expansion_ratio)
+
+        assert abs(temp_a - temp_b) > 5.0, (
+            f"Adiabatic flame temperatures should differ between distinct "
+            f"compositions registered under the same name; got "
+            f"{temp_a:.2f} K vs {temp_b:.2f} K"
+        )
+        assert abs(isp_a - isp_b) > 0.5, (
+            f"Specific impulses should differ between distinct compositions "
+            f"registered under the same name; got {isp_a:.3f} s vs {isp_b:.3f} s"
+        )
+
+    def test_same_name_custom_oxidizer_keeps_distinct_properties(self):
+        shared_ox_name = "REGISTRY_ISOLATION_OX"
+        fuel_card = (
+            "name CustomMMH  C 1 H 6 N 2  wt%=100.0\n"
+            "h,cal=12800.0  t(k)=298.15  rho,g/cc=0.866"
+        )
+
+        ox_card_a = (
+            "name CustomOxA  N 2 O 4  wt%=100.0\n"
+            "h,cal=-4676.0  t(k)=298.15  rho,g/cc=1.443"
+        )
+        # Different heat of formation -> different combustion temperature.
+        ox_card_b = (
+            "name CustomOxB  N 2 O 4  wt%=100.0\n"
+            "h,cal=2000.0  t(k)=298.15  rho,g/cc=1.443"
+        )
+
+        service_a = create_cea_service(
+            oxidizer_name=shared_ox_name,
+            oxidizer_card_string=ox_card_a,
+            fuel_name="REGISTRY_ISOLATION_FUEL_A",
+            fuel_card_string=fuel_card,
+            oxidizer_to_fuel_ratio=1.65,
+        )
+        service_b = create_cea_service(
+            oxidizer_name=shared_ox_name,
+            oxidizer_card_string=ox_card_b,
+            fuel_name="REGISTRY_ISOLATION_FUEL_B",
+            fuel_card_string=fuel_card,
+            oxidizer_to_fuel_ratio=1.65,
+        )
+
+        temp_a = service_a.get_adiabatic_flame_temperature(3e6)
+        temp_b = service_b.get_adiabatic_flame_temperature(3e6)
+
+        assert abs(temp_a - temp_b) > 5.0, (
+            f"Adiabatic flame temperatures should differ between oxidizers with "
+            f"different heats of formation registered under the same name; got "
+            f"{temp_a:.2f} K vs {temp_b:.2f} K"
+        )
+
+
 def test_generate_card_string_utility():
     """Test the generate_card_string utility function."""
     components = [


### PR DESCRIPTION
## Summary
- `rocketcea`'s `add_new_propellant` / `add_new_oxidizer` / `add_new_fuel` mutate a *process-global* Fortran registry. Two registrations sharing a user-facing name silently clobbered each other — breaking Monte Carlo over composition, parametric trade studies, and back-to-back runs in the same Jupyter session or pytest process.
- `create_cea_service` now suffixes every custom registration with a per-call `uuid4().hex[:8]` and uses the mangled identifier for both `add_new_*` and `CEA_Obj(...)`. Built-in propellant/oxidizer/fuel names (no `card_string`) pass through unchanged; `propellant.name` is untouched.
- Adds `TestRegistryIsolation` regression tests that register two distinct compositions under the same shared name and assert their evaluated flame temperatures and Isps diverge.

Closes #167

## Test plan
- [x] `pytest tests/test_services/test_cea.py -v` — all 19 tests pass, including the two new isolation tests
- [x] `pytest tests/` — full suite green (535 passed)
- [x] `ruff check` and `ruff format --check` clean on touched files