### PR TITLE
Symlink unversioned gfortran on macOS smoke-test runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,16 @@ jobs:
 
       - name: Install gfortran (macOS)
         if: runner.os == 'macOS'
-        run: brew install gcc
+        run: |
+          brew install gcc
+          brew_prefix=$(brew --prefix)
+          gfortran_versioned=$(ls "$brew_prefix"/bin/gfortran-* 2>/dev/null | sort -V | tail -n 1)
+          if [ -z "$gfortran_versioned" ]; then
+            echo "::error::No gfortran-* binary found in $brew_prefix/bin after brew install gcc"
+            exit 1
+          fi
+          ln -sf "$gfortran_versioned" "$brew_prefix/bin/gfortran"
+          gfortran --version
 
       - name: Install built wheel
         run: python -m pip install dist/*.whl


### PR DESCRIPTION
## Summary
- Follow-up to #212. After `brew install gcc`, create an unversioned `gfortran` symlink in `$(brew --prefix)/bin` pointing at the highest installed `gfortran-N`. Meson, invoked by the rocketcea source build, searches PATH for an unversioned `gfortran` and was failing on the macOS smoke legs of the publish workflow.
- Fails the step loudly if no `gfortran-*` binary is present after `brew install`, so a future Homebrew change is caught at install time rather than masked.

Closes #213

## Test plan
- [ ] Branch CI stays green (this change only touches `publish.yml`, which only runs on `release: published`)
- [ ] Verified after merge by the next release tag: the three macOS legs of `Smoke test built wheel` install the wheel cleanly instead of erroring on `Unknown compiler(s)`