### PR TITLE
Use precise factor for Pascal to psi conversion

### DIFF
--- a/machwave/core/conversions.py
+++ b/machwave/core/conversions.py
@@ -1,3 +1,6 @@
+import scipy.constants
+
+
 def convert_pa_to_psi(pressure_pa: float) -> float:
     """
     Converts pressure in Pascal to psi.
@@ -8,7 +11,7 @@ def convert_pa_to_psi(pressure_pa: float) -> float:
     Returns:
         Pressure [psi].
     """
-    return pressure_pa * 1.45e-4
+    return pressure_pa / scipy.constants.psi
 
 
 def convert_pa_to_mpa(pressure_pa: float) -> float:

--- a/tests/test_core/test_conversions.py
+++ b/tests/test_core/test_conversions.py
@@ -6,13 +6,13 @@ from machwave.core import conversions
 @pytest.mark.parametrize(
     "pa, expected_psi",
     [
-        (100_000, 14.5037735),
+        (100_000, 14.503773773020924),
         (0, 0.0),
-        (-50_000, -7.252642),
+        (-50_000, -7.251886886510462),
     ],
 )
 def test_convert_pa_to_psi(pa, expected_psi):
-    assert conversions.convert_pa_to_psi(pa) == pytest.approx(expected_psi, rel=1e-2)
+    assert conversions.convert_pa_to_psi(pa) == pytest.approx(expected_psi, rel=1e-9)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #220.

## Summary
- Replace the hardcoded `1.45e-4` factor in `convert_pa_to_psi` with `scipy.constants.psi`, eliminating the 0.026% error that propagated into kinetics-loss pressure correction and every RocketCEA call.
- Pull from `scipy.constants` to stay consistent with the existing usage of `R` and `g` elsewhere in the codebase.
- Tighten the unit test tolerance from `rel=1e-2` to `rel=1e-9` and update expected values to the precise factor so future rounding regressions are caught.

## Test plan
- [x] `pytest tests/test_core/test_conversions.py`