### PR TITLE
Install gfortran on macOS smoke-test runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,10 @@ jobs:
           name: dist
           path: dist
 
+      - name: Install gfortran (macOS)
+        if: runner.os == 'macOS'
+        run: brew install gcc
+
       - name: Install built wheel
         run: python -m pip install dist/*.whl
 


### PR DESCRIPTION
## Summary
- Adds a macOS-only step that runs `brew install gcc` (which provides `gfortran`) before the smoke job pip-installs the built wheel
- Unblocks the PyPI publish workflow's macOS matrix entries, which currently fail because `rocketcea` has no macOS wheel on PyPI and the source build cannot find a Fortran compiler on the GitHub-hosted runner

Closes #211

## Test plan
- [ ] Branch CI runs the existing Machwave CI workflow and stays green (this change only touches `publish.yml`, which only runs on `release: published`)
- [ ] Verified after merge by the next release: the three macOS legs of `Smoke test built wheel` install the wheel cleanly instead of erroring on `Unknown compiler(s)`