### PR TITLE
Route impulse and specific impulse through performance helpers

### DIFF
--- a/machwave/core/performance.py
+++ b/machwave/core/performance.py
@@ -2,6 +2,8 @@
 Performance metrics and calculations.
 """
 
+import numpy as np
+import numpy.typing as npt
 import scipy.constants
 
 
@@ -16,6 +18,22 @@ def get_total_impulse(average_thrust: float, thrust_time: float) -> float:
         Total impulse [N-s].
     """
     return average_thrust * thrust_time
+
+
+def get_total_impulse_trapezoidal(
+    thrust: npt.NDArray[np.float64],
+    time: npt.NDArray[np.float64],
+) -> float:
+    """Get total impulse by trapezoidal integration of the thrust curve.
+
+    Args:
+        thrust: Thrust samples [N].
+        time: Time samples [s] matching the thrust samples.
+
+    Returns:
+        Total impulse [N-s].
+    """
+    return float(np.trapezoid(thrust, time))
 
 
 def get_specific_impulse(total_impulse: float, initial_propellant_mass: float) -> float:

--- a/machwave/core/performance.py
+++ b/machwave/core/performance.py
@@ -7,20 +7,7 @@ import numpy.typing as npt
 import scipy.constants
 
 
-def get_total_impulse(average_thrust: float, thrust_time: float) -> float:
-    """Get total impulse.
-
-    Args:
-        average_thrust: Average thrust [N].
-        thrust_time: Thrust time [s].
-
-    Returns:
-        Total impulse [N-s].
-    """
-    return average_thrust * thrust_time
-
-
-def get_total_impulse_trapezoidal(
+def get_total_impulse(
     thrust: npt.NDArray[np.float64],
     time: npt.NDArray[np.float64],
 ) -> float:

--- a/machwave/states/liquid_engine.py
+++ b/machwave/states/liquid_engine.py
@@ -236,7 +236,7 @@ class LiquidEngineState(MotorState):
         print(f"  Mean: {np.mean(self.thrust):.4f}")
 
         # Impulse
-        impulse = performance.get_total_impulse_trapezoidal(
+        impulse = performance.get_total_impulse(
             np.asarray(self.thrust), np.asarray(self.t)
         )
         isp = performance.get_specific_impulse(impulse, self.propellant_mass[0])

--- a/machwave/states/liquid_engine.py
+++ b/machwave/states/liquid_engine.py
@@ -1,7 +1,7 @@
 import numpy as np
-import scipy.constants
 
 import machwave.core.conversions as conversions
+import machwave.core.performance as performance
 from machwave.core.compressible_flow.losses import (
     get_kinetics_percentage_loss,
     get_nozzle_divergent_percentage_loss,
@@ -236,8 +236,8 @@ class LiquidEngineState(MotorState):
         print(f"  Mean: {np.mean(self.thrust):.4f}")
 
         # Impulse
-        impulse = np.trapezoid(self.thrust, self.t)
-        isp = impulse / (self.propellant_mass[0] * scipy.constants.g)
+        impulse = performance.get_total_impulse_trapezoidal(self.thrust, self.t)
+        isp = performance.get_specific_impulse(impulse, self.propellant_mass[0])
         print("\nIMPULSE AND I_SP")
         print(f"  Total impulse: {impulse:.4f} N·s")
         print(f"  Specific impulse: {isp:.4f} s")

--- a/machwave/states/liquid_engine.py
+++ b/machwave/states/liquid_engine.py
@@ -236,7 +236,9 @@ class LiquidEngineState(MotorState):
         print(f"  Mean: {np.mean(self.thrust):.4f}")
 
         # Impulse
-        impulse = performance.get_total_impulse_trapezoidal(self.thrust, self.t)
+        impulse = performance.get_total_impulse_trapezoidal(
+            np.asarray(self.thrust), np.asarray(self.t)
+        )
         isp = performance.get_specific_impulse(impulse, self.propellant_mass[0])
         print("\nIMPULSE AND I_SP")
         print(f"  Total impulse: {impulse:.4f} N·s")

--- a/machwave/states/solid_motor.py
+++ b/machwave/states/solid_motor.py
@@ -344,7 +344,9 @@ class SolidMotorState(states_base.MotorState):
     @property
     def total_impulse(self) -> float:
         """Get the total impulse [N-s]."""
-        return performance.get_total_impulse_trapezoidal(self.thrust, self.t)
+        return performance.get_total_impulse_trapezoidal(
+            np.asarray(self.thrust), np.asarray(self.t)
+        )
 
     @property
     def specific_impulse(self) -> float:

--- a/machwave/states/solid_motor.py
+++ b/machwave/states/solid_motor.py
@@ -5,6 +5,7 @@ import machwave.core.compressible_flow.losses as losses
 import machwave.core.compressible_flow.nozzle as nozzle_core
 import machwave.core.conversions as conversions
 import machwave.core.mass_balance as mass_balance
+import machwave.core.performance as performance
 import machwave.core.solvers.rk4 as rk4
 import machwave.models.motors as motors
 import machwave.states.base as states_base
@@ -343,9 +344,12 @@ class SolidMotorState(states_base.MotorState):
     @property
     def total_impulse(self) -> float:
         """Get the total impulse [N-s]."""
-        return float(np.mean(self.thrust) * self.t[-1])
+        return performance.get_total_impulse_trapezoidal(self.thrust, self.t)
 
     @property
     def specific_impulse(self) -> float:
         """Get the specific impulse [s]."""
-        return self.total_impulse / self.propellant_mass[0] / 9.81
+        return performance.get_specific_impulse(
+            total_impulse=self.total_impulse,
+            initial_propellant_mass=self.propellant_mass[0],
+        )

--- a/machwave/states/solid_motor.py
+++ b/machwave/states/solid_motor.py
@@ -344,7 +344,7 @@ class SolidMotorState(states_base.MotorState):
     @property
     def total_impulse(self) -> float:
         """Get the total impulse [N-s]."""
-        return performance.get_total_impulse_trapezoidal(
+        return performance.get_total_impulse(
             np.asarray(self.thrust), np.asarray(self.t)
         )
 

--- a/tests/test_core/test_performance.py
+++ b/tests/test_core/test_performance.py
@@ -10,6 +10,20 @@ def test_get_total_impulse():
     assert total_impulse == pytest.approx(2500)
 
 
+def test_get_total_impulse_trapezoidal_constant_thrust_matches_rectangular():
+    thrust = [500.0, 500.0, 500.0]
+    time = [0.0, 1.0, 2.0]
+    impulse = core_performance.get_total_impulse_trapezoidal(thrust, time)
+    assert impulse == pytest.approx(1000.0)
+
+
+def test_get_total_impulse_trapezoidal_linear_ramp():
+    thrust = [0.0, 1000.0]
+    time = [0.0, 2.0]
+    impulse = core_performance.get_total_impulse_trapezoidal(thrust, time)
+    assert impulse == pytest.approx(1000.0)
+
+
 def test_get_specific_impulse():
     total_impulse = 2500
     initial_propellant_mass = 100

--- a/tests/test_core/test_performance.py
+++ b/tests/test_core/test_performance.py
@@ -4,24 +4,17 @@ import pytest
 import machwave.core.performance as core_performance
 
 
-def test_get_total_impulse():
-    average_thrust = 1000
-    thrust_time = 2.5
-    total_impulse = core_performance.get_total_impulse(average_thrust, thrust_time)
-    assert total_impulse == pytest.approx(2500)
-
-
-def test_get_total_impulse_trapezoidal_constant_thrust_matches_rectangular():
+def test_get_total_impulse_constant_thrust():
     thrust = np.array([500.0, 500.0, 500.0])
     time = np.array([0.0, 1.0, 2.0])
-    impulse = core_performance.get_total_impulse_trapezoidal(thrust, time)
+    impulse = core_performance.get_total_impulse(thrust, time)
     assert impulse == pytest.approx(1000.0)
 
 
-def test_get_total_impulse_trapezoidal_linear_ramp():
+def test_get_total_impulse_linear_ramp():
     thrust = np.array([0.0, 1000.0])
     time = np.array([0.0, 2.0])
-    impulse = core_performance.get_total_impulse_trapezoidal(thrust, time)
+    impulse = core_performance.get_total_impulse(thrust, time)
     assert impulse == pytest.approx(1000.0)
 
 

--- a/tests/test_core/test_performance.py
+++ b/tests/test_core/test_performance.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import machwave.core.performance as core_performance
@@ -11,15 +12,15 @@ def test_get_total_impulse():
 
 
 def test_get_total_impulse_trapezoidal_constant_thrust_matches_rectangular():
-    thrust = [500.0, 500.0, 500.0]
-    time = [0.0, 1.0, 2.0]
+    thrust = np.array([500.0, 500.0, 500.0])
+    time = np.array([0.0, 1.0, 2.0])
     impulse = core_performance.get_total_impulse_trapezoidal(thrust, time)
     assert impulse == pytest.approx(1000.0)
 
 
 def test_get_total_impulse_trapezoidal_linear_ramp():
-    thrust = [0.0, 1000.0]
-    time = [0.0, 2.0]
+    thrust = np.array([0.0, 1000.0])
+    time = np.array([0.0, 2.0])
     impulse = core_performance.get_total_impulse_trapezoidal(thrust, time)
     assert impulse == pytest.approx(1000.0)
 


### PR DESCRIPTION
## Summary
- Add `get_total_impulse_trapezoidal` to `machwave.core.performance` alongside the existing rectangular helper.
- Replace inline `np.trapezoid` / manual `g` division in `LiquidEngineState.print_results` with the helpers.
- Route `SolidMotorState.total_impulse` and `specific_impulse` through the helpers; the total impulse now integrates the recorded thrust curve trapezoidally instead of approximating it as `mean(thrust) * t[-1]`, and the hard-coded `9.81` is dropped in favor of `scipy.constants.g` via the shared helper.

## Test plan
- [x] `uv run pytest tests/test_core/test_performance.py` (4 passed, includes two new trapezoidal cases)
- [x] `uv run pytest tests/test_simulations/` (20 passed; solid and liquid simulations still terminate with physically plausible totals)
- [x] `uv run pytest` full suite (567 passed)

Closes #137