### PR TITLE
Inline run_timestep helpers in motor state classes

### DIFF
--- a/machwave/states/liquid_engine.py
+++ b/machwave/states/liquid_engine.py
@@ -71,6 +71,9 @@ class LiquidEngineState(MotorState):
             motor.feed_system.oxidizer_tank.get_pressure()
         ]
 
+    def get_m_dot_in(self) -> float:
+        return self._m_dot_fuel + self._m_dot_ox
+
     def run_timestep(
         self,
         d_t: float,
@@ -86,136 +89,74 @@ class LiquidEngineState(MotorState):
         if self.end_thrust:
             return
 
-        self._append_time(d_t)
-        m_dot_fuel, m_dot_ox = self._compute_nominal_mass_flows()
-        m_dot_fuel, m_dot_ox = self._clamp_mass_flows(m_dot_fuel, m_dot_ox, d_t)
-        m_dot_fuel, m_dot_ox = self._adjust_flows_for_stoichiometry(
-            m_dot_fuel, m_dot_ox, d_t
-        )
-        self._m_dot_fuel = m_dot_fuel
-        self._m_dot_ox = m_dot_ox
-        self._update_propellant_properties()
+        nz = self.motor.thrust_chamber.nozzle
+        injector = self.motor.thrust_chamber.injector
+        feed = self.motor.feed_system
 
-        new_P = self._compute_chamber_pressure(d_t, P_ext)
-        self._append_chamber_pressure(new_P)
-        P_exit = self._compute_exit_pressure()
-        self._append_exit_pressure(P_exit)
-        n_cf = self._compute_cf_correction()
-        self._append_cf_correction(n_cf)
-        cf, cf_ideal = self._compute_thrust_coefficients(P_exit, P_ext)
-        self._append_thrust(cf, cf_ideal)
-
-        self._update_propellant_masses(m_dot_fuel, m_dot_ox, d_t)
-        self._update_tank_pressures()
-        self._check_burn_end()
-        self._check_thrust_end(P_ext)
-
-    def _append_time(self, d_t: float) -> None:
         self.t.append(self.t[-1] + d_t)
 
-    def _update_propellant_properties(self) -> None:
-        self.motor.propellant.properties = self.motor.propellant.evaluate(
-            chamber_pressure=self.P_0[-1],
-            expansion_ratio=self.motor.thrust_chamber.nozzle.expansion_ratio,
-        )
-
-    def _compute_nominal_mass_flows(self) -> tuple[float, float]:
         if self.m_prop[-1] > 0:
-            fuel_flow = self.motor.feed_system.get_mass_flow_fuel(
+            m_dot_fuel = feed.get_mass_flow_fuel(
                 chamber_pressure=self.P_0[-1],
-                discharge_coefficient=self.motor.thrust_chamber.injector.discharge_coefficient_fuel,
-                injector_area=self.motor.thrust_chamber.injector.area_fuel,
+                discharge_coefficient=injector.discharge_coefficient_fuel,
+                injector_area=injector.area_fuel,
             )
-            ox_flow = self.motor.feed_system.get_mass_flow_ox(
+            m_dot_ox = feed.get_mass_flow_ox(
                 chamber_pressure=self.P_0[-1],
-                discharge_coefficient=self.motor.thrust_chamber.injector.discharge_coefficient_oxidizer,
-                injector_area=self.motor.thrust_chamber.injector.area_ox,
+                discharge_coefficient=injector.discharge_coefficient_oxidizer,
+                injector_area=injector.area_ox,
             )
         else:
-            fuel_flow = ox_flow = 0.0
-        return fuel_flow, ox_flow
+            m_dot_fuel = m_dot_ox = 0.0
 
-    def _clamp_mass_flows(
-        self, m_dot_fuel: float, m_dot_ox: float, d_t: float
-    ) -> tuple[float, float]:
-        max_fuel_rate = self.fuel_mass[-1] / d_t
-        max_ox_rate = self.oxidizer_mass[-1] / d_t
-        return min(m_dot_fuel, max_fuel_rate), min(m_dot_ox, max_ox_rate)
+        m_dot_fuel = min(m_dot_fuel, self.fuel_mass[-1] / d_t)
+        m_dot_ox = min(m_dot_ox, self.oxidizer_mass[-1] / d_t)
 
-    def _adjust_flows_for_stoichiometry(
-        self, m_dot_fuel: float, m_dot_ox: float, d_t: float
-    ) -> tuple[float, float]:
         of = self.motor.propellant.of_ratio
         assert of is not None
-        fuel_last = self.fuel_mass[-1]
-        ox_last = self.oxidizer_mass[-1]
-        # convert to consumed mass this step
         cons_f = m_dot_fuel * d_t
         cons_o = m_dot_ox * d_t
-        # limiting reagent
-        if cons_f >= fuel_last:
-            cons_f = fuel_last
+        if cons_f >= self.fuel_mass[-1]:
+            cons_f = self.fuel_mass[-1]
             cons_o = of * cons_f
             self.end_burn = True
             self.burn_time = self.t[-1]
-        elif cons_o >= ox_last:
-            cons_o = ox_last
+        elif cons_o >= self.oxidizer_mass[-1]:
+            cons_o = self.oxidizer_mass[-1]
             cons_f = cons_o / of
             self.end_burn = True
             self.burn_time = self.t[-1]
-        # back to rates
-        return cons_f / d_t, cons_o / d_t
+        m_dot_fuel = cons_f / d_t
+        m_dot_ox = cons_o / d_t
+        self._m_dot_fuel = m_dot_fuel
+        self._m_dot_ox = m_dot_ox
 
-    def get_m_dot_in(self) -> float:
-        return self._m_dot_fuel + self._m_dot_ox
-
-    def _compute_chamber_pressure(self, d_t: float, P_ext: float) -> float:
+        self.motor.propellant.properties = self.motor.propellant.evaluate(
+            chamber_pressure=self.P_0[-1],
+            expansion_ratio=nz.expansion_ratio,
+        )
         props = self.motor.propellant.properties
         assert props is not None
-        return rk4th_ode_solver(
+
+        new_P = rk4th_ode_solver(
             variables={"P0": self.P_0[-1]},
             equation=compute_chamber_pressure_mass_balance,
             d_t=d_t,
             Pe=P_ext,
             m_in=self.get_m_dot_in(),
             V0=self.motor.thrust_chamber.combustion_chamber.internal_volume,
-            At=self.motor.thrust_chamber.nozzle.get_throat_area(),
+            At=nz.get_throat_area(),
             k=props.gamma_chamber,
             R=props.R_chamber,
             T0=props.adiabatic_flame_temperature,
         )[0]
+        self.P_0.append(new_P)
+        P_exit = get_exit_pressure(props.gamma_exhaust, nz.expansion_ratio, new_P)
+        self.P_exit.append(P_exit)
 
-    def _append_chamber_pressure(self, pressure: float) -> None:
-        self.P_0.append(pressure)
-
-    def _compute_exit_pressure(self) -> float:
-        assert self.motor.propellant.properties is not None
-        return get_exit_pressure(
-            self.motor.propellant.properties.gamma_exhaust,
-            self.motor.thrust_chamber.nozzle.expansion_ratio,
-            self.P_0[-1],
-        )
-
-    def _append_exit_pressure(self, pressure: float) -> None:
-        self.P_exit.append(pressure)
-
-    def _compute_cf_correction(self) -> float:
-        """Compute the overall thrust coefficient correction factor.
-
-        Applies divergent nozzle loss, kinetics loss (frozen vs shifting Isp), and
-        combustion efficiency. Boundary layer and two-phase losses are omitted for
-        liquid propellants (gas-only combustion, no condensed phase).
-
-        Returns:
-            Overall nozzle correction factor (0–1).
-        """
-        assert self.motor.propellant.properties is not None
-        props = self.motor.propellant.properties
-        nozzle = self.motor.thrust_chamber.nozzle
-        chamber_pressure_psi = conversions.convert_pa_to_psi(self.P_0[-1])
-
+        chamber_pressure_psi = conversions.convert_pa_to_psi(new_P)
         eta_div = get_nozzle_divergent_percentage_loss(
-            divergent_angle=nozzle.divergent_angle,
+            divergent_angle=nz.divergent_angle,
         )
         eta_kin = get_kinetics_percentage_loss(
             i_sp_th_frozen=props.i_sp_frozen,
@@ -225,72 +166,41 @@ class LiquidEngineState(MotorState):
         nozzle_efficiency = get_overall_nozzle_efficiency(
             eta_div, eta_kin, 0.0, 0.0, other_losses=self.other_losses
         )
-        return nozzle_efficiency * self.motor.propellant.combustion_efficiency
+        n_cf = nozzle_efficiency * self.motor.propellant.combustion_efficiency
+        self.n_cf.append(n_cf)
 
-    def _append_cf_correction(self, value: float) -> None:
-        self.n_cf.append(value)
-
-    def _compute_thrust_coefficients(
-        self,
-        exit_pressure: float,
-        P_ext: float,
-    ) -> tuple[float, float]:
-        assert self.motor.propellant.properties is not None
         cf_ideal = get_ideal_thrust_coefficient(
-            self.P_0[-1],
-            exit_pressure,
+            new_P,
+            P_exit,
             P_ext,
-            self.motor.thrust_chamber.nozzle.expansion_ratio,
-            self.motor.propellant.properties.gamma_exhaust,
+            nz.expansion_ratio,
+            props.gamma_exhaust,
         )
-        cf = apply_thrust_coefficient_correction(cf_ideal, self.n_cf[-1])
-        return cf, cf_ideal
-
-    def _append_thrust(self, cf: float, cf_ideal: float) -> None:
-        thrust_val = get_thrust_from_thrust_coefficient(
-            cf,
-            self.P_0[-1],
-            self.motor.thrust_chamber.nozzle.get_throat_area(),
-        )
+        cf = apply_thrust_coefficient_correction(cf_ideal, n_cf)
         self.C_f.append(cf)
         self.C_f_ideal.append(cf_ideal)
-        self.thrust.append(thrust_val)
+        self.thrust.append(
+            get_thrust_from_thrust_coefficient(cf, new_P, nz.get_throat_area())
+        )
 
-    def _update_propellant_masses(
-        self, m_dot_fuel: float, m_dot_ox: float, d_t: float
-    ) -> None:
-        consumed_f = m_dot_fuel * d_t
-        consumed_o = m_dot_ox * d_t
-
-        self.motor.feed_system.fuel_tank.remove_propellant(consumed_f)
-        self.motor.feed_system.oxidizer_tank.remove_propellant(consumed_o)
-
-        new_fuel = self.fuel_mass[-1] - consumed_f
-        new_ox = self.oxidizer_mass[-1] - consumed_o
+        feed.fuel_tank.remove_propellant(cons_f)
+        feed.oxidizer_tank.remove_propellant(cons_o)
+        new_fuel = self.fuel_mass[-1] - cons_f
+        new_ox = self.oxidizer_mass[-1] - cons_o
         self.fuel_mass.append(new_fuel)
         self.oxidizer_mass.append(new_ox)
         self.m_prop.append(new_fuel + new_ox)
 
-    def _update_tank_pressures(self) -> None:
-        new_fuel_tank_pressure = self.motor.feed_system.get_fuel_tank_pressure()
-        new_oxidizer_tank_pressure = self.motor.feed_system.get_oxidizer_tank_pressure()
+        self.fuel_tank_pressure.append(feed.get_fuel_tank_pressure())
+        self.oxidizer_tank_pressure.append(feed.get_oxidizer_tank_pressure())
 
-        self.fuel_tank_pressure.append(new_fuel_tank_pressure)
-        self.oxidizer_tank_pressure.append(new_oxidizer_tank_pressure)
-
-    def _check_burn_end(self) -> None:
-        if self.end_burn:
-            return
-        if self.m_prop[-1] <= 0:
+        if self.m_prop[-1] <= 0 and not self.end_burn:
             self.end_burn = True
             self.burn_time = self.t[-1]
-
-    def _check_thrust_end(self, P_ext: float) -> None:
-        assert self.motor.propellant.properties is not None
         if not is_flow_choked(
-            self.P_0[-1],
+            new_P,
             P_ext,
-            get_critical_pressure_ratio(self.motor.propellant.properties.gamma_chamber),
+            get_critical_pressure_ratio(props.gamma_chamber),
         ):
             self._thrust_time = self.t[-1]
             self.end_thrust = True

--- a/machwave/states/solid_motor.py
+++ b/machwave/states/solid_motor.py
@@ -1,8 +1,8 @@
 import numpy as np
 
-import machwave.core.compressible_flow.nozzle as nozzle
 import machwave.core.compressible_flow.isentropic as isentropic
 import machwave.core.compressible_flow.losses as losses
+import machwave.core.compressible_flow.nozzle as nozzle_core
 import machwave.core.conversions as conversions
 import machwave.core.mass_balance as mass_balance
 import machwave.core.solvers.rk4 as rk4
@@ -85,6 +85,13 @@ class SolidMotorState(states_base.MotorState):
         self.nozzle_efficiency: states_base.SimulationArray = [0.0]
         self.overall_efficiency: states_base.SimulationArray = [0.0]
 
+    def get_m_dot_in(self) -> float:
+        propellant_density = self.motor.grain.get_real_density(
+            web_distance=self.web[-1],
+            ideal_density=self.motor.propellant.ideal_density,
+        )
+        return propellant_density * self.burn_rate[-1] * self.burn_area[-1]
+
     def run_timestep(
         self,
         d_t: float,
@@ -99,58 +106,42 @@ class SolidMotorState(states_base.MotorState):
         if self.end_thrust:
             return
 
-        self._append_time(d_t)
-        self._update_grain_geometry()
-        self._update_chamber_volume_and_mass()
-        self._update_cog_and_moi()
-        self._compute_pressure(d_t, P_ext)
-        self._compute_flow(P_ext)
-        self._check_burn_end()
-        self._check_thrust_end(P_ext)
+        propellant_properties = self.motor.propellant.properties
+        if propellant_properties is None:
+            raise ValueError(
+                "Propellant properties must be defined to run the simulation."
+            )
 
-    def _append_time(self, d_t: float) -> None:
+        nozzle = self.motor.thrust_chamber.nozzle
+        ideal_density = self.motor.propellant.ideal_density
+
         self.t.append(self.t[-1] + d_t)
 
-    def _update_grain_geometry(self) -> None:
         web_last = self.web[-1]
         self.burn_area.append(self.motor.grain.get_burn_area(web_last))
         self.propellant_volume.append(self.motor.grain.get_propellant_volume(web_last))
         burn_rate = self.motor.propellant.get_burn_rate(self.P_0[-1])
         self.burn_rate.append(burn_rate)
-        dx = burn_rate * (self.t[-1] - self.t[-2])
-        self.web.append(web_last + dx)
+        self.web.append(web_last + burn_rate * (self.t[-1] - self.t[-2]))
 
-    def _update_chamber_volume_and_mass(self) -> None:
         self.V_0.append(self.motor.get_free_chamber_volume(self.propellant_volume[-1]))
         self.m_prop.append(
             self.motor.grain.get_propellant_mass(
                 web_distance=self.web[-1],
-                ideal_density=self.motor.propellant.ideal_density,
+                ideal_density=ideal_density,
             )
         )
 
-    def _update_cog_and_moi(self) -> None:
-        # Update center of gravity and moment of inertia
-        cog = self.motor.grain.get_center_of_gravity(
-            web_distance=self.web[-1],
+        self.propellant_cog.append(
+            self.motor.grain.get_center_of_gravity(web_distance=self.web[-1])
         )
-        moi = self.motor.grain.get_moment_of_inertia(
-            ideal_density=self.motor.propellant.ideal_density,
-            web_distance=self.web[-1],
+        self.propellant_moi.append(
+            self.motor.grain.get_moment_of_inertia(
+                ideal_density=ideal_density,
+                web_distance=self.web[-1],
+            )
         )
-        self.propellant_cog.append(cog)
-        self.propellant_moi.append(moi)
 
-    def get_m_dot_in(self) -> float:
-        propellant_density = self.motor.grain.get_real_density(
-            web_distance=self.web[-1],
-            ideal_density=self.motor.propellant.ideal_density,
-        )
-        return propellant_density * self.burn_rate[-1] * self.burn_area[-1]
-
-    def _compute_pressure(self, d_t: float, P_ext: float) -> None:
-        props = self.motor.propellant.properties
-        assert props is not None
         new_P = rk4.rk4th_ode_solver(
             variables={"P0": self.P_0[-1]},
             equation=mass_balance.compute_chamber_pressure_mass_balance,
@@ -158,52 +149,43 @@ class SolidMotorState(states_base.MotorState):
             Pe=P_ext,
             m_in=self.get_m_dot_in(),
             V0=self.V_0[-1],
-            At=self.motor.thrust_chamber.nozzle.get_throat_area(),
-            k=props.gamma_chamber,
-            R=props.R_chamber,
-            T0=props.adiabatic_flame_temperature,
+            At=nozzle.get_throat_area(),
+            k=propellant_properties.gamma_chamber,
+            R=propellant_properties.R_chamber,
+            T0=propellant_properties.adiabatic_flame_temperature,
         )[0]
         self.P_0.append(new_P)
         self.P_exit.append(
             isentropic.get_exit_pressure(
-                props.gamma_exhaust,
-                self.motor.thrust_chamber.nozzle.expansion_ratio,
-                new_P,
+                propellant_properties.gamma_exhaust, nozzle.expansion_ratio, new_P
             )
         )
 
-    def _compute_flow(self, P_ext: float) -> None:
-        P0 = self.P_0[-1]
-        chamber_pressure_psi = conversions.convert_pa_to_psi(P0)
-        throat_diameter_inch = conversions.convert_meter_to_inch(
-            self.motor.thrust_chamber.nozzle.throat_diameter
-        )
-
+        chamber_pressure_psi = conversions.convert_pa_to_psi(new_P)
+        throat_diameter_inch = conversions.convert_meter_to_inch(nozzle.throat_diameter)
         eta_div = losses.get_nozzle_divergent_percentage_loss(
-            divergent_angle=self.motor.thrust_chamber.nozzle.divergent_angle,
+            divergent_angle=nozzle.divergent_angle,
         )
-        props = self.motor.propellant.properties
-        assert props is not None
         eta_kin = losses.get_kinetics_percentage_loss(
-            i_sp_th_frozen=props.i_sp_frozen,
-            i_sp_th_shifting=props.i_sp_shifting,
+            i_sp_th_frozen=propellant_properties.i_sp_frozen,
+            i_sp_th_shifting=propellant_properties.i_sp_shifting,
             chamber_pressure_psi=chamber_pressure_psi,
         )
         eta_bl = losses.get_boundary_layer_percentage_loss(
             chamber_pressure_psi=chamber_pressure_psi,
             throat_diameter_inch=throat_diameter_inch,
-            expansion_ratio=self.motor.thrust_chamber.nozzle.expansion_ratio,
+            expansion_ratio=nozzle.expansion_ratio,
             time=self.t[-1],
-            c_1=self.motor.thrust_chamber.nozzle.c_1,
-            c_2=self.motor.thrust_chamber.nozzle.c_2,
+            c_1=nozzle.c_1,
+            c_2=nozzle.c_2,
         )
         eta_2p = losses.get_two_phase_flow_percentage_loss(
             chamber_pressure_psi=chamber_pressure_psi,
-            mass_fraction_of_condensed_phase=props.qsi_chamber,
-            expansion_ratio=self.motor.thrust_chamber.nozzle.expansion_ratio,
+            mass_fraction_of_condensed_phase=propellant_properties.qsi_chamber,
+            expansion_ratio=nozzle.expansion_ratio,
             throat_diameter_inch=throat_diameter_inch,
             characteristic_length_inch=conversions.convert_meter_to_inch(
-                self.V_0[-1] / self.motor.thrust_chamber.nozzle.get_throat_area()
+                self.V_0[-1] / nozzle.get_throat_area()
             ),
         )
         nozzle_efficiency = losses.get_overall_nozzle_efficiency(
@@ -212,7 +194,6 @@ class SolidMotorState(states_base.MotorState):
         overall_efficiency = (
             nozzle_efficiency * self.motor.propellant.combustion_efficiency
         )
-
         self.eta_div.append(eta_div)
         self.eta_kin.append(eta_kin)
         self.eta_bl.append(eta_bl)
@@ -220,35 +201,31 @@ class SolidMotorState(states_base.MotorState):
         self.nozzle_efficiency.append(nozzle_efficiency)
         self.overall_efficiency.append(overall_efficiency)
 
-        cf_ideal = nozzle.get_ideal_thrust_coefficient(
-            P0,
+        cf_ideal = nozzle_core.get_ideal_thrust_coefficient(
+            new_P,
             self.P_exit[-1],
             P_ext,
-            self.motor.thrust_chamber.nozzle.expansion_ratio,
-            props.gamma_exhaust,
+            nozzle.expansion_ratio,
+            propellant_properties.gamma_exhaust,
         )
-        cf = nozzle.apply_thrust_coefficient_correction(cf_ideal, overall_efficiency)
+        cf = nozzle_core.apply_thrust_coefficient_correction(
+            cf_ideal, overall_efficiency
+        )
         self.C_f.append(cf)
         self.C_f_ideal.append(cf_ideal)
         self.thrust.append(
-            nozzle.get_thrust_from_thrust_coefficient(
-                cf, P0, self.motor.thrust_chamber.nozzle.get_throat_area()
+            nozzle_core.get_thrust_from_thrust_coefficient(
+                cf, new_P, nozzle.get_throat_area()
             )
         )
 
-    def _check_burn_end(self) -> None:
         if self.m_prop[-1] <= 0 and not self.end_burn:
             self.burn_time = self.t[-1]
             self.end_burn = True
-
-    def _check_thrust_end(self, P_ext: float) -> None:
-        assert self.motor.propellant.properties is not None
         if not isentropic.is_flow_choked(
-            self.P_0[-1],
+            new_P,
             P_ext,
-            isentropic.get_critical_pressure_ratio(
-                self.motor.propellant.properties.gamma_chamber
-            ),
+            isentropic.get_critical_pressure_ratio(propellant_properties.gamma_chamber),
         ):
             self._thrust_time = self.t[-1]
             self.end_thrust = True


### PR DESCRIPTION
## Summary

- Inlines the bodies of the private helper methods chained from `SolidMotorState.run_timestep` and `LiquidEngineState.run_timestep` directly into `run_timestep`. Each per-step block now reads top-to-bottom in one place.
- Architecture is unchanged: `MotorState` subclasses still expose `run_timestep`, called once per loop iteration from `InternalBallisticsSimulation.run`. `get_m_dot_in` is preserved because it is part of the public `MotorState` interface.
- Solid motor state aliases its `machwave.core.compressible_flow.nozzle` module import to `nozzle_core` so it does not collide with the new local `nozzle` variable referencing the motor's `Nozzle` instance.

Closes #207.

## Test plan

- [x] `pytest tests` — 545 tests pass.
- [x] Solid motor example (`apcp_motor`) run in process on this branch and on master, every recorded array (`t`, `P_0`, `P_exit`, `thrust`, `C_f`, `burn_area`, `burn_rate`, `web`, `V_0`, `m_prop`, `nozzle_efficiency`, `overall_efficiency`) hashed and compared — bit-for-bit identical, including `burn_time` and `thrust_time`.
- [x] Liquid engine example (`1kn_lre`) run in process on this branch and on master, every recorded array (`t`, `P_0`, `P_exit`, `thrust`, `C_f`, `fuel_mass`, `oxidizer_mass`, `m_prop`, `n_cf`, `fuel_tank_pressure`, `oxidizer_tank_pressure`) hashed and compared — bit-for-bit identical.