### PR TITLE
Adopt PEP-8 identifiers (#179)

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -111,7 +111,7 @@ from machwave.services.plots import internal_ballistics as ib_plots
 
 sim.print_results()
 
-ib_plots.thrust_pressure_plot(time, state.thrust, state.P_0).show()
+ib_plots.thrust_pressure_plot(time, state.thrust, state.chamber_pressure).show()
 ```
 
 `print_results()` outputs initial propellant mass, max/average chamber pressure,

--- a/docs/theory/mass_balance.md
+++ b/docs/theory/mass_balance.md
@@ -192,7 +192,7 @@ Huzel & Huang (1992) Ch. 1 §1.4 (The Gas-Flow Processes).*
 The exit term is identical to §2.2.2 — the choked-flow expression derived in §1.7
 (Sutton & Biblarz §3.3). For LRE the implementation drops the throat discharge
 coefficient (\(C_d \equiv 1\)) and uses the chamber-state isentropic exponent
-\(k = \gamma_\text{chamber}\):
+\(k = k_\text{chamber}\):
 
 \[
 \dot{m}_{out} = \frac{P_0\, A_t}{\sqrt{R T_0}}\,\sqrt{k}\left(\frac{2}{k+1}\right)^{(k+1)/[2(k-1)]}.

--- a/examples/1kn_lre.py
+++ b/examples/1kn_lre.py
@@ -105,7 +105,7 @@ def main():
     (time, ib_state) = simulation.run()
 
     simulation.print_results()
-    thrust_pressure_plot(time, ib_state.thrust, ib_state.P_0).show()
+    thrust_pressure_plot(time, ib_state.thrust, ib_state.chamber_pressure).show()
     plot_bipropellant_tank_profiles(
         time,
         ib_state.oxidizer_tank_pressure,

--- a/examples/apcp_motor.py
+++ b/examples/apcp_motor.py
@@ -70,7 +70,7 @@ def main():
     (time, ib_state) = sim.run()
 
     internal_ballistics_plots.thrust_pressure_plot(
-        time, ib_state.thrust, ib_state.P_0
+        time, ib_state.thrust, ib_state.chamber_pressure
     ).show()
 
     sim.print_results()

--- a/examples/kappa_rnakka.py
+++ b/examples/kappa_rnakka.py
@@ -68,7 +68,7 @@ def main():
     (time, ib_state) = sim.run()
 
     internal_ballistics_plots.thrust_pressure_plot(
-        time, ib_state.thrust, ib_state.P_0
+        time, ib_state.thrust, ib_state.chamber_pressure
     ).show()
 
     sim.print_results()

--- a/examples/losses/boundary_layer.py
+++ b/examples/losses/boundary_layer.py
@@ -59,7 +59,7 @@ for (
     TIMES,
     C1_C2_VALUES,
 ):
-    eta_bl = losses.get_boundary_layer_percentage_loss(
+    boundary_layer_loss = losses.get_boundary_layer_percentage_loss(
         chamber_pressure_psi=P_ch,
         throat_diameter_inch=d_t,
         expansion_ratio=eps,
@@ -76,7 +76,7 @@ for (
             "time (s)": t,
             "C1": c1,
             "C2": c2,
-            "η_bl (%)": round(eta_bl, 3),
+            "η_bl (%)": round(boundary_layer_loss, 3),
         }
     )
 

--- a/examples/losses/divergent.py
+++ b/examples/losses/divergent.py
@@ -27,12 +27,12 @@ DIVERGENT_ANGLES = (
 records: list[dict[str, float]] = []
 
 for angle in DIVERGENT_ANGLES:
-    eta_div = get_nozzle_divergent_percentage_loss(divergent_angle=angle)
+    divergent_loss = get_nozzle_divergent_percentage_loss(divergent_angle=angle)
 
     records.append(
         {
             "θ_half (deg)": angle,
-            "η_div (%)": round(eta_div, 3),
+            "η_div (%)": round(divergent_loss, 3),
         }
     )
 

--- a/examples/losses/kinetics.py
+++ b/examples/losses/kinetics.py
@@ -29,7 +29,7 @@ for P_ch, (i_sp_frozen, i_sp_shifting) in product(
     CHAMBER_PRESSURES_PSI,
     ISP_TH_PAIRS,
 ):
-    eta_kin = get_kinetics_percentage_loss(
+    kinetics_loss = get_kinetics_percentage_loss(
         i_sp_th_frozen=i_sp_frozen,
         i_sp_th_shifting=i_sp_shifting,
         chamber_pressure_psi=P_ch,
@@ -40,7 +40,7 @@ for P_ch, (i_sp_frozen, i_sp_shifting) in product(
             "P_ch (psi)": P_ch,
             "Isp_frozen (s)": i_sp_frozen,
             "Isp_shifting (s)": i_sp_shifting,
-            "η_kin (%)": round(eta_kin, 3),
+            "η_kin (%)": round(kinetics_loss, 3),
         }
     )
 

--- a/examples/losses/two_phase.py
+++ b/examples/losses/two_phase.py
@@ -51,12 +51,11 @@ for P_ch, d_t, x_c, eps, l_star in product(
 ):
     d_p_um = losses._get_two_phase_phase_loss_particle_size(
         chamber_pressure_psi=P_ch,
-        xi=x_c,
+        mass_fraction_of_condensed_phase=x_c,
         throat_diameter_inch=d_t,
         characteristic_length_inch=l_star,
     )
-    eta_2p = 100 * (0.012 + 0.83 * eps**-0.35) * x_c
-    eta_2p = losses.get_two_phase_flow_percentage_loss(
+    two_phase_loss = losses.get_two_phase_flow_percentage_loss(
         chamber_pressure_psi=P_ch,
         mass_fraction_of_condensed_phase=x_c,
         expansion_ratio=eps,
@@ -72,7 +71,7 @@ for P_ch, d_t, x_c, eps, l_star in product(
             "ε": eps,
             "l* (in)": l_star,
             "d_p (µm)": round(d_p_um, 2),
-            "η_2φ (%)": round(eta_2p, 3),
+            "η_2φ (%)": round(two_phase_loss, 3),
         }
     )
 

--- a/examples/nero_motor.py
+++ b/examples/nero_motor.py
@@ -69,7 +69,7 @@ def main():
     (time, ib_state) = sim.run()
 
     internal_ballistics_plots.thrust_pressure_plot(
-        time, ib_state.thrust, ib_state.P_0
+        time, ib_state.thrust, ib_state.chamber_pressure
     ).show()
 
     sim.print_results()

--- a/examples/olympus.py
+++ b/examples/olympus.py
@@ -85,10 +85,13 @@ def main():
     sim.print_results()
 
     internal_ballistics_plots.thrust_pressure_plot(
-        t, ib_state.thrust, ib_state.P_0
+        t, ib_state.thrust, ib_state.chamber_pressure
     ).show()
     internal_ballistics_plots.thrust_coefficient_plot(
-        t, ib_state.C_f_ideal, ib_state.C_f, show_efficiency=True
+        t,
+        ib_state.thrust_coefficient_ideal,
+        ib_state.thrust_coefficient,
+        show_efficiency=True,
     ).show()
 
 

--- a/examples/olympus_montecarlo.py
+++ b/examples/olympus_montecarlo.py
@@ -91,7 +91,7 @@ def main():
     mc.plot_time_series_extremes(
         1,
         "t",
-        series_property="P_0",
+        series_property="chamber_pressure",
         title="Pressão de Câmara (MPa)",
     )
     mc.plot_time_series_extremes(

--- a/machwave/adapters/rocketpy/base.py
+++ b/machwave/adapters/rocketpy/base.py
@@ -117,7 +117,7 @@ class RocketPyMotorAdapter(abc.ABC, typing.Generic[M]):
             "reshape_thrust_curve": RESHAPE_THRUST_CURVE,
             "interpolation_method": INTERPOLATION_METHOD,
             "coordinate_system_orientation": ROCKETPY_MOTOR_COORDINATE_SYSTEM,
-            "reference_pressure": self.motor_state.P_exit[0],
+            "reference_pressure": self.motor_state.exit_pressure[0],
         }
 
     @property

--- a/machwave/core/compressible_flow/isentropic.py
+++ b/machwave/core/compressible_flow/isentropic.py
@@ -60,21 +60,23 @@ def get_exit_mach_from_expansion_ratio(k: float, expansion_ratio: float) -> floa
 
 
 def get_exit_pressure(
-    k_ex: float, expansion_ratio: float, chamber_pressure: float
+    k_exhaust: float,
+    expansion_ratio: float,
+    chamber_pressure: float,
 ) -> float:
     """Get exit pressure from isentropic relations.
 
     Args:
-        k_ex: Isentropic exponent at exit.
+        k_exhaust: Isentropic exponent at exit.
         expansion_ratio: Expansion ratio.
         chamber_pressure: Chamber pressure [Pa].
 
     Returns:
         Exit pressure [Pa].
     """
-    exit_mach = get_exit_mach_from_expansion_ratio(k_ex, expansion_ratio)
-    return chamber_pressure * (1 + 0.5 * (k_ex - 1) * exit_mach**2) ** (
-        -k_ex / (k_ex - 1)
+    exit_mach = get_exit_mach_from_expansion_ratio(k_exhaust, expansion_ratio)
+    return chamber_pressure * (1 + 0.5 * (k_exhaust - 1) * exit_mach**2) ** (
+        -k_exhaust / (k_exhaust - 1)
     )
 
 

--- a/machwave/core/compressible_flow/losses.py
+++ b/machwave/core/compressible_flow/losses.py
@@ -136,7 +136,7 @@ def get_boundary_layer_percentage_loss(
 
 def _get_two_phase_phase_loss_particle_size(
     chamber_pressure_psi: float,
-    xi: float,
+    mass_fraction_of_condensed_phase: float,
     throat_diameter_inch: float,
     characteristic_length_inch: float,
 ) -> float:
@@ -148,7 +148,7 @@ def _get_two_phase_phase_loss_particle_size(
 
     Args:
         chamber_pressure_psi: The chamber pressure [psi].
-        xi: The mass fraction of the condensed phase.
+        mass_fraction_of_condensed_phase: The mass fraction of the condensed phase.
         throat_diameter_inch: The throat diameter [in].
         characteristic_length_inch: The characteristic length [in].
 
@@ -158,7 +158,7 @@ def _get_two_phase_phase_loss_particle_size(
     return (
         0.454
         * chamber_pressure_psi ** (1 / 3)
-        * xi ** (1 / 3)
+        * mass_fraction_of_condensed_phase ** (1 / 3)
         * (1 - np.exp(-0.004 * characteristic_length_inch))
         * (1 + 0.045 * throat_diameter_inch)
     )
@@ -194,9 +194,8 @@ def get_two_phase_flow_percentage_loss(
         throat_diameter_inch,
         characteristic_length_inch,
     )
-    xi: float = mass_fraction_of_condensed_phase
 
-    if xi >= 0.09:
+    if mass_fraction_of_condensed_phase >= 0.09:
         c_4 = 0.5
         if throat_diameter_inch < 1.0:
             c_3, c_5, c_6 = 9.0, 1.0, 1.0
@@ -209,7 +208,7 @@ def get_two_phase_flow_percentage_loss(
                 c_3, c_5, c_6 = 10.2, 0.8, 0.4
             else:
                 c_3, c_5, c_6 = 7.58, 0.8, 0.33
-    else:  # xi < 0.09
+    else:  # mass_fraction_of_condensed_phase < 0.09
         c_4 = 1.0
         if throat_diameter_inch < 1.0:
             c_3, c_5, c_6 = 30.0, 1.0, 1.0
@@ -223,7 +222,7 @@ def get_two_phase_flow_percentage_loss(
             else:
                 c_3, c_5, c_6 = 25.2, 0.8, 0.33
 
-    numerator = (xi**c_4) * (particle_size_um**c_5)
+    numerator = (mass_fraction_of_condensed_phase**c_4) * (particle_size_um**c_5)
     denominator = (
         (chamber_pressure_psi**0.15)
         * (expansion_ratio**0.08)
@@ -235,23 +234,33 @@ def get_two_phase_flow_percentage_loss(
 
 @decorators.check_bounds(lower=0.0, upper=1.0)
 def get_overall_nozzle_efficiency(
-    eta_div: float,
-    eta_kin: float,
-    eta_bl: float,
-    eta_2p: float,
+    divergent_loss: float,
+    kinetics_loss: float,
+    boundary_layer_loss: float,
+    two_phase_loss: float,
     other_losses: float,
 ) -> float:
     """
     Calculates the overall nozzle efficiency by combining the correction factors.
 
     Args:
-        eta_div: The divergent nozzle correction factor.
-        eta_kin: The kinetics correction factor.
-        eta_bl: The boundary layer correction factor.
-        eta_2p: The two-phase flow correction factor.
+        divergent_loss: The divergent nozzle correction factor.
+        kinetics_loss: The kinetics correction factor.
+        boundary_layer_loss: The boundary layer correction factor.
+        two_phase_loss: The two-phase flow correction factor.
         other_losses: Additional losses, in percent.
 
     Returns:
         The overall nozzle efficiency.
     """
-    return 1 - (eta_div + eta_kin + eta_bl + eta_2p + other_losses) / 100
+    return (
+        1
+        - (
+            divergent_loss
+            + kinetics_loss
+            + boundary_layer_loss
+            + two_phase_loss
+            + other_losses
+        )
+        / 100
+    )

--- a/machwave/core/compressible_flow/nozzle.py
+++ b/machwave/core/compressible_flow/nozzle.py
@@ -29,7 +29,7 @@ def get_ideal_thrust_coefficient(
     exit_pressure: float,
     external_pressure: float,
     expansion_ratio: float,
-    k_ex: float,
+    k_exhaust: float,
 ) -> float:
     """Get ideal thrust coefficient for DeLaval nozzle.
 
@@ -38,7 +38,7 @@ def get_ideal_thrust_coefficient(
         exit_pressure: Exit pressure [Pa].
         external_pressure: External pressure [Pa].
         expansion_ratio: Expansion ratio.
-        k_ex: Isentropic exponent at exit.
+        k_exhaust: Isentropic exponent at exit.
 
     Returns:
         Ideal thrust coefficient.
@@ -49,9 +49,9 @@ def get_ideal_thrust_coefficient(
     pressure_ratio = exit_pressure / chamber_pressure
     return (
         np.sqrt(
-            (2 * (k_ex**2) / (k_ex - 1))
-            * ((2 / (k_ex + 1)) ** ((k_ex + 1) / (k_ex - 1)))
-            * (1 - (pressure_ratio ** ((k_ex - 1) / k_ex)))
+            (2 * (k_exhaust**2) / (k_exhaust - 1))
+            * ((2 / (k_exhaust + 1)) ** ((k_exhaust + 1) / (k_exhaust - 1)))
+            * (1 - (pressure_ratio ** ((k_exhaust - 1) / k_exhaust)))
         )
         + expansion_ratio * (exit_pressure - external_pressure) / chamber_pressure
     )

--- a/machwave/core/mass_balance.py
+++ b/machwave/core/mass_balance.py
@@ -2,15 +2,15 @@ from .compressible_flow.isentropic import get_critical_pressure_ratio
 
 
 def compute_chamber_pressure_mass_balance(
-    P0: float,
-    Pe: float,
-    m_in: float,
-    V0: float,
-    At: float,
+    chamber_pressure: float,
+    external_pressure: float,
+    mass_flow_in: float,
+    free_chamber_volume: float,
+    throat_area: float,
     k: float,
     R: float,
-    T0: float,
-    Cd: float = 1.0,
+    flame_temperature: float,
+    discharge_coefficient: float = 1.0,
 ) -> tuple[float]:
     """
     Right-hand side of the chamber pressure ODE from a control-volume mass balance.
@@ -18,32 +18,40 @@ def compute_chamber_pressure_mass_balance(
     Handles both choked and sub-critical nozzle flow (Seidel 1965, Eq. 35).
 
     Args:
-        P0: Chamber pressure [Pa].
-        Pe: External pressure [Pa].
-        m_in: Mass flow rate into the chamber [kg/s].
-        V0: Chamber free volume [m^3].
-        At: Nozzle throat area [m^2].
+        chamber_pressure: Chamber pressure [Pa].
+        external_pressure: External pressure [Pa].
+        mass_flow_in: Mass flow rate into the chamber [kg/s].
+        free_chamber_volume: Chamber free volume [m^3].
+        throat_area: Nozzle throat area [m^2].
         k: Isentropic exponent of the mix.
         R: Gas constant per molecular weight [J/(kg·K)].
-        T0: Flame temperature [K].
-        Cd: Discharge coefficient.
+        flame_temperature: Flame temperature [K].
+        discharge_coefficient: Discharge coefficient.
 
     Returns:
         Derivative of chamber pressure with respect to time, as a one-tuple.
     """
     critical_pressure_ratio = get_critical_pressure_ratio(k=k)
-    Pr = Pe / P0
+    pressure_ratio = external_pressure / chamber_pressure
 
-    if Pr <= critical_pressure_ratio:  # choked
+    if pressure_ratio <= critical_pressure_ratio:  # choked
         H = (k**0.5) * (2 / (k + 1)) ** ((k + 1) / (2 * (k - 1)))
     else:
         H = (
             ((2 * k / (k - 1)) ** 0.5)
-            * Pr ** (1 / k)
-            * (1 - Pr ** ((k - 1) / k)) ** 0.5
+            * pressure_ratio ** (1 / k)
+            * (1 - pressure_ratio ** ((k - 1) / k)) ** 0.5
         )
 
-    m_out = Cd * P0 * At * H / (R * T0) ** 0.5
+    mass_flow_out = (
+        discharge_coefficient
+        * chamber_pressure
+        * throat_area
+        * H
+        / (R * flame_temperature) ** 0.5
+    )
 
-    dP0_dt = (R * T0 / V0) * (m_in - m_out)
-    return (dP0_dt,)
+    chamber_pressure_derivative = (R * flame_temperature / free_chamber_volume) * (
+        mass_flow_in - mass_flow_out
+    )
+    return (chamber_pressure_derivative,)

--- a/machwave/models/motors/liquid.py
+++ b/machwave/models/motors/liquid.py
@@ -121,7 +121,7 @@ class LiquidEngine(Motor[BiliquidPropellant, LiquidEngineThrustChamber]):
         exit_pressure: float,
         external_pressure: float,
         expansion_ratio: float,
-        k_ex: float,
+        k_exhaust: float,
         other_losses: float,
     ) -> float:
         """Get thrust coefficient.
@@ -131,18 +131,20 @@ class LiquidEngine(Motor[BiliquidPropellant, LiquidEngineThrustChamber]):
             exit_pressure: Exit pressure [Pa].
             external_pressure: External pressure [Pa].
             expansion_ratio: Expansion ratio.
-            k_ex: Two-phase isentropic coefficient.
+            k_exhaust: Two-phase isentropic coefficient.
             other_losses: Additional losses not covered by specific mechanisms [%].
 
         Returns:
             Instantaneous thrust coefficient.
         """
-        cf_ideal = get_ideal_thrust_coefficient(
+        thrust_coefficient_ideal = get_ideal_thrust_coefficient(
             chamber_pressure=chamber_pressure,
             exit_pressure=exit_pressure,
             external_pressure=external_pressure,
             expansion_ratio=expansion_ratio,
-            k_ex=k_ex,
+            k_exhaust=k_exhaust,
         )
-        n_cf = self.get_thrust_coefficient_correction_factor(other_losses)
-        return cf_ideal * n_cf
+        nozzle_correction_factor = self.get_thrust_coefficient_correction_factor(
+            other_losses
+        )
+        return thrust_coefficient_ideal * nozzle_correction_factor

--- a/machwave/models/motors/solid.py
+++ b/machwave/models/motors/solid.py
@@ -31,8 +31,8 @@ class SolidMotor(
 
         self.grain = grain
         self.propellant: propellants.SolidPropellant = propellant
-        self.cf_ideal = None  # ideal thrust coefficient
-        self.cf_real = None  # real thrust coefficient
+        self.thrust_coefficient_ideal = None
+        self.thrust_coefficient_real = None
 
     def get_free_chamber_volume(self, propellant_volume: float) -> float:
         """
@@ -64,8 +64,8 @@ class SolidMotor(
         exit_pressure: float,
         external_pressure: float,
         expansion_ratio: float,
-        k_ex: float,
-        n_cf: float,
+        k_exhaust: float,
+        nozzle_correction_factor: float,
     ) -> float:
         """
         Args:
@@ -73,21 +73,23 @@ class SolidMotor(
             exit_pressure: Exit pressure, in Pa
             external_pressure: External pressure, in Pa
             expansion_ratio: Expansion ratio, adimensional
-            k_ex: Two-phase isentropic coefficient, adimensional
-            n_cf: Thrust coefficient correction factor, adimensional
+            k_exhaust: Two-phase isentropic coefficient, adimensional
+            nozzle_correction_factor: Thrust coefficient correction factor, adimensional
 
         Returns:
             Instanteneous thrust coefficient, adimensional
         """
-        self.cf_ideal = nozzle.get_ideal_thrust_coefficient(
+        self.thrust_coefficient_ideal = nozzle.get_ideal_thrust_coefficient(
             chamber_pressure,
             exit_pressure,
             external_pressure,
             expansion_ratio,
-            k_ex,
+            k_exhaust,
         )
-        self.cf_real = nozzle.apply_thrust_coefficient_correction(self.cf_ideal, n_cf)
-        return self.cf_real
+        self.thrust_coefficient_real = nozzle.apply_thrust_coefficient_correction(
+            self.thrust_coefficient_ideal, nozzle_correction_factor
+        )
+        return self.thrust_coefficient_real
 
     def get_launch_mass(self) -> float:
         return self.thrust_chamber.dry_mass + self.initial_propellant_mass

--- a/machwave/models/propellants/categories/base.py
+++ b/machwave/models/propellants/categories/base.py
@@ -101,11 +101,11 @@ class Propellant(abc.ABC):
             chamber_pressure=chamber_pressure
         )
 
-        molecular_weight_chamber, gamma_chamber = service.get_chamber_properties(
+        molecular_weight_chamber, k_chamber = service.get_chamber_properties(
             chamber_pressure=chamber_pressure, expansion_ratio=expansion_ratio
         )
 
-        molecular_weight_exhaust, gamma_exhaust = service.get_exhaust_properties(
+        molecular_weight_exhaust, k_exhaust = service.get_exhaust_properties(
             chamber_pressure=chamber_pressure, expansion_ratio=expansion_ratio
         )
 
@@ -117,8 +117,8 @@ class Propellant(abc.ABC):
         )
 
         properties = ThermochemicalProperties(
-            gamma_chamber=gamma_chamber,
-            gamma_exhaust=gamma_exhaust,
+            k_chamber=k_chamber,
+            k_exhaust=k_exhaust,
             adiabatic_flame_temperature=adiabatic_flame_temperature,
             molecular_weight_chamber=molecular_weight_chamber,
             molecular_weight_exhaust=molecular_weight_exhaust,

--- a/machwave/models/propellants/formulations/base.py
+++ b/machwave/models/propellants/formulations/base.py
@@ -113,8 +113,8 @@ def _parse_properties(
 
     props_data = data["properties"]
     return propellant_properties.ThermochemicalProperties(
-        gamma_chamber=props_data["gamma_chamber"],
-        gamma_exhaust=props_data["gamma_exhaust"],
+        k_chamber=props_data["k_chamber"],
+        k_exhaust=props_data["k_exhaust"],
         adiabatic_flame_temperature=props_data["adiabatic_flame_temperature"],
         molecular_weight_chamber=props_data["molecular_weight_chamber"],
         molecular_weight_exhaust=props_data["molecular_weight_exhaust"],

--- a/machwave/models/propellants/formulations/solid/kndx.json
+++ b/machwave/models/propellants/formulations/solid/kndx.json
@@ -29,8 +29,8 @@
     {"min": 8502000, "max": 11200000, "a": 4.775, "n": 0.442}
   ],
   "properties": {
-    "gamma_chamber": 1.1308,
-    "gamma_exhaust": 1.0430,
+    "k_chamber": 1.1308,
+    "k_exhaust": 1.0430,
     "adiabatic_flame_temperature": 1712,
     "molecular_weight_chamber": 0.042391,
     "molecular_weight_exhaust": 0.042882,

--- a/machwave/models/propellants/formulations/solid/kner.json
+++ b/machwave/models/propellants/formulations/solid/kner.json
@@ -25,8 +25,8 @@
     {"min": 0, "max": 100000000, "a": 2.903, "n": 0.395}
   ],
   "properties": {
-    "gamma_chamber": 1.1390,
-    "gamma_exhaust": 1.0426,
+    "k_chamber": 1.1390,
+    "k_exhaust": 1.0426,
     "adiabatic_flame_temperature": 1608,
     "molecular_weight_chamber": 0.038570,
     "molecular_weight_exhaust": 0.038779,

--- a/machwave/models/propellants/formulations/solid/knsb.json
+++ b/machwave/models/propellants/formulations/solid/knsb.json
@@ -25,8 +25,8 @@
     {"min": 0, "max": 11000000, "a": 5.13, "n": 0.222}
   ],
   "properties": {
-    "gamma_chamber": 1.1361,
-    "gamma_exhaust": 1.0420,
+    "k_chamber": 1.1361,
+    "k_exhaust": 1.0420,
     "adiabatic_flame_temperature": 1603,
     "molecular_weight_chamber": 0.039857,
     "molecular_weight_exhaust": 0.040048,

--- a/machwave/models/propellants/formulations/solid/knsb_nakka.json
+++ b/machwave/models/propellants/formulations/solid/knsb_nakka.json
@@ -29,8 +29,8 @@
     {"min": 7033000, "max": 10670000, "a": 9.653, "n": 0.064}
   ],
   "properties": {
-    "gamma_chamber": 1.1361,
-    "gamma_exhaust": 1.0420,
+    "k_chamber": 1.1361,
+    "k_exhaust": 1.0420,
     "adiabatic_flame_temperature": 1603,
     "molecular_weight_chamber": 0.039857,
     "molecular_weight_exhaust": 0.040048,

--- a/machwave/models/propellants/formulations/solid/knsu.json
+++ b/machwave/models/propellants/formulations/solid/knsu.json
@@ -25,8 +25,8 @@
     {"min": 0, "max": 100000000, "a": 8.260, "n": 0.319}
   ],
   "properties": {
-    "gamma_chamber": 1.1330,
-    "gamma_exhaust": 1.1044,
+    "k_chamber": 1.1330,
+    "k_exhaust": 1.1044,
     "adiabatic_flame_temperature": 1722,
     "molecular_weight_chamber": 0.041964,
     "molecular_weight_exhaust": 0.041517,

--- a/machwave/models/propellants/formulations/solid/mit_cherry_limeade.json
+++ b/machwave/models/propellants/formulations/solid/mit_cherry_limeade.json
@@ -34,8 +34,8 @@
     {"min": 0, "max": 6350000, "a": 3.2373, "n": 0.3273}
   ],
   "properties": {
-    "gamma_chamber": 1.2100,
-    "gamma_exhaust": 1.2501,
+    "k_chamber": 1.2100,
+    "k_exhaust": 1.2501,
     "adiabatic_flame_temperature": 2800,
     "molecular_weight_chamber": 0.023724,
     "molecular_weight_exhaust": 0.023811,

--- a/machwave/models/propellants/formulations/solid/rnx_57.json
+++ b/machwave/models/propellants/formulations/solid/rnx_57.json
@@ -34,8 +34,8 @@
     {"min": 0, "max": 100000000, "a": 1.95, "n": 0.477}
   ],
   "properties": {
-    "gamma_chamber": 1.1279,
-    "gamma_exhaust": 1.1279,
+    "k_chamber": 1.1279,
+    "k_exhaust": 1.1279,
     "adiabatic_flame_temperature": 1644,
     "molecular_weight_chamber": 0.04554,
     "molecular_weight_exhaust": 0.04554,

--- a/machwave/models/propellants/formulations/solid/rnx_71v.json
+++ b/machwave/models/propellants/formulations/solid/rnx_71v.json
@@ -34,8 +34,8 @@
     {"min": 0, "max": 100000000, "a": 2.57, "n": 0.371}
   ],
   "properties": {
-    "gamma_chamber": 1.1384,
-    "gamma_exhaust": 1.1384,
+    "k_chamber": 1.1384,
+    "k_exhaust": 1.1384,
     "adiabatic_flame_temperature": 1492,
     "molecular_weight_chamber": 0.04183,
     "molecular_weight_exhaust": 0.04183,

--- a/machwave/models/propellants/properties.py
+++ b/machwave/models/propellants/properties.py
@@ -9,8 +9,8 @@ import scipy.constants
 # NOTE 1: field_name must match the dataclass' ThermochemicalProperties attributes
 # NOTE 2: bounds are inclusive on both ends
 VALIDATION_BOUNDS: dict[str, tuple[float, float]] = {
-    "gamma_chamber": (1.0, 2.0),
-    "gamma_exhaust": (1.0, 2.0),
+    "k_chamber": (1.0, 2.0),
+    "k_exhaust": (1.0, 2.0),
     "adiabatic_flame_temperature": (0.0, 5000.0),
     "molecular_weight_chamber": (0.001, 0.200),
     "molecular_weight_exhaust": (0.001, 0.200),
@@ -27,8 +27,8 @@ class ThermochemicalProperties:
     propellants.
 
     Attributes:
-        gamma_chamber: Isentropic exponent in chamber.
-        gamma_exhaust: Isentropic exponent at nozzle exit.
+        k_chamber: Isentropic exponent in chamber.
+        k_exhaust: Isentropic exponent at nozzle exit.
         adiabatic_flame_temperature: Ideal combustion temperature [K].
         molecular_weight_chamber: Molecular weight in chamber [kg/mol].
         molecular_weight_exhaust: Molecular weight at exit [kg/mol].
@@ -41,8 +41,8 @@ class ThermochemicalProperties:
         ValueError: If any parameter is outside a valid range.
     """
 
-    gamma_chamber: float
-    gamma_exhaust: float
+    k_chamber: float
+    k_exhaust: float
     adiabatic_flame_temperature: float
     molecular_weight_chamber: float
     molecular_weight_exhaust: float

--- a/machwave/services/cea.py
+++ b/machwave/services/cea.py
@@ -187,66 +187,66 @@ class RocketCEAService:
     def get_chamber_properties(
         self, chamber_pressure: float, expansion_ratio: float
     ) -> tuple[float, float]:
-        """Get chamber molecular weight [kg/mol] and gamma."""
+        """Get chamber molecular weight [kg/mol] and isentropic exponent."""
         chamber_pressure_psi = convert_pa_to_psi(chamber_pressure)
         if self.oxidizer_to_fuel_ratio is not None:
-            mw_g, gamma = self.cea_obj.get_Chamber_MolWt_gamma(
+            mw_g, k = self.cea_obj.get_Chamber_MolWt_gamma(
                 Pc=chamber_pressure_psi,
                 MR=self.oxidizer_to_fuel_ratio,
                 eps=expansion_ratio,
             )
         else:
-            mw_g, gamma = self.cea_obj.get_Chamber_MolWt_gamma(
+            mw_g, k = self.cea_obj.get_Chamber_MolWt_gamma(
                 Pc=chamber_pressure_psi, eps=expansion_ratio
             )
-        return mw_g / 1000.0, gamma
+        return mw_g / 1000.0, k
 
     def get_exhaust_properties(
         self, chamber_pressure: float, expansion_ratio: float
     ) -> tuple[float, float]:
-        """Get exhaust molecular weight [kg/mol] and gamma (frozen flow)."""
+        """Get exhaust molecular weight [kg/mol] and isentropic exponent (frozen flow)."""
         chamber_pressure_psi = convert_pa_to_psi(chamber_pressure)
 
         if self.oxidizer_to_fuel_ratio is not None:
-            mw_g, gamma = self.cea_obj.get_exit_MolWt_gamma(
+            mw_g, k = self.cea_obj.get_exit_MolWt_gamma(
                 Pc=chamber_pressure_psi,
                 MR=self.oxidizer_to_fuel_ratio,
                 eps=expansion_ratio,
                 frozen=1,
             )
         else:
-            mw_g, gamma = self.cea_obj.get_exit_MolWt_gamma(
+            mw_g, k = self.cea_obj.get_exit_MolWt_gamma(
                 Pc=chamber_pressure_psi, eps=expansion_ratio, frozen=1
             )
 
-        # RocketCEA can occasionally return gamma=0.0 for custom propellants when
-        # requesting frozen exit gamma. Fall back to equilibrium exit gamma, and
-        # if that is still invalid, fall back to throat gamma.
-        if gamma <= 1.0:
+        # RocketCEA can occasionally return k=0.0 for custom propellants when
+        # requesting frozen exit k. Fall back to equilibrium exit k, and
+        # if that is still invalid, fall back to throat k.
+        if k <= 1.0:
             if self.oxidizer_to_fuel_ratio is not None:
-                mw_g, gamma = self.cea_obj.get_exit_MolWt_gamma(
+                mw_g, k = self.cea_obj.get_exit_MolWt_gamma(
                     Pc=chamber_pressure_psi,
                     MR=self.oxidizer_to_fuel_ratio,
                     eps=expansion_ratio,
                     frozen=0,
                 )
             else:
-                mw_g, gamma = self.cea_obj.get_exit_MolWt_gamma(
+                mw_g, k = self.cea_obj.get_exit_MolWt_gamma(
                     Pc=chamber_pressure_psi, eps=expansion_ratio, frozen=0
                 )
-        if gamma <= 1.0:
+        if k <= 1.0:
             if self.oxidizer_to_fuel_ratio is not None:
-                mw_g, gamma = self.cea_obj.get_Throat_MolWt_gamma(
+                mw_g, k = self.cea_obj.get_Throat_MolWt_gamma(
                     Pc=chamber_pressure_psi,
                     MR=self.oxidizer_to_fuel_ratio,
                     eps=expansion_ratio,
                 )
             else:
-                mw_g, gamma = self.cea_obj.get_Throat_MolWt_gamma(
+                mw_g, k = self.cea_obj.get_Throat_MolWt_gamma(
                     Pc=chamber_pressure_psi, eps=expansion_ratio
                 )
 
-        return mw_g / 1000.0, gamma
+        return mw_g / 1000.0, k
 
     def get_specific_impulse(
         self, chamber_pressure: float, expansion_ratio: float

--- a/machwave/services/plots/internal_ballistics.py
+++ b/machwave/services/plots/internal_ballistics.py
@@ -158,8 +158,8 @@ def plot_bipropellant_tank_profiles(
 
 def thrust_coefficient_plot(
     time: np.ndarray,
-    cf_ideal: np.ndarray,
-    cf_real: np.ndarray,
+    thrust_coefficient_ideal: np.ndarray,
+    thrust_coefficient_real: np.ndarray,
     show_efficiency: bool = True,
 ) -> go.Figure:
     """
@@ -167,8 +167,8 @@ def thrust_coefficient_plot(
 
     Args:
         time: Time array [s].
-        cf_ideal: Ideal thrust coefficient array [-].
-        cf_real: Real thrust coefficient array [-].
+        thrust_coefficient_ideal: Ideal thrust coefficient array [-].
+        thrust_coefficient_real: Real thrust coefficient array [-].
         show_efficiency: If True, adds η = Cf_real / Cf_ideal on a secondary Y axis.
 
     Returns:
@@ -186,7 +186,7 @@ def thrust_coefficient_plot(
     )(
         go.Scatter(
             x=time,
-            y=cf_ideal,
+            y=thrust_coefficient_ideal,
             mode="lines",
             name="Cf (ideal)",
         )
@@ -199,7 +199,7 @@ def thrust_coefficient_plot(
     )(
         go.Scatter(
             x=time,
-            y=cf_real,
+            y=thrust_coefficient_real,
             mode="lines",
             name="Cf (real)",
         )
@@ -207,7 +207,10 @@ def thrust_coefficient_plot(
 
     if show_efficiency:
         eta = np.divide(
-            cf_real, cf_ideal, out=np.full_like(cf_real, np.nan), where=cf_ideal != 0
+            thrust_coefficient_real,
+            thrust_coefficient_ideal,
+            out=np.full_like(thrust_coefficient_real, np.nan),
+            where=thrust_coefficient_ideal != 0,
         )
         fig.add_trace(
             go.Scatter(

--- a/machwave/simulation.py
+++ b/machwave/simulation.py
@@ -86,12 +86,12 @@ class InternalBallisticsSimulation:
         self.motor_state = self.get_motor_state()
 
         d_t = self.params.d_t
-        P_ext = self.params.external_pressure
+        external_pressure = self.params.external_pressure
         t_values: list[float] = [0.0]
 
         while not self.motor_state.end_thrust:
             t_values.append(t_values[-1] + d_t)
-            self.motor_state.run_timestep(d_t, P_ext)
+            self.motor_state.run_timestep(d_t, external_pressure)
 
         self.t = np.asarray(t_values)
         self.motor_state.convert_simulation_arrays_to_numpy()

--- a/machwave/states/base.py
+++ b/machwave/states/base.py
@@ -18,11 +18,11 @@ class MotorState(ABC):
 
     SIMULATION_ARRAY_ATTRIBUTE_NAMES: tuple[str, ...] = (
         "t",
-        "m_prop",
-        "P_0",
-        "P_exit",
-        "C_f",
-        "C_f_ideal",
+        "propellant_mass",
+        "chamber_pressure",
+        "exit_pressure",
+        "thrust_coefficient",
+        "thrust_coefficient_ideal",
         "thrust",
     )
 
@@ -42,12 +42,12 @@ class MotorState(ABC):
 
         self.t: SimulationArray = [0.0]
 
-        self.m_prop: SimulationArray = [motor.initial_propellant_mass]
-        self.P_0: SimulationArray = [initial_pressure]
-        self.P_exit: SimulationArray = [initial_atmospheric_pressure]
+        self.propellant_mass: SimulationArray = [motor.initial_propellant_mass]
+        self.chamber_pressure: SimulationArray = [initial_pressure]
+        self.exit_pressure: SimulationArray = [initial_atmospheric_pressure]
 
-        self.C_f: SimulationArray = [0.0]
-        self.C_f_ideal: SimulationArray = [0.0]
+        self.thrust_coefficient: SimulationArray = [0.0]
+        self.thrust_coefficient_ideal: SimulationArray = [0.0]
         self.thrust: SimulationArray = [0.0]
 
         self._thrust_time = None

--- a/machwave/states/liquid_engine.py
+++ b/machwave/states/liquid_engine.py
@@ -26,9 +26,6 @@ from machwave.states.base import MotorState, SimulationArray
 class LiquidEngineState(MotorState):
     """
     State for a Liquid Rocket Engine.
-
-    The variable names correspond to what they are commonly referred to in books and papers related to
-    Rocket Propulsion. Therefore, PEP8's snake_case will not be followed rigorously.
     """
 
     motor: LiquidEngine
@@ -36,7 +33,7 @@ class LiquidEngineState(MotorState):
     SIMULATION_ARRAY_ATTRIBUTE_NAMES = MotorState.SIMULATION_ARRAY_ATTRIBUTE_NAMES + (
         "oxidizer_mass",
         "fuel_mass",
-        "n_cf",
+        "nozzle_correction_factor",
         "fuel_tank_pressure",
         "oxidizer_tank_pressure",
     )
@@ -62,7 +59,7 @@ class LiquidEngineState(MotorState):
             motor.feed_system.oxidizer_tank.fluid_mass
         ]
         self.fuel_mass: SimulationArray = [motor.feed_system.fuel_tank.fluid_mass]
-        self.n_cf: SimulationArray = [1.0]
+        self.nozzle_correction_factor: SimulationArray = [1.0]
 
         self.fuel_tank_pressure: SimulationArray = [
             motor.feed_system.fuel_tank.get_pressure()
@@ -77,14 +74,14 @@ class LiquidEngineState(MotorState):
     def run_timestep(
         self,
         d_t: float,
-        P_ext: float,
+        external_pressure: float,
     ) -> None:
         """
-        Advance simulation by time step d_t under external pressure P_ext.
+        Advance simulation by time step d_t under external pressure.
 
         Args:
             d_t: Time step.
-            P_ext: External pressure.
+            external_pressure: External pressure.
         """
         if self.end_thrust:
             return
@@ -95,14 +92,14 @@ class LiquidEngineState(MotorState):
 
         self.t.append(self.t[-1] + d_t)
 
-        if self.m_prop[-1] > 0:
+        if self.propellant_mass[-1] > 0:
             m_dot_fuel = feed.get_mass_flow_fuel(
-                chamber_pressure=self.P_0[-1],
+                chamber_pressure=self.chamber_pressure[-1],
                 discharge_coefficient=injector.discharge_coefficient_fuel,
                 injector_area=injector.area_fuel,
             )
             m_dot_ox = feed.get_mass_flow_ox(
-                chamber_pressure=self.P_0[-1],
+                chamber_pressure=self.chamber_pressure[-1],
                 discharge_coefficient=injector.discharge_coefficient_oxidizer,
                 injector_area=injector.area_ox,
             )
@@ -132,55 +129,63 @@ class LiquidEngineState(MotorState):
         self._m_dot_ox = m_dot_ox
 
         self.motor.propellant.properties = self.motor.propellant.evaluate(
-            chamber_pressure=self.P_0[-1],
+            chamber_pressure=self.chamber_pressure[-1],
             expansion_ratio=nz.expansion_ratio,
         )
         props = self.motor.propellant.properties
         assert props is not None
 
-        new_P = rk4th_ode_solver(
-            variables={"P0": self.P_0[-1]},
+        new_chamber_pressure = rk4th_ode_solver(
+            variables={"chamber_pressure": self.chamber_pressure[-1]},
             equation=compute_chamber_pressure_mass_balance,
             d_t=d_t,
-            Pe=P_ext,
-            m_in=self.get_m_dot_in(),
-            V0=self.motor.thrust_chamber.combustion_chamber.internal_volume,
-            At=nz.get_throat_area(),
-            k=props.gamma_chamber,
+            external_pressure=external_pressure,
+            mass_flow_in=self.get_m_dot_in(),
+            free_chamber_volume=self.motor.thrust_chamber.combustion_chamber.internal_volume,
+            throat_area=nz.get_throat_area(),
+            k=props.k_chamber,
             R=props.R_chamber,
-            T0=props.adiabatic_flame_temperature,
+            flame_temperature=props.adiabatic_flame_temperature,
         )[0]
-        self.P_0.append(new_P)
-        P_exit = get_exit_pressure(props.gamma_exhaust, nz.expansion_ratio, new_P)
-        self.P_exit.append(P_exit)
+        self.chamber_pressure.append(new_chamber_pressure)
+        exit_pressure = get_exit_pressure(
+            props.k_exhaust, nz.expansion_ratio, new_chamber_pressure
+        )
+        self.exit_pressure.append(exit_pressure)
 
-        chamber_pressure_psi = conversions.convert_pa_to_psi(new_P)
-        eta_div = get_nozzle_divergent_percentage_loss(
+        chamber_pressure_psi = conversions.convert_pa_to_psi(new_chamber_pressure)
+        divergent_loss = get_nozzle_divergent_percentage_loss(
             divergent_angle=nz.divergent_angle,
         )
-        eta_kin = get_kinetics_percentage_loss(
+        kinetics_loss = get_kinetics_percentage_loss(
             i_sp_th_frozen=props.i_sp_frozen,
             i_sp_th_shifting=props.i_sp_shifting,
             chamber_pressure_psi=chamber_pressure_psi,
         )
         nozzle_efficiency = get_overall_nozzle_efficiency(
-            eta_div, eta_kin, 0.0, 0.0, other_losses=self.other_losses
+            divergent_loss, kinetics_loss, 0.0, 0.0, other_losses=self.other_losses
         )
-        n_cf = nozzle_efficiency * self.motor.propellant.combustion_efficiency
-        self.n_cf.append(n_cf)
+        nozzle_correction_factor = (
+            nozzle_efficiency * self.motor.propellant.combustion_efficiency
+        )
+        self.nozzle_correction_factor.append(nozzle_correction_factor)
 
-        cf_ideal = get_ideal_thrust_coefficient(
-            new_P,
-            P_exit,
-            P_ext,
+        thrust_coefficient_ideal = get_ideal_thrust_coefficient(
+            new_chamber_pressure,
+            exit_pressure,
+            external_pressure,
             nz.expansion_ratio,
-            props.gamma_exhaust,
+            props.k_exhaust,
         )
-        cf = apply_thrust_coefficient_correction(cf_ideal, n_cf)
-        self.C_f.append(cf)
-        self.C_f_ideal.append(cf_ideal)
+        thrust_coefficient = apply_thrust_coefficient_correction(
+            thrust_coefficient_ideal, nozzle_correction_factor
+        )
+        self.thrust_coefficient.append(thrust_coefficient)
+        self.thrust_coefficient_ideal.append(thrust_coefficient_ideal)
         self.thrust.append(
-            get_thrust_from_thrust_coefficient(cf, new_P, nz.get_throat_area())
+            get_thrust_from_thrust_coefficient(
+                thrust_coefficient, new_chamber_pressure, nz.get_throat_area()
+            )
         )
 
         feed.fuel_tank.remove_propellant(cons_f)
@@ -189,18 +194,18 @@ class LiquidEngineState(MotorState):
         new_ox = self.oxidizer_mass[-1] - cons_o
         self.fuel_mass.append(new_fuel)
         self.oxidizer_mass.append(new_ox)
-        self.m_prop.append(new_fuel + new_ox)
+        self.propellant_mass.append(new_fuel + new_ox)
 
         self.fuel_tank_pressure.append(feed.get_fuel_tank_pressure())
         self.oxidizer_tank_pressure.append(feed.get_oxidizer_tank_pressure())
 
-        if self.m_prop[-1] <= 0 and not self.end_burn:
+        if self.propellant_mass[-1] <= 0 and not self.end_burn:
             self.end_burn = True
             self.burn_time = self.t[-1]
         if not is_flow_choked(
-            new_P,
-            P_ext,
-            get_critical_pressure_ratio(props.gamma_chamber),
+            new_chamber_pressure,
+            external_pressure,
+            get_critical_pressure_ratio(props.k_chamber),
         ):
             self._thrust_time = self.t[-1]
             self.end_thrust = True
@@ -213,7 +218,7 @@ class LiquidEngineState(MotorState):
         print("\nLIQUID ENGINE OPERATION RESULTS")
 
         # Propellant summary
-        print(f"Initial propellant mass: {self.m_prop[0]:.4f} kg")
+        print(f"Initial propellant mass: {self.propellant_mass[0]:.4f} kg")
         try:
             print(f"Burnout time: {self.burn_time:.4f} s")
         except AttributeError:
@@ -222,8 +227,8 @@ class LiquidEngineState(MotorState):
 
         # Chamber pressure
         print("\nCHAMBER PRESSURE (MPa)")
-        print(f"  Max: {np.max(self.P_0) * 1e-6:.4f}")
-        print(f"  Mean: {np.mean(self.P_0) * 1e-6:.4f}")
+        print(f"  Max: {np.max(self.chamber_pressure) * 1e-6:.4f}")
+        print(f"  Mean: {np.mean(self.chamber_pressure) * 1e-6:.4f}")
 
         # Thrust
         print("\nTHRUST (N)")
@@ -232,7 +237,7 @@ class LiquidEngineState(MotorState):
 
         # Impulse
         impulse = np.trapezoid(self.thrust, self.t)
-        isp = impulse / (self.m_prop[0] * scipy.constants.g)
+        isp = impulse / (self.propellant_mass[0] * scipy.constants.g)
         print("\nIMPULSE AND I_SP")
         print(f"  Total impulse: {impulse:.4f} N·s")
         print(f"  Specific impulse: {isp:.4f} s")

--- a/machwave/states/solid_motor.py
+++ b/machwave/states/solid_motor.py
@@ -13,25 +13,20 @@ import machwave.states.base as states_base
 class SolidMotorState(states_base.MotorState):
     """
     State for a Solid Rocket Motor.
-
-    The variable names correspond to what they are commonly referred to in
-    books and papers related to Solid Rocket Propulsion.
-
-    Therefore, PEP8's snake_case will not be followed rigorously.
     """
 
     SIMULATION_ARRAY_ATTRIBUTE_NAMES = (
         states_base.MotorState.SIMULATION_ARRAY_ATTRIBUTE_NAMES
         + (
-            "V_0",
+            "free_chamber_volume",
             "web",
             "burn_area",
             "propellant_volume",
             "burn_rate",
-            "eta_div",
-            "eta_kin",
-            "eta_bl",
-            "eta_2p",
+            "divergent_loss",
+            "kinetics_loss",
+            "boundary_layer_loss",
+            "two_phase_loss",
             "nozzle_efficiency",
             "overall_efficiency",
         )
@@ -56,7 +51,7 @@ class SolidMotorState(states_base.MotorState):
 
         self.motor: motors.SolidMotor = motor
 
-        self.V_0: states_base.SimulationArray = [
+        self.free_chamber_volume: states_base.SimulationArray = [
             motor.thrust_chamber.combustion_chamber.internal_volume
         ]
         self.web: states_base.SimulationArray = [0.0]
@@ -78,10 +73,10 @@ class SolidMotorState(states_base.MotorState):
         self.propellant_cog = [initial_cog]  # [x, y, z] in meters
         self.propellant_moi = [initial_moi]  # 3x3 tensor in kg-m²
 
-        self.eta_div: states_base.SimulationArray = [0.0]
-        self.eta_kin: states_base.SimulationArray = [0.0]
-        self.eta_bl: states_base.SimulationArray = [0.0]
-        self.eta_2p: states_base.SimulationArray = [0.0]
+        self.divergent_loss: states_base.SimulationArray = [0.0]
+        self.kinetics_loss: states_base.SimulationArray = [0.0]
+        self.boundary_layer_loss: states_base.SimulationArray = [0.0]
+        self.two_phase_loss: states_base.SimulationArray = [0.0]
         self.nozzle_efficiency: states_base.SimulationArray = [0.0]
         self.overall_efficiency: states_base.SimulationArray = [0.0]
 
@@ -95,13 +90,13 @@ class SolidMotorState(states_base.MotorState):
     def run_timestep(
         self,
         d_t: float,
-        P_ext: float,
+        external_pressure: float,
     ) -> None:
         """Iterate the motor operation by calculating operational parameters.
 
         Args:
             d_t: Time increment [s].
-            P_ext: External pressure [Pa].
+            external_pressure: External pressure [Pa].
         """
         if self.end_thrust:
             return
@@ -120,12 +115,14 @@ class SolidMotorState(states_base.MotorState):
         web_last = self.web[-1]
         self.burn_area.append(self.motor.grain.get_burn_area(web_last))
         self.propellant_volume.append(self.motor.grain.get_propellant_volume(web_last))
-        burn_rate = self.motor.propellant.get_burn_rate(self.P_0[-1])
+        burn_rate = self.motor.propellant.get_burn_rate(self.chamber_pressure[-1])
         self.burn_rate.append(burn_rate)
         self.web.append(web_last + burn_rate * (self.t[-1] - self.t[-2]))
 
-        self.V_0.append(self.motor.get_free_chamber_volume(self.propellant_volume[-1]))
-        self.m_prop.append(
+        self.free_chamber_volume.append(
+            self.motor.get_free_chamber_volume(self.propellant_volume[-1])
+        )
+        self.propellant_mass.append(
             self.motor.grain.get_propellant_mass(
                 web_distance=self.web[-1],
                 ideal_density=ideal_density,
@@ -142,36 +139,38 @@ class SolidMotorState(states_base.MotorState):
             )
         )
 
-        new_P = rk4.rk4th_ode_solver(
-            variables={"P0": self.P_0[-1]},
+        new_chamber_pressure = rk4.rk4th_ode_solver(
+            variables={"chamber_pressure": self.chamber_pressure[-1]},
             equation=mass_balance.compute_chamber_pressure_mass_balance,
             d_t=d_t,
-            Pe=P_ext,
-            m_in=self.get_m_dot_in(),
-            V0=self.V_0[-1],
-            At=nozzle.get_throat_area(),
-            k=propellant_properties.gamma_chamber,
+            external_pressure=external_pressure,
+            mass_flow_in=self.get_m_dot_in(),
+            free_chamber_volume=self.free_chamber_volume[-1],
+            throat_area=nozzle.get_throat_area(),
+            k=propellant_properties.k_chamber,
             R=propellant_properties.R_chamber,
-            T0=propellant_properties.adiabatic_flame_temperature,
+            flame_temperature=propellant_properties.adiabatic_flame_temperature,
         )[0]
-        self.P_0.append(new_P)
-        self.P_exit.append(
+        self.chamber_pressure.append(new_chamber_pressure)
+        self.exit_pressure.append(
             isentropic.get_exit_pressure(
-                propellant_properties.gamma_exhaust, nozzle.expansion_ratio, new_P
+                propellant_properties.k_exhaust,
+                nozzle.expansion_ratio,
+                new_chamber_pressure,
             )
         )
 
-        chamber_pressure_psi = conversions.convert_pa_to_psi(new_P)
+        chamber_pressure_psi = conversions.convert_pa_to_psi(new_chamber_pressure)
         throat_diameter_inch = conversions.convert_meter_to_inch(nozzle.throat_diameter)
-        eta_div = losses.get_nozzle_divergent_percentage_loss(
+        divergent_loss = losses.get_nozzle_divergent_percentage_loss(
             divergent_angle=nozzle.divergent_angle,
         )
-        eta_kin = losses.get_kinetics_percentage_loss(
+        kinetics_loss = losses.get_kinetics_percentage_loss(
             i_sp_th_frozen=propellant_properties.i_sp_frozen,
             i_sp_th_shifting=propellant_properties.i_sp_shifting,
             chamber_pressure_psi=chamber_pressure_psi,
         )
-        eta_bl = losses.get_boundary_layer_percentage_loss(
+        boundary_layer_loss = losses.get_boundary_layer_percentage_loss(
             chamber_pressure_psi=chamber_pressure_psi,
             throat_diameter_inch=throat_diameter_inch,
             expansion_ratio=nozzle.expansion_ratio,
@@ -179,53 +178,57 @@ class SolidMotorState(states_base.MotorState):
             c_1=nozzle.c_1,
             c_2=nozzle.c_2,
         )
-        eta_2p = losses.get_two_phase_flow_percentage_loss(
+        two_phase_loss = losses.get_two_phase_flow_percentage_loss(
             chamber_pressure_psi=chamber_pressure_psi,
             mass_fraction_of_condensed_phase=propellant_properties.qsi_chamber,
             expansion_ratio=nozzle.expansion_ratio,
             throat_diameter_inch=throat_diameter_inch,
             characteristic_length_inch=conversions.convert_meter_to_inch(
-                self.V_0[-1] / nozzle.get_throat_area()
+                self.free_chamber_volume[-1] / nozzle.get_throat_area()
             ),
         )
         nozzle_efficiency = losses.get_overall_nozzle_efficiency(
-            eta_div, eta_kin, eta_bl, eta_2p, other_losses=self.other_losses
+            divergent_loss,
+            kinetics_loss,
+            boundary_layer_loss,
+            two_phase_loss,
+            other_losses=self.other_losses,
         )
         overall_efficiency = (
             nozzle_efficiency * self.motor.propellant.combustion_efficiency
         )
-        self.eta_div.append(eta_div)
-        self.eta_kin.append(eta_kin)
-        self.eta_bl.append(eta_bl)
-        self.eta_2p.append(eta_2p)
+        self.divergent_loss.append(divergent_loss)
+        self.kinetics_loss.append(kinetics_loss)
+        self.boundary_layer_loss.append(boundary_layer_loss)
+        self.two_phase_loss.append(two_phase_loss)
         self.nozzle_efficiency.append(nozzle_efficiency)
         self.overall_efficiency.append(overall_efficiency)
 
-        cf_ideal = nozzle_core.get_ideal_thrust_coefficient(
-            new_P,
-            self.P_exit[-1],
-            P_ext,
+        thrust_coefficient_ideal = nozzle_core.get_ideal_thrust_coefficient(
+            new_chamber_pressure,
+            self.exit_pressure[-1],
+            external_pressure,
             nozzle.expansion_ratio,
-            propellant_properties.gamma_exhaust,
+            propellant_properties.k_exhaust,
         )
-        cf = nozzle_core.apply_thrust_coefficient_correction(
-            cf_ideal, overall_efficiency
+        thrust_coefficient = nozzle_core.apply_thrust_coefficient_correction(
+            thrust_coefficient_ideal, overall_efficiency
         )
-        self.C_f.append(cf)
-        self.C_f_ideal.append(cf_ideal)
+        self.thrust_coefficient.append(thrust_coefficient)
+        self.thrust_coefficient_ideal.append(thrust_coefficient_ideal)
         self.thrust.append(
             nozzle_core.get_thrust_from_thrust_coefficient(
-                cf, new_P, nozzle.get_throat_area()
+                thrust_coefficient, new_chamber_pressure, nozzle.get_throat_area()
             )
         )
 
-        if self.m_prop[-1] <= 0 and not self.end_burn:
+        if self.propellant_mass[-1] <= 0 and not self.end_burn:
             self.burn_time = self.t[-1]
             self.end_burn = True
         if not isentropic.is_flow_choked(
-            new_P,
-            P_ext,
-            isentropic.get_critical_pressure_ratio(propellant_properties.gamma_chamber),
+            new_chamber_pressure,
+            external_pressure,
+            isentropic.get_critical_pressure_ratio(propellant_properties.k_chamber),
         ):
             self._thrust_time = self.t[-1]
             self.end_thrust = True
@@ -235,10 +238,10 @@ class SolidMotorState(states_base.MotorState):
         Prints the results obtained during the SRM operation.
         """
         print("\nBURN REGRESSION")
-        if self.m_prop[0] > 1:
-            print(f" Propellant initial mass {self.m_prop[0]:.3f} kg")
+        if self.propellant_mass[0] > 1:
+            print(f" Propellant initial mass {self.propellant_mass[0]:.3f} kg")
         else:
-            print(f" Propellant initial mass {self.m_prop[0] * 1e3:.3f} g")
+            print(f" Propellant initial mass {self.propellant_mass[0] * 1e3:.3f} g")
         print(" Mean Kn: %.2f" % np.mean(self.klemmung))
         print(" Max Kn: %.2f" % np.max(self.klemmung))
         print(f" Initial to final Kn ratio: {self.initial_to_final_klemmung_ratio:.3f}")
@@ -252,8 +255,8 @@ class SolidMotorState(states_base.MotorState):
 
         print("\nCHAMBER PRESSURE")
         print(
-            f" Maximum, average chamber pressure: {np.max(self.P_0) * 1e-6:.3f}, "
-            f"{np.mean(self.P_0) * 1e-6:.3f} MPa"
+            f" Maximum, average chamber pressure: {np.max(self.chamber_pressure) * 1e-6:.3f}, "
+            f"{np.mean(self.chamber_pressure) * 1e-6:.3f} MPa"
         )
 
         print("\nTHRUST AND IMPULSE")
@@ -270,10 +273,18 @@ class SolidMotorState(states_base.MotorState):
         print("\nNOZZLE DESIGN")
         print(f" Average nozzle efficiency: {np.mean(self.nozzle_efficiency):.3%}")
         print(f" Average overall efficiency: {np.mean(self.overall_efficiency):.3%}")
-        print(f" Divergent nozzle correction factor: {np.mean(self.eta_div):.3f}%")
-        print(f" Average kinetics correction factor: {np.mean(self.eta_kin):.3f}%")
-        print(f" Average boundary layer correction factor: {np.mean(self.eta_bl):.3f}%")
-        print(f" Average two-phase flow correction factor: {np.mean(self.eta_2p):.3f}%")
+        print(
+            f" Divergent nozzle correction factor: {np.mean(self.divergent_loss):.3f}%"
+        )
+        print(
+            f" Average kinetics correction factor: {np.mean(self.kinetics_loss):.3f}%"
+        )
+        print(
+            f" Average boundary layer correction factor: {np.mean(self.boundary_layer_loss):.3f}%"
+        )
+        print(
+            f" Average two-phase flow correction factor: {np.mean(self.two_phase_loss):.3f}%"
+        )
 
     @property
     def klemmung(self) -> np.ndarray:
@@ -337,4 +348,4 @@ class SolidMotorState(states_base.MotorState):
     @property
     def specific_impulse(self) -> float:
         """Get the specific impulse [s]."""
-        return self.total_impulse / self.m_prop[0] / 9.81
+        return self.total_impulse / self.propellant_mass[0] / 9.81

--- a/tests/test_core/test_compressible_flow/test_isentropic.py
+++ b/tests/test_core/test_compressible_flow/test_isentropic.py
@@ -27,12 +27,14 @@ def test_get_exit_mach_from_expansion_ratio():
 
 
 def test_get_exit_pressure():
-    k_ex = 1.4
-    E = 8.0
-    P_0 = 7e6
-    P_exit = isentropic.get_exit_pressure(k_ex, E, P_0)
+    k_exhaust = 1.4
+    expansion_ratio = 8.0
+    chamber_pressure = 7e6
+    exit_pressure = isentropic.get_exit_pressure(
+        k_exhaust, expansion_ratio, chamber_pressure
+    )
 
-    assert P_exit == pytest.approx(71545.88, rel=1e-2)
+    assert exit_pressure == pytest.approx(71545.88, rel=1e-2)
 
 
 def test_is_flow_choked_true():

--- a/tests/test_core/test_compressible_flow/test_losses.py
+++ b/tests/test_core/test_compressible_flow/test_losses.py
@@ -26,10 +26,10 @@ def test_get_nozzle_divergent_correction_factor(
     """
     Parameters obtained from Sutton.
     """
-    eta_div = losses.get_nozzle_divergent_percentage_loss(
+    divergent_loss = losses.get_nozzle_divergent_percentage_loss(
         divergent_angle=divergent_angle
     )
-    assert eta_div == pytest.approx(expected_correction_factor, abs=1e-2)
+    assert divergent_loss == pytest.approx(expected_correction_factor, abs=1e-2)
 
 
 @pytest.mark.parametrize(
@@ -49,16 +49,16 @@ def test_get_nozzle_divergent_correction_factor(
 def test_get_kinetics_correction_factor(
     i_sp_th_frozen, i_sp_th_shifting, chamber_pressure_psi, expected_correction_factor
 ):
-    eta_kin = losses.get_kinetics_percentage_loss(
+    kinetics_loss = losses.get_kinetics_percentage_loss(
         i_sp_th_frozen=i_sp_th_frozen,
         i_sp_th_shifting=i_sp_th_shifting,
         chamber_pressure_psi=chamber_pressure_psi,
     )
-    assert eta_kin == pytest.approx(expected_correction_factor, abs=1e-2)
+    assert kinetics_loss == pytest.approx(expected_correction_factor, abs=1e-2)
 
 
 @pytest.mark.parametrize(
-    "chamber_pressure_psi, throat_diam_in, expansion_ratio, time_s, c1, c2, expected_eta_bl",
+    "chamber_pressure_psi, throat_diam_in, expansion_ratio, time_s, c1, c2, expected_boundary_layer_loss",
     [
         # Ordinary nozzle, t = 0, maximal transient term
         (1000.0, 1.0, 9.0, 0.0, 0.00365, 0.000937, 2.75051564250),
@@ -79,9 +79,9 @@ def test_get_boundary_layer_correction_factor(
     time_s,
     c1,
     c2,
-    expected_eta_bl,
+    expected_boundary_layer_loss,
 ):
-    eta_bl = losses.get_boundary_layer_percentage_loss(
+    boundary_layer_loss = losses.get_boundary_layer_percentage_loss(
         chamber_pressure_psi=chamber_pressure_psi,
         throat_diameter_inch=throat_diam_in,
         expansion_ratio=expansion_ratio,
@@ -90,7 +90,7 @@ def test_get_boundary_layer_correction_factor(
         c_2=c2,
     )
 
-    assert eta_bl == pytest.approx(expected_eta_bl, abs=1e-9)
+    assert boundary_layer_loss == pytest.approx(expected_boundary_layer_loss, abs=1e-9)
 
 
 @pytest.mark.parametrize(
@@ -111,7 +111,7 @@ def test_get_two_phase_phase_loss_particle_size(
 ):
     size_um = losses._get_two_phase_phase_loss_particle_size(
         chamber_pressure_psi=P_psi,
-        xi=xi,
+        mass_fraction_of_condensed_phase=xi,
         throat_diameter_inch=d_throat_in,
         characteristic_length_inch=L_c_in,
     )
@@ -183,7 +183,7 @@ def test_get_two_phase_flow_correction_factor(
 
 
 @pytest.mark.parametrize(
-    "eta_div, eta_kin, eta_bl, eta_2p, expected_eta_noz",
+    "divergent_loss, kinetics_loss, boundary_layer_loss, two_phase_loss, expected_efficiency",
     [
         (0.0, 0.0, 0.0, 0.0, 1.0),  # all zero, upper-bound edge case
         (2, 3, 4, 5, 0.86),  # typical values
@@ -191,21 +191,25 @@ def test_get_two_phase_flow_correction_factor(
     ],
 )
 def test_get_overall_nozzle_efficiency_valid(
-    eta_div, eta_kin, eta_bl, eta_2p, expected_eta_noz
+    divergent_loss,
+    kinetics_loss,
+    boundary_layer_loss,
+    two_phase_loss,
+    expected_efficiency,
 ):
     """
     Ensures the overall efficiency equals the arithmetic sum and
     respects decorator-enforced [0, 1] bounds.
     """
-    eta_total = losses.get_overall_nozzle_efficiency(
-        eta_div=eta_div,
-        eta_kin=eta_kin,
-        eta_bl=eta_bl,
-        eta_2p=eta_2p,
+    overall_efficiency = losses.get_overall_nozzle_efficiency(
+        divergent_loss=divergent_loss,
+        kinetics_loss=kinetics_loss,
+        boundary_layer_loss=boundary_layer_loss,
+        two_phase_loss=two_phase_loss,
         other_losses=0,
     )
 
-    assert eta_total == pytest.approx(expected_eta_noz, abs=1e-12)
+    assert overall_efficiency == pytest.approx(expected_efficiency, abs=1e-12)
 
 
 def test_get_overall_nozzle_efficiency_out_of_bounds():
@@ -215,7 +219,11 @@ def test_get_overall_nozzle_efficiency_out_of_bounds():
     with pytest.raises((ValueError, AssertionError)):
         # Sum = 1.10, outside allowed range.
         losses.get_overall_nozzle_efficiency(
-            eta_div=40, eta_kin=30, eta_bl=20, eta_2p=20, other_losses=0
+            divergent_loss=40,
+            kinetics_loss=30,
+            boundary_layer_loss=20,
+            two_phase_loss=20,
+            other_losses=0,
         )
 
 
@@ -248,10 +256,10 @@ def test_table_4_5_simplified_method(
     JANNAF/AFRPL-TR-75-36 Table 4-5.
     """
     eta_cf = losses.get_overall_nozzle_efficiency(
-        eta_div=loss_div_pct,
-        eta_kin=loss_kin_pct,
-        eta_bl=loss_bl_pct,
-        eta_2p=loss_tp_pct,
+        divergent_loss=loss_div_pct,
+        kinetics_loss=loss_kin_pct,
+        boundary_layer_loss=loss_bl_pct,
+        two_phase_loss=loss_tp_pct,
         other_losses=0,
     )
 

--- a/tests/test_core/test_compressible_flow/test_nozzle.py
+++ b/tests/test_core/test_compressible_flow/test_nozzle.py
@@ -5,38 +5,48 @@ import machwave.core.compressible_flow.nozzle as core_nozzle
 
 def test_get_optimal_expansion_ratio():
     k = 1.15
-    P_0 = 6.4e6
-    P_ext = 1e5
-    exp_opt = core_nozzle.get_optimal_expansion_ratio(k, P_0, P_ext)
+    chamber_pressure = 6.4e6
+    external_pressure = 1e5
+    optimal_expansion_ratio = core_nozzle.get_optimal_expansion_ratio(
+        k, chamber_pressure, external_pressure
+    )
 
-    assert exp_opt == pytest.approx(9.37, rel=1e-2)
+    assert optimal_expansion_ratio == pytest.approx(9.37, rel=1e-2)
 
 
 def test_get_ideal_thrust_coefficient():
-    P_0 = 7e6
-    P_exit = 1.2e5
-    P_external = 1e5
-    E = 8.0
-    k = 1.4
-    Cf_ideal = core_nozzle.get_ideal_thrust_coefficient(P_0, P_exit, P_external, E, k)
+    chamber_pressure = 7e6
+    exit_pressure = 1.2e5
+    external_pressure = 1e5
+    expansion_ratio = 8.0
+    k_exhaust = 1.4
+    thrust_coefficient_ideal = core_nozzle.get_ideal_thrust_coefficient(
+        chamber_pressure,
+        exit_pressure,
+        external_pressure,
+        expansion_ratio,
+        k_exhaust,
+    )
 
-    assert Cf_ideal == pytest.approx(1.524507)
+    assert thrust_coefficient_ideal == pytest.approx(1.524507)
 
 
 def test_apply_thrust_coefficient_correction():
-    Cf_ideal = 1.524507
-    n_cf = 0.8
-    Cf = core_nozzle.apply_thrust_coefficient_correction(Cf_ideal, n_cf)
+    thrust_coefficient_ideal = 1.524507
+    nozzle_correction_factor = 0.8
+    thrust_coefficient = core_nozzle.apply_thrust_coefficient_correction(
+        thrust_coefficient_ideal, nozzle_correction_factor
+    )
 
-    assert Cf == pytest.approx(1.219605)
+    assert thrust_coefficient == pytest.approx(1.219605)
 
 
 def test_get_thrust_from_thrust_coefficient():
-    C_f = 1.6
-    P_0 = 7e6
+    thrust_coefficient = 1.6
+    chamber_pressure = 7e6
     nozzle_throat_area = 0.01
     thrust = core_nozzle.get_thrust_from_thrust_coefficient(
-        C_f, P_0, nozzle_throat_area
+        thrust_coefficient, chamber_pressure, nozzle_throat_area
     )
 
     assert thrust == pytest.approx(112000, rel=1e-2)

--- a/tests/test_models/test_propulsion/factories.py
+++ b/tests/test_models/test_propulsion/factories.py
@@ -23,7 +23,7 @@ class SolidPropellantPropertiesFactory(DataclassFactory[ThermochemicalProperties
 
         # Override specific fields
         props = SolidPropellantPropertiesFactory.build(
-            gamma_chamber=1.20,
+            k_chamber=1.20,
             density=1850.0
         )
 
@@ -34,13 +34,13 @@ class SolidPropellantPropertiesFactory(DataclassFactory[ThermochemicalProperties
     __model__ = ThermochemicalProperties
 
     @classmethod
-    def gamma_chamber(cls) -> float:
-        """Typical gamma for combustion chamber (1.1-1.3 for solid propellants)."""
+    def k_chamber(cls) -> float:
+        """Typical isentropic exponent in chamber (1.1-1.3 for solid propellants)."""
         return 1.15
 
     @classmethod
-    def gamma_exhaust(cls) -> float:
-        """Typical gamma for exhaust (slightly lower than chamber)."""
+    def k_exhaust(cls) -> float:
+        """Typical isentropic exponent at exit (slightly lower than chamber)."""
         return 1.10
 
     @classmethod
@@ -101,7 +101,7 @@ class LiquidPropellantPropertiesFactory(DataclassFactory[ThermochemicalPropertie
 
         # Override specific fields
         props = LiquidPropellantPropertiesFactory.build(
-            gamma_chamber=1.25,
+            k_chamber=1.25,
             i_sp_frozen=320.0
         )
 
@@ -112,13 +112,13 @@ class LiquidPropellantPropertiesFactory(DataclassFactory[ThermochemicalPropertie
     __model__ = ThermochemicalProperties
 
     @classmethod
-    def gamma_chamber(cls) -> float:
-        """Typical gamma for combustion chamber (1.15-1.25 for liquid propellants)."""
+    def k_chamber(cls) -> float:
+        """Typical isentropic exponent in chamber (1.15-1.25 for liquid propellants)."""
         return 1.20
 
     @classmethod
-    def gamma_exhaust(cls) -> float:
-        """Typical gamma for exhaust."""
+    def k_exhaust(cls) -> float:
+        """Typical isentropic exponent at exit."""
         return 1.15
 
     @classmethod

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_base.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_base.py
@@ -207,8 +207,8 @@ class TestParseProperties:
     def test_parse_properties_when_present(self):
         data = {
             "properties": {
-                "gamma_chamber": 1.24,
-                "gamma_exhaust": 1.23,
+                "k_chamber": 1.24,
+                "k_exhaust": 1.23,
                 "adiabatic_flame_temperature": 3580.0,
                 "molecular_weight_chamber": 0.0225,
                 "molecular_weight_exhaust": 0.0230,
@@ -221,8 +221,8 @@ class TestParseProperties:
         result = _parse_properties(data)
 
         assert result is not None
-        assert result.gamma_chamber == 1.24
-        assert result.gamma_exhaust == 1.23
+        assert result.k_chamber == 1.24
+        assert result.k_exhaust == 1.23
         assert result.adiabatic_flame_temperature == 3580.0
         assert result.i_sp_frozen == 325.0
         assert result.qsi_chamber == 0.0
@@ -235,7 +235,7 @@ class TestParseProperties:
     def test_missing_required_property_raises_error(self):
         data = {
             "properties": {
-                "gamma_chamber": 1.24,
+                "k_chamber": 1.24,
                 # Missing other required fields
             }
         }

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_json_loader.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_json_loader.py
@@ -112,8 +112,8 @@ class TestJSONFormulationLoading:
         # Verify properties if present
         if propellant.properties:
             props = propellant.properties
-            assert props.gamma_chamber > 1.0, f"{json_file.stem}: Invalid gamma_chamber"
-            assert props.gamma_exhaust > 1.0, f"{json_file.stem}: Invalid gamma_exhaust"
+            assert props.k_chamber > 1.0, f"{json_file.stem}: Invalid k_chamber"
+            assert props.k_exhaust > 1.0, f"{json_file.stem}: Invalid k_exhaust"
             assert props.adiabatic_flame_temperature > 0, (
                 f"{json_file.stem}: Invalid temperature"
             )
@@ -225,7 +225,7 @@ class TestJSONFormulationLoading:
 
         # Should return the pre-defined properties
         assert result == kndx.properties, "Should return pre-defined properties"
-        assert result.gamma_chamber == 1.1308
+        assert result.k_chamber == 1.1308
         assert result.i_sp_frozen == 152.4
 
     def test_component_to_cea_dict(self):
@@ -321,7 +321,7 @@ class TestJSONFormulationLoading:
         )
 
         props = cea_propellant.evaluate(5e6, 8.0)
-        assert 1.0 < props.gamma_chamber <= 2.0
+        assert 1.0 < props.k_chamber <= 2.0
         assert props.adiabatic_flame_temperature > 0
         assert props.molecular_weight_chamber > 0
         assert props.i_sp_frozen > 0
@@ -358,7 +358,7 @@ class TestJSONFormulationLoading:
         def rel_diff(a: float, b: float) -> float:
             return abs(a - b) / abs(b) if b else float("inf")
 
-        assert rel_diff(cea.gamma_chamber, fixed.gamma_chamber) < 0.10
+        assert rel_diff(cea.k_chamber, fixed.k_chamber) < 0.10
         assert (
             rel_diff(cea.adiabatic_flame_temperature, fixed.adiabatic_flame_temperature)
             < 0.10

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_solid.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_solid.py
@@ -95,12 +95,8 @@ class TestAllSolidPropellants:
         assert propellant.properties is not None, f"{name} properties is None"
 
         # Check theoretical properties are present and valid
-        assert propellant.properties.gamma_chamber > 1.0, (
-            f"{name} gamma_chamber invalid"
-        )
-        assert propellant.properties.gamma_exhaust > 1.0, (
-            f"{name} gamma_exhaust invalid"
-        )
+        assert propellant.properties.k_chamber > 1.0, f"{name} k_chamber invalid"
+        assert propellant.properties.k_exhaust > 1.0, f"{name} k_exhaust invalid"
         assert propellant.properties.adiabatic_flame_temperature > 0, (
             f"{name} temperature invalid"
         )
@@ -187,17 +183,17 @@ class TestConsistency:
         ), f"{name} shifting Isp relationship violated"
 
     @pytest.mark.parametrize("name,propellant", ALL_SOLID_PROPELLANTS)
-    def test_gamma_reasonable_range(self, name, propellant):
-        """Verify gamma values are in reasonable range."""
+    def test_isentropic_exponent_reasonable_range(self, name, propellant):
+        """Verify isentropic exponent values are in reasonable range."""
         # Ensure properties exist
         if propellant.properties is None:
             propellant.evaluate(5e6, 8.0)
 
-        assert 1.0 < propellant.properties.gamma_chamber < 1.7, (
-            f"{name} chamber gamma out of range"
+        assert 1.0 < propellant.properties.k_chamber < 1.7, (
+            f"{name} chamber isentropic exponent out of range"
         )
-        assert 1.0 < propellant.properties.gamma_exhaust < 1.7, (
-            f"{name} exhaust gamma out of range"
+        assert 1.0 < propellant.properties.k_exhaust < 1.7, (
+            f"{name} exit isentropic exponent out of range"
         )
 
     @pytest.mark.parametrize("name,propellant", ALL_SOLID_PROPELLANTS)

--- a/tests/test_models/test_propulsion/test_propellants/test_properties.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_properties.py
@@ -24,7 +24,7 @@ class TestThermochemicalPropertiesBasics:
         assert isinstance(props, ThermochemicalProperties)
 
         with pytest.raises(AttributeError):
-            props.gamma_chamber = 1.5
+            props.k_chamber = 1.5
 
 
 class TestDerivedProperties:
@@ -64,10 +64,10 @@ class TestIsTwoPhaseFlow:
 class TestInputValidation:
     """Test suite for input validation using tuple-based bounds."""
 
-    def test_invalid_gamma_raises_error(self):
-        """Test that gamma outside valid range raises ValueError."""
+    def test_invalid_isentropic_exponent_raises_error(self):
+        """Test that isentropic exponent outside valid range raises ValueError."""
         base_data = SolidPropellantPropertiesFactory.build().__dict__
-        base_data["gamma_chamber"] = 0.9  # Below minimum
+        base_data["k_chamber"] = 0.9  # Below minimum
 
         with pytest.raises(ValueError, match="outside valid range"):
             ThermochemicalProperties(**base_data)

--- a/tests/test_services/test_cea.py
+++ b/tests/test_services/test_cea.py
@@ -37,17 +37,13 @@ class TestCreateCEAServiceSolidPropellant:
         temp = service.get_adiabatic_flame_temperature(chamber_pressure)
         assert 2000 < temp < 4000, f"Unexpected temperature: {temp} K"
 
-        mw_c, gamma_c = service.get_chamber_properties(
-            chamber_pressure, expansion_ratio
-        )
+        mw_c, k_c = service.get_chamber_properties(chamber_pressure, expansion_ratio)
         assert 0.01 < mw_c < 0.1, f"Unexpected chamber MW: {mw_c} kg/mol"
-        assert 1.0 < gamma_c < 1.5, f"Unexpected chamber gamma: {gamma_c}"
+        assert 1.0 < k_c < 1.5, f"Unexpected chamber k: {k_c}"
 
-        mw_e, gamma_e = service.get_exhaust_properties(
-            chamber_pressure, expansion_ratio
-        )
+        mw_e, k_e = service.get_exhaust_properties(chamber_pressure, expansion_ratio)
         assert 0.01 < mw_e < 0.1, f"Unexpected exhaust MW: {mw_e} kg/mol"
-        assert 1.0 < gamma_e < 1.5, f"Unexpected exhaust gamma: {gamma_e}"
+        assert 1.0 < k_e < 1.5, f"Unexpected exit k: {k_e}"
 
         isp_f, isp_s = service.get_specific_impulse(chamber_pressure, expansion_ratio)
         assert 150 < isp_f < 400, f"Unexpected frozen Isp: {isp_f} s"
@@ -96,12 +92,10 @@ class TestCreateCEAServiceSolidPropellant:
         # KNSU typically 1600-1800 K
         assert 1500 < temp < 2000, f"KNSU temp out of range: {temp} K"
 
-        mw_c, gamma_c = service.get_chamber_properties(
-            chamber_pressure, expansion_ratio
-        )
+        mw_c, k_c = service.get_chamber_properties(chamber_pressure, expansion_ratio)
         # KNSU has relatively high MW due to condensed species
         assert 0.035 < mw_c < 0.045, f"KNSU MW out of range: {mw_c} kg/mol"
-        assert 1.1 < gamma_c < 1.2, f"KNSU gamma out of range: {gamma_c}"
+        assert 1.1 < k_c < 1.2, f"KNSU k out of range: {k_c}"
 
         isp_f, isp_s = service.get_specific_impulse(chamber_pressure, expansion_ratio)
         # KNSU typical Isp 150-170 s
@@ -134,12 +128,10 @@ class TestCreateCEAServiceBiliquidPropellant:
         # LOX/RP1 typically 3400-3700 K
         assert 3200 < temp < 3800, f"LOX/RP1 temp out of range: {temp} K"
 
-        mw_c, gamma_c = service.get_chamber_properties(
-            chamber_pressure, expansion_ratio
-        )
+        mw_c, k_c = service.get_chamber_properties(chamber_pressure, expansion_ratio)
         # LOX/RP1 MW around 22-24 g/mol
         assert 0.020 < mw_c < 0.030, f"LOX/RP1 MW out of range: {mw_c} kg/mol"
-        assert 1.1 < gamma_c < 1.2, f"LOX/RP1 gamma out of range: {gamma_c}"
+        assert 1.1 < k_c < 1.2, f"LOX/RP1 k out of range: {k_c}"
 
         isp_f, isp_s = service.get_specific_impulse(chamber_pressure, expansion_ratio)
         # LOX/RP1 typical Isp 280-320 s
@@ -168,12 +160,10 @@ class TestCreateCEAServiceBiliquidPropellant:
         # LOX/LH2 lower temp than LOX/RP1
         assert 2500 < temp < 3500, f"LOX/LH2 temp out of range: {temp} K"
 
-        mw_c, gamma_c = service.get_chamber_properties(
-            chamber_pressure, expansion_ratio
-        )
+        mw_c, k_c = service.get_chamber_properties(chamber_pressure, expansion_ratio)
         # LOX/LH2 has very low MW (mostly H2O)
         assert 0.010 < mw_c < 0.020, f"LOX/LH2 MW out of range: {mw_c} kg/mol"
-        assert 1.10 < gamma_c < 1.30, f"LOX/LH2 gamma out of range: {gamma_c}"
+        assert 1.10 < k_c < 1.30, f"LOX/LH2 k out of range: {k_c}"
 
         isp_f, isp_s = service.get_specific_impulse(chamber_pressure, expansion_ratio)
         # LOX/LH2 highest Isp of chemical propellants
@@ -328,10 +318,10 @@ class TestServiceParameterValidation:
         chamber_pressure = 3e6
         expansion_ratio = 8.0
 
-        mw_c, gamma_c = lox_rp1_service.get_chamber_properties(
+        mw_c, k_c = lox_rp1_service.get_chamber_properties(
             chamber_pressure, expansion_ratio
         )
-        mw_e, gamma_e = lox_rp1_service.get_exhaust_properties(
+        mw_e, k_e = lox_rp1_service.get_exhaust_properties(
             chamber_pressure, expansion_ratio
         )
 
@@ -339,8 +329,8 @@ class TestServiceParameterValidation:
         mw_diff_pct = abs(mw_e - mw_c) / mw_c * 100
         assert mw_diff_pct < 20, f"MW difference too large: {mw_diff_pct:.1f}%"
 
-        # Exhaust gamma typically higher due to frozen composition
-        assert gamma_e >= gamma_c * 0.95, "Exhaust gamma should be similar or higher"
+        # Exit k typically higher due to frozen composition
+        assert k_e >= k_c * 0.95, "Exit k should be similar or higher"
 
     def test_parameter_consistency_across_calls(self, lox_rp1_service):
         """Test that repeated calls return consistent values."""
@@ -369,9 +359,9 @@ class TestServiceEdgeCases:
         assert temp > 0, "Should handle low pressure"
 
         # Properties should still be reasonable
-        mw, gamma = service.get_chamber_properties(1e5, 8.0)
+        mw, k = service.get_chamber_properties(1e5, 8.0)
         assert 0.01 < mw < 0.05
-        assert 1.0 < gamma < 1.5
+        assert 1.0 < k < 1.5
 
     def test_very_high_pressure(self):
         """Test service at very high chamber pressure."""

--- a/tests/test_simulations/test_liquid_engine_simulation.py
+++ b/tests/test_simulations/test_liquid_engine_simulation.py
@@ -145,7 +145,7 @@ def test_propellant_masses_are_monotone_non_increasing(
     simulation_result: SimulationResult,
 ) -> None:
     state = simulation_result.state
-    for series_name in ("fuel_mass", "oxidizer_mass", "m_prop"):
+    for series_name in ("fuel_mass", "oxidizer_mass", "propellant_mass"):
         series = np.asarray(getattr(state, series_name))
         diffs = np.diff(series)
         assert (diffs <= 1e-9).all(), (
@@ -158,7 +158,7 @@ def test_chamber_pressure_and_thrust_are_physically_plausible(
     simulation_result: SimulationResult,
 ) -> None:
     state = simulation_result.state
-    peak_pressure = float(np.max(state.P_0))
+    peak_pressure = float(np.max(state.chamber_pressure))
     peak_thrust = float(np.max(state.thrust))
     # A 1 kN-class biliquid engine should peak at 0.5 to 5 MPa chamber pressure
     # and produce on the order of 100 N to 10 kN of peak thrust.
@@ -176,15 +176,15 @@ def test_recorded_per_timestep_arrays_are_aligned(
     assert_recorded_arrays_aligned(
         simulation_result.state,
         attribute_names=(
-            "P_0",
-            "P_exit",
+            "chamber_pressure",
+            "exit_pressure",
             "thrust",
-            "C_f",
-            "C_f_ideal",
+            "thrust_coefficient",
+            "thrust_coefficient_ideal",
             "fuel_mass",
             "oxidizer_mass",
-            "m_prop",
-            "n_cf",
+            "propellant_mass",
+            "nozzle_correction_factor",
             "fuel_tank_pressure",
             "oxidizer_tank_pressure",
         ),

--- a/tests/test_simulations/test_solid_motor_simulation.py
+++ b/tests/test_simulations/test_solid_motor_simulation.py
@@ -214,20 +214,20 @@ def test_burn_time_and_thrust_time_are_finite_and_ordered(
 def test_propellant_mass_is_monotone_non_increasing(
     simulation_result: SimulationResult,
 ) -> None:
-    m_prop = np.asarray(simulation_result.state.m_prop)
-    diffs = np.diff(m_prop)
+    propellant_mass = np.asarray(simulation_result.state.propellant_mass)
+    diffs = np.diff(propellant_mass)
     # Allow tiny floating-point noise but no real growth between steps.
     assert (diffs <= 1e-9).all(), (
         f"propellant mass increased between steps; max delta={diffs.max():.3e}"
     )
-    assert m_prop[-1] <= m_prop[0]
+    assert propellant_mass[-1] <= propellant_mass[0]
 
 
 def test_chamber_pressure_and_thrust_are_physically_plausible(
     simulation_result: SimulationResult,
 ) -> None:
     state = simulation_result.state
-    peak_pressure = float(np.max(state.P_0))
+    peak_pressure = float(np.max(state.chamber_pressure))
     peak_thrust = float(np.max(state.thrust))
     # Hobbyist-to-experimental solid motors should peak between roughly 1 MPa
     # and 30 MPa chamber pressure, producing thrust in the 100 N to 100 kN range.
@@ -247,20 +247,20 @@ def test_recorded_per_timestep_arrays_are_aligned(
     assert_recorded_arrays_aligned(
         simulation_result.state,
         attribute_names=(
-            "P_0",
-            "P_exit",
+            "chamber_pressure",
+            "exit_pressure",
             "thrust",
-            "C_f",
-            "C_f_ideal",
+            "thrust_coefficient",
+            "thrust_coefficient_ideal",
             "burn_area",
             "burn_rate",
             "web",
-            "V_0",
-            "m_prop",
-            "eta_div",
-            "eta_kin",
-            "eta_bl",
-            "eta_2p",
+            "free_chamber_volume",
+            "propellant_mass",
+            "divergent_loss",
+            "kinetics_loss",
+            "boundary_layer_loss",
+            "two_phase_loss",
             "nozzle_efficiency",
             "overall_efficiency",
         ),


### PR DESCRIPTION
## Summary

Standardizes identifiers across the public state API and the
compressible-flow / mass-balance core to PEP-8 snake_case. Closes #179.

- **State attributes**: `P_0` → `chamber_pressure`, `P_exit` → `exit_pressure`, `C_f`/`C_f_ideal` → `thrust_coefficient`/`thrust_coefficient_ideal`, `eta_div`/`eta_kin`/`eta_bl`/`eta_2p` → `divergent_loss`/`kinetics_loss`/`boundary_layer_loss`/`two_phase_loss`, `m_prop` → `propellant_mass`, `V_0` → `free_chamber_volume`, `n_cf` → `nozzle_correction_factor`.
- **`mass_balance.py`**: `P0`/`Pe`/`m_in`/`V0`/`At`/`T0`/`Cd` and locals `Pr`/`dP0_dt` renamed; `k` and `R` kept as bare math symbols.
- **`losses.py`**: `get_overall_nozzle_efficiency` parameters renamed; `c_1`–`c_6` semi-empirical coefficients kept; redundant `xi` alias dropped and `_get_two_phase_phase_loss_particle_size`'s `xi` parameter renamed to `mass_fraction_of_condensed_phase`.
- **`isentropic.py` / `nozzle.py` / motor models**: `k_ex` → `k_exhaust`. `SolidMotor.cf_ideal`/`cf_real` → `thrust_coefficient_ideal`/`thrust_coefficient_real`.
- **`PropellantProperties`**: `gamma_chamber`/`gamma_exhaust` → `k_chamber`/`k_exhaust`; JSON formulation schema and 9 propellant data files updated. CEA service local `gamma` returns renamed to `k`.
- **No backward-compat aliases** — `machwave` is on `0.x.x`, so the old names are removed in this change.
- Theory pages keep textbook math notation; `docs/theory/mass_balance.md` updated where it referenced the removed `\gamma_\text{chamber}`.

## Test plan

- [x] `uv run pytest` — 565 tests pass.
- [x] Spot-check a downstream notebook or trajectory simulation for the new attribute names.