### PR TITLE
Document macOS gfortran prerequisite in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ Install Machwave using pip:
 pip install machwave
 ```
 
+#### macOS prerequisite: gfortran
+
+Machwave depends on [rocketcea](https://pypi.org/project/RocketCEA/), which does
+not publish macOS wheels on PyPI. On macOS, pip therefore builds rocketcea from
+source and needs a Fortran compiler. Homebrew's `gcc` formula installs only
+versioned binaries (e.g. `gfortran-15`), so an unversioned `gfortran` symlink
+must be added to `PATH` before `pip install machwave`:
+
+```bash
+brew install gcc
+ln -sf "$(ls "$(brew --prefix)"/bin/gfortran-* | sort -V | tail -n 1)" "$(brew --prefix)/bin/gfortran"
+```
+
+Linux and Windows users do not need this step — rocketcea ships prebuilt wheels
+for those platforms.
+
 ### Documentation
 
 The full documentation is available at


### PR DESCRIPTION
## Summary
- Adds a short `macOS prerequisite: gfortran` subsection under `### Installation` explaining why `pip install machwave` fails on macOS without it (rocketcea has no macOS wheel on PyPI and falls back to a source build that needs a Fortran compiler) and providing the `brew install gcc` plus unversioned-symlink recipe
- Calls out explicitly that Linux and Windows users don't need this step

Closes #215

## Test plan
- [ ] PR CI stays green
- [ ] Render-check the new section on the rendered README (formatting, link to rocketcea PyPI page)
- [ ] Optional manual sanity check: copy-paste the two commands on a fresh macOS environment and confirm `gfortran --version` resolves