### PR TITLE
Adopt loss-fraction convention across nozzle losses

### DIFF
--- a/docs/theory/nozzle_losses.md
+++ b/docs/theory/nozzle_losses.md
@@ -25,15 +25,15 @@ exit plane:
 = \frac{1 + \cos\alpha}{2}
 \]
 
-The divergence loss in percent is \(1 - \lambda\), expressed as a percentage:
+The divergence loss is \(1 - \lambda\), expressed as a fraction in [0, 1]:
 
 \[
-\boxed{\eta_{div} = 50\,(1-\cos\alpha) \quad [\%]}
+\boxed{\eta_{div} = \tfrac{1}{2}\,(1-\cos\alpha)}
 \]
 
 Applicable to **conical nozzles only**. Contoured (bell) nozzles can achieve near-zero
 divergence loss by design. Implemented in
-[`get_nozzle_divergent_percentage_loss`][machwave.core.compressible_flow.losses.get_nozzle_divergent_percentage_loss].
+[`get_nozzle_divergent_loss_fraction`][machwave.core.compressible_flow.losses.get_nozzle_divergent_loss_fraction].
 
 *Applies to: solid and liquid motors.*
 
@@ -50,7 +50,7 @@ The magnitude is proportional to the gap between CEA-predicted frozen and
 equilibrium (shifting) specific impulses:
 
 \[
-\eta_{kin} = 33.3\left(1 - \frac{I_{sp,frozen}}{I_{sp,shifting}}\right) \times f_P \quad [\%]
+\eta_{kin} = 0.333\left(1 - \frac{I_{sp,frozen}}{I_{sp,shifting}}\right) \times f_P
 \]
 
 where the pressure correction factor accounts for the fact that higher chamber
@@ -61,7 +61,7 @@ f_P = \begin{cases} 1 & P_0 < 200\ \text{psi} \\ \dfrac{200}{P_0[\text{psi}]} & 
 \]
 
 Implemented in
-[`get_kinetics_percentage_loss`][machwave.core.compressible_flow.losses.get_kinetics_percentage_loss].
+[`get_kinetics_loss_fraction`][machwave.core.compressible_flow.losses.get_kinetics_loss_fraction].
 
 *Applies to: solid and liquid motors.*
 
@@ -79,15 +79,16 @@ The loss is also time-dependent: the wall heats up during the burn, reducing the
 heat-flux driving force and therefore the loss:
 
 \[
-\eta_{BL} = C_1\frac{P_0^{0.8}}{D_t^{0.2}}
+\eta_{BL} = 0.01 \cdot C_1\frac{P_0^{0.8}}{D_t^{0.2}}
 \left[1 + 2\exp\!\left(-\frac{C_2\, P_0^{0.8}\, t}{D_t^{0.2}}\right)\right]
-\left[1 + 0.016\,(\varepsilon - 9)\right] \quad [\%]
+\left[1 + 0.016\,(\varepsilon - 9)\right]
 \]
 
-with pressures in psi and diameter in inches. \(C_1\) and \(C_2\) are
-nozzle-material constants (e.g. \(C_1=0.003650\), \(C_2=0.000937\) for a
-standard graphite/phenolic nozzle). Implemented in
-[`get_boundary_layer_percentage_loss`][machwave.core.compressible_flow.losses.get_boundary_layer_percentage_loss].
+with pressures in psi and diameter in inches. The 0.01 factor converts the
+classical percent-form expression to the fraction convention used here.
+\(C_1\) and \(C_2\) are nozzle-material constants (e.g. \(C_1=0.003650\),
+\(C_2=0.000937\) for a standard graphite/phenolic nozzle). Implemented in
+[`get_boundary_layer_loss_fraction`][machwave.core.compressible_flow.losses.get_boundary_layer_loss_fraction].
 
 *Applies to: solid motors only* (the empirical constants \(C_1, C_2\) are
 calibrated against a BATES motor; the LRE state passes \(\eta_{BL} = 0\)).
@@ -115,12 +116,13 @@ chamber length [in], and \(D_t\) is the throat diameter [in].
 **Step 2 — Two-phase loss** (tabulated power-law fit):
 
 \[
-\eta_{2p} = C_3\,\frac{\xi^{C_4}\,d_p^{C_5}}{P_0^{0.15}\,\varepsilon^{0.08}\,D_t^{C_6}} \quad [\%]
+\eta_{2p} = 0.01 \cdot C_3\,\frac{\xi^{C_4}\,d_p^{C_5}}{P_0^{0.15}\,\varepsilon^{0.08}\,D_t^{C_6}}
 \]
 
 Coefficients \(C_3\)–\(C_6\) depend on \(\xi\), \(D_t\), and \(d_p\) ranges
-(tabulated in AFRPL-TR-75-36). Implemented in
-[`get_two_phase_flow_percentage_loss`][machwave.core.compressible_flow.losses.get_two_phase_flow_percentage_loss].
+(tabulated in AFRPL-TR-75-36; the 0.01 factor converts the percent-form
+expression to the fraction convention used here). Implemented in
+[`get_two_phase_flow_loss_fraction`][machwave.core.compressible_flow.losses.get_two_phase_flow_loss_fraction].
 
 *Applies to: solid motors only.* Liquid bipropellants typically produce gas-phase
 products with no condensed phase, so the LRE state passes \(\eta_{2p} = 0\).
@@ -129,11 +131,11 @@ products with no condensed phase, so the LRE state passes \(\eta_{2p} = 0\).
 
 ## 4.5 Overall Nozzle Efficiency
 
-The four losses are additive in percentage, giving the overall efficiency applied
+The four loss fractions are additive, giving the overall efficiency applied
 to the ideal thrust coefficient:
 
 \[
-\boxed{\eta_{nozzle} = 1 - \frac{\eta_{div} + \eta_{kin} + \eta_{BL} + \eta_{2p} + \eta_{other}}{100}}
+\boxed{\eta_{nozzle} = 1 - \left(\eta_{div} + \eta_{kin} + \eta_{BL} + \eta_{2p} + \eta_{other}\right)}
 \]
 
 \[

--- a/examples/1kn_lre.py
+++ b/examples/1kn_lre.py
@@ -98,7 +98,7 @@ def main():
     )
 
     sim_params = InternalBallisticsSimulationParams(
-        d_t=1e-4, igniter_pressure=1e6, external_pressure=1e5, other_losses=12.0
+        d_t=1e-4, igniter_pressure=1e6, external_pressure=1e5, other_losses=0.12
     )
     simulation = InternalBallisticsSimulation(motor=lre, params=sim_params)
 

--- a/examples/apcp_motor.py
+++ b/examples/apcp_motor.py
@@ -63,7 +63,7 @@ def main():
         d_t=0.01,
         igniter_pressure=1e6,
         external_pressure=1e5,
-        other_losses=12.0,
+        other_losses=0.12,
     )
 
     sim = simulation.InternalBallisticsSimulation(motor=motor, params=params)

--- a/examples/kappa_rnakka.py
+++ b/examples/kappa_rnakka.py
@@ -61,7 +61,7 @@ def main():
         d_t=0.001,
         igniter_pressure=1e6,
         external_pressure=1e5,
-        other_losses=12.0,
+        other_losses=0.12,
     )
 
     sim = simulation.InternalBallisticsSimulation(motor=motor, params=params)

--- a/examples/losses/boundary_layer.py
+++ b/examples/losses/boundary_layer.py
@@ -59,7 +59,7 @@ for (
     TIMES,
     C1_C2_VALUES,
 ):
-    boundary_layer_loss = losses.get_boundary_layer_percentage_loss(
+    boundary_layer_loss = losses.get_boundary_layer_loss_fraction(
         chamber_pressure_psi=P_ch,
         throat_diameter_inch=d_t,
         expansion_ratio=eps,
@@ -76,7 +76,7 @@ for (
             "time (s)": t,
             "C1": c1,
             "C2": c2,
-            "η_bl (%)": round(boundary_layer_loss, 3),
+            "η_bl (fraction)": round(boundary_layer_loss, 5),
         }
     )
 
@@ -85,8 +85,8 @@ df = pd.DataFrame(records)
 print(
     dedent(
         """
-        Boundary-layer percentage losses
-        --------------------------------
+        Boundary-layer loss fractions
+        -----------------------------
         """
     ).strip()
 )

--- a/examples/losses/divergent.py
+++ b/examples/losses/divergent.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 import pandas as pd
 
 from machwave.core.compressible_flow.losses import (
-    get_nozzle_divergent_percentage_loss,
+    get_nozzle_divergent_loss_fraction,
 )
 
 DIVERGENT_ANGLES = (
@@ -27,12 +27,12 @@ DIVERGENT_ANGLES = (
 records: list[dict[str, float]] = []
 
 for angle in DIVERGENT_ANGLES:
-    divergent_loss = get_nozzle_divergent_percentage_loss(divergent_angle=angle)
+    divergent_loss = get_nozzle_divergent_loss_fraction(divergent_angle=angle)
 
     records.append(
         {
             "θ_half (deg)": angle,
-            "η_div (%)": round(divergent_loss, 3),
+            "η_div (fraction)": round(divergent_loss, 5),
         }
     )
 
@@ -41,7 +41,7 @@ df = pd.DataFrame(records)
 print(
     dedent(
         """
-        Nozzle Divergent Half-Angle vs. Percentage Loss
+        Nozzle Divergent Half-Angle vs. Loss Fraction
         ---------------------------------------------
         """
     ).strip()

--- a/examples/losses/kinetics.py
+++ b/examples/losses/kinetics.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 
 import pandas as pd
 
-from machwave.core.compressible_flow.losses import get_kinetics_percentage_loss
+from machwave.core.compressible_flow.losses import get_kinetics_loss_fraction
 
 CHAMBER_PRESSURES_PSI = (
     150,
@@ -29,7 +29,7 @@ for P_ch, (i_sp_frozen, i_sp_shifting) in product(
     CHAMBER_PRESSURES_PSI,
     ISP_TH_PAIRS,
 ):
-    kinetics_loss = get_kinetics_percentage_loss(
+    kinetics_loss = get_kinetics_loss_fraction(
         i_sp_th_frozen=i_sp_frozen,
         i_sp_th_shifting=i_sp_shifting,
         chamber_pressure_psi=P_ch,
@@ -40,7 +40,7 @@ for P_ch, (i_sp_frozen, i_sp_shifting) in product(
             "P_ch (psi)": P_ch,
             "Isp_frozen (s)": i_sp_frozen,
             "Isp_shifting (s)": i_sp_shifting,
-            "η_kin (%)": round(kinetics_loss, 3),
+            "η_kin (fraction)": round(kinetics_loss, 5),
         }
     )
 
@@ -49,8 +49,8 @@ df = pd.DataFrame(records)
 print(
     dedent(
         """
-        Kinetics percentage losses
-        --------------------------
+        Kinetics loss fractions
+        -----------------------
         """
     ).strip()
 )

--- a/examples/losses/two_phase.py
+++ b/examples/losses/two_phase.py
@@ -55,7 +55,7 @@ for P_ch, d_t, x_c, eps, l_star in product(
         throat_diameter_inch=d_t,
         characteristic_length_inch=l_star,
     )
-    two_phase_loss = losses.get_two_phase_flow_percentage_loss(
+    two_phase_loss = losses.get_two_phase_flow_loss_fraction(
         chamber_pressure_psi=P_ch,
         mass_fraction_of_condensed_phase=x_c,
         expansion_ratio=eps,
@@ -71,7 +71,7 @@ for P_ch, d_t, x_c, eps, l_star in product(
             "ε": eps,
             "l* (in)": l_star,
             "d_p (µm)": round(d_p_um, 2),
-            "η_2φ (%)": round(two_phase_loss, 3),
+            "η_2φ (fraction)": round(two_phase_loss, 5),
         }
     )
 
@@ -80,8 +80,8 @@ df = pd.DataFrame(records)
 print(
     dedent(
         """
-        Two-phase flow percentage losses & particle size
-        -----------------------------------------------
+        Two-phase flow loss fractions & particle size
+        ---------------------------------------------
         """
     ).strip()
 )

--- a/examples/nero_motor.py
+++ b/examples/nero_motor.py
@@ -62,7 +62,7 @@ def main():
         d_t=0.01,
         igniter_pressure=1e6,
         external_pressure=1e5,
-        other_losses=12.0,
+        other_losses=0.12,
     )
 
     sim = simulation.InternalBallisticsSimulation(motor=motor, params=params)

--- a/examples/olympus.py
+++ b/examples/olympus.py
@@ -76,7 +76,7 @@ def main():
         d_t=0.001,
         igniter_pressure=1e6,
         external_pressure=1.013e5,
-        other_losses=12.0,
+        other_losses=0.12,
     )
 
     sim = simulation.InternalBallisticsSimulation(motor=motor, params=params)

--- a/examples/olympus_montecarlo.py
+++ b/examples/olympus_montecarlo.py
@@ -69,7 +69,7 @@ def main():
         d_t=0.01,
         external_pressure=1e5,
         igniter_pressure=1e6,
-        other_losses=12.0,
+        other_losses=0.12,
     )
 
     mc = montecarlo.MonteCarloSimulation(

--- a/examples/rocketpy_srm_simulation.py
+++ b/examples/rocketpy_srm_simulation.py
@@ -73,7 +73,7 @@ def main():
         d_t=0.01,
         igniter_pressure=1e6,
         external_pressure=1.013e5,
-        other_losses=12.0,
+        other_losses=0.12,
     )
 
     sim = simulation.InternalBallisticsSimulation(motor=motor, params=params)

--- a/machwave/core/compressible_flow/__init__.py
+++ b/machwave/core/compressible_flow/__init__.py
@@ -16,11 +16,11 @@ from .isentropic import (
     is_flow_choked,
 )
 from .losses import (
-    get_boundary_layer_percentage_loss,
-    get_kinetics_percentage_loss,
-    get_nozzle_divergent_percentage_loss,
+    get_boundary_layer_loss_fraction,
+    get_kinetics_loss_fraction,
+    get_nozzle_divergent_loss_fraction,
     get_overall_nozzle_efficiency,
-    get_two_phase_flow_percentage_loss,
+    get_two_phase_flow_loss_fraction,
 )
 
 __all__ = [
@@ -36,9 +36,9 @@ __all__ = [
     "get_exit_pressure",
     "is_flow_choked",
     # losses
-    "get_nozzle_divergent_percentage_loss",
-    "get_kinetics_percentage_loss",
-    "get_boundary_layer_percentage_loss",
-    "get_two_phase_flow_percentage_loss",
+    "get_nozzle_divergent_loss_fraction",
+    "get_kinetics_loss_fraction",
+    "get_boundary_layer_loss_fraction",
+    "get_two_phase_flow_loss_fraction",
     "get_overall_nozzle_efficiency",
 ]

--- a/machwave/core/compressible_flow/losses.py
+++ b/machwave/core/compressible_flow/losses.py
@@ -1,6 +1,6 @@
 """
 Losses and correction factors for rocket engines.
-All functions return a correction factor that is between 0 and 1.
+All functions return a fraction, between 0 and 1.
 
 References:
     Coats, D. E., Levine, J. N., Nickerson, G. R., Tyson, T. J.,
@@ -20,40 +20,40 @@ KINETICS_LOSS_PRESSURE_THRESHOLD_PSI = 200  # psi
 """
 AD-A015 140 cites typical ranges for the correction factors.
 Some of these ranges were adjusted based on the experience of the authors and the
-typical outcomes for validation cases.
+typical outcomes for validation cases. Ranges are expressed as fractions.
 """
 
 TYPICAL_RANGES = {
-    "divergent_loss": {"lower": 0.75, "upper": 5},
-    "kinetics_loss": {"lower": 0.1, "upper": 5},
-    "boundary_layer_loss": {"lower": 0.1, "upper": 3},
-    "two_phase_flow_loss": {"lower": 0.1, "upper": 5},
+    "divergent_loss": {"lower": 0.0075, "upper": 0.05},
+    "kinetics_loss": {"lower": 0.001, "upper": 0.05},
+    "boundary_layer_loss": {"lower": 0.001, "upper": 0.03},
+    "two_phase_flow_loss": {"lower": 0.001, "upper": 0.05},
 }
 
 
-@decorators.check_bounds(lower=0.0, upper=100.0)
+@decorators.check_bounds(lower=0.0, upper=1.0)
 @decorators.warn_if_outside_range(**TYPICAL_RANGES["divergent_loss"])
-def get_nozzle_divergent_percentage_loss(divergent_angle: float) -> float:
+def get_nozzle_divergent_loss_fraction(divergent_angle: float) -> float:
     """
-    Calculates the divergent nozzle correction factor given the half angle.
+    Calculates the divergent nozzle loss fraction given the half angle.
     NOTE: only applicable for a conical convergent-divergent nozzle.
 
     Args:
         divergent_angle: The half angle of the divergent nozzle [degrees].
 
     Returns:
-        The divergent correction factor.
+        The divergent loss fraction in [0, 1].
     """
-    return 50 * (1 - np.cos(np.deg2rad(divergent_angle)))
+    return 0.5 * (1 - np.cos(np.deg2rad(divergent_angle)))
 
 
-@decorators.check_bounds(lower=0.0, upper=100.0)
+@decorators.check_bounds(lower=0.0, upper=1.0)
 @decorators.warn_if_outside_range(**TYPICAL_RANGES["kinetics_loss"])
-def get_kinetics_percentage_loss(
+def get_kinetics_loss_fraction(
     i_sp_th_frozen: float, i_sp_th_shifting: float, chamber_pressure_psi: float
 ) -> float:
     """
-    The kinetics correction factor accounts for the decrement in performance due to
+    The kinetics loss accounts for the decrement in performance due to
     incomplete heat transfer of latent heat to sensible heat caused by the finite time
     required for the gas phase chemical reactions to occur.
 
@@ -61,14 +61,17 @@ def get_kinetics_percentage_loss(
     The expansion ratio of the i_sp_th_frozen and i_sp_th_shifting should be the same.
 
     Pressure correction is applied for chamber pressures above 1.379 MPa (200 psi), in
-    order to dampen the effect of the kinetics correction factor.
+    order to dampen the effect of the kinetics loss.
+
+    The source AFRPL-TR-75-36 calculates it as a percentage, here it is converted to a
+    fraction [0, 1].
 
     Args:
         i_sp_th_frozen: The specific impulse of the frozen flow [s].
         i_sp_th_shifting: The specific impulse of the shifting flow [s].
         chamber_pressure_psi: The chamber pressure [psi].
     Returns:
-        The kinetics correction factor.
+        The kinetics loss fraction in [0, 1].
     """
     i_sp_th_ratio = i_sp_th_frozen / i_sp_th_shifting
 
@@ -79,12 +82,12 @@ def get_kinetics_percentage_loss(
             KINETICS_LOSS_PRESSURE_THRESHOLD_PSI / chamber_pressure_psi
         )
 
-    return 33.3 * (1 - i_sp_th_ratio) * pressure_correction
+    return 0.333 * (1 - i_sp_th_ratio) * pressure_correction
 
 
-@decorators.check_bounds(lower=0.0, upper=100.0)
+@decorators.check_bounds(lower=0.0, upper=1.0)
 @decorators.warn_if_outside_range(**TYPICAL_RANGES["boundary_layer_loss"])
-def get_boundary_layer_percentage_loss(
+def get_boundary_layer_loss_fraction(
     chamber_pressure_psi: float,
     throat_diameter_inch: float,
     expansion_ratio: float,
@@ -93,7 +96,7 @@ def get_boundary_layer_percentage_loss(
     c_2: float,
 ) -> float:
     """
-    Boundary layer correction factor accounts for the decrement in performance due to
+    Boundary layer loss accounts for the decrement in performance due to
     the viscous and heat transfer effects in the nozzle walls. It is time dependent.
 
     Valid for liquid, solid, and hybrid propellants.
@@ -115,15 +118,18 @@ def get_boundary_layer_percentage_loss(
     C1 = 0.005060
     C2 = 0.000000
 
+    The source AFRPL-TR-75-36 calculates it as a percentage, here it is converted to a
+    fraction [0, 1].
+
     Args:
         chamber_pressure_psi: The chamber pressure [psi].
         throat_diameter_inch: The throat diameter [in].
         expansion_ratio: The expansion ratio of the nozzle.
         time: The time in seconds [s].
-        c_1: Coefficient for the boundary layer correction factor.
-        c_2: Coefficient for the boundary layer correction factor.
+        c_1: Coefficient for the boundary layer loss.
+        c_2: Coefficient for the boundary layer loss.
     Returns:
-        The boundary layer correction factor.
+        The boundary layer loss fraction in [0, 1].
     """
     term_1 = c_1 * (chamber_pressure_psi**0.8) / (throat_diameter_inch**0.2)
     term_2 = 1 + 2 * np.exp(
@@ -131,7 +137,7 @@ def get_boundary_layer_percentage_loss(
     )
     term_3 = 1 + 0.016 * (expansion_ratio - 9)
 
-    return term_1 * term_2 * term_3
+    return 0.01 * term_1 * term_2 * term_3
 
 
 def _get_two_phase_phase_loss_particle_size(
@@ -164,9 +170,9 @@ def _get_two_phase_phase_loss_particle_size(
     )
 
 
-@decorators.check_bounds(lower=0.0, upper=100.0)
+@decorators.check_bounds(lower=0.0, upper=1.0)
 @decorators.warn_if_outside_range(**TYPICAL_RANGES["two_phase_flow_loss"])
-def get_two_phase_flow_percentage_loss(
+def get_two_phase_flow_loss_fraction(
     chamber_pressure_psi: float,
     mass_fraction_of_condensed_phase: float,
     expansion_ratio: float,
@@ -174,10 +180,13 @@ def get_two_phase_flow_percentage_loss(
     characteristic_length_inch: float,
 ) -> float:
     """
-    Two-phase flow correction factor accounts for the decrement in performance due to
+    Two-phase flow loss accounts for the decrement in performance due to
     the presence of a condensed phase in the combustion products.
 
     Valid for solid, and hybrid propellants.
+
+    The source AFRPL-TR-75-36 calculates it as a percentage, here it is converted to a
+    fraction [0, 1].
 
     Args:
         chamber_pressure_psi: The chamber pressure [psi].
@@ -186,7 +195,7 @@ def get_two_phase_flow_percentage_loss(
         throat_diameter_inch: The throat diameter [in].
         characteristic_length_inch: The characteristic length [in].
     Returns:
-        The two-phase flow correction factor.
+        The two-phase flow loss fraction in [0, 1].
     """
     particle_size_um: float = _get_two_phase_phase_loss_particle_size(
         chamber_pressure_psi,
@@ -229,7 +238,7 @@ def get_two_phase_flow_percentage_loss(
         * (throat_diameter_inch**c_6)
     )
 
-    return c_3 * numerator / denominator
+    return 0.01 * c_3 * numerator / denominator
 
 
 @decorators.check_bounds(lower=0.0, upper=1.0)
@@ -241,26 +250,24 @@ def get_overall_nozzle_efficiency(
     other_losses: float,
 ) -> float:
     """
-    Calculates the overall nozzle efficiency by combining the correction factors.
+    Calculates the overall nozzle efficiency by combining the loss fractions.
+
+    All inputs are loss fractions in [0, 1] (not percentages).
 
     Args:
-        divergent_loss: The divergent nozzle correction factor.
-        kinetics_loss: The kinetics correction factor.
-        boundary_layer_loss: The boundary layer correction factor.
-        two_phase_loss: The two-phase flow correction factor.
-        other_losses: Additional losses, in percent.
+        divergent_loss: The divergent nozzle loss fraction.
+        kinetics_loss: The kinetics loss fraction.
+        boundary_layer_loss: The boundary layer loss fraction.
+        two_phase_loss: The two-phase flow loss fraction.
+        other_losses: Additional losses, as a fraction in [0, 1].
 
     Returns:
-        The overall nozzle efficiency.
+        The overall nozzle efficiency, as a fraction in [0, 1].
     """
-    return (
-        1
-        - (
-            divergent_loss
-            + kinetics_loss
-            + boundary_layer_loss
-            + two_phase_loss
-            + other_losses
-        )
-        / 100
+    return 1.0 - (
+        divergent_loss
+        + kinetics_loss
+        + boundary_layer_loss
+        + two_phase_loss
+        + other_losses
     )

--- a/machwave/models/motors/base.py
+++ b/machwave/models/motors/base.py
@@ -76,12 +76,13 @@ class Motor(Generic[P, T], ABC):
         get the real thrust coefficient.
 
         Args:
-            other_losses: Additional losses not covered by specific mechanisms [%].
+            other_losses: Additional losses not covered by specific mechanisms,
+                as a fraction in [0, 1].
 
         Returns:
             Thrust coefficient correction factor
         """
-        return ((100.0 - other_losses) / 100.0) * self.propellant.combustion_efficiency
+        return (1.0 - other_losses) * self.propellant.combustion_efficiency
 
     @abstractmethod
     def get_thrust_coefficient(self, *args, **kwargs) -> float:

--- a/machwave/models/motors/liquid.py
+++ b/machwave/models/motors/liquid.py
@@ -132,7 +132,8 @@ class LiquidEngine(Motor[BiliquidPropellant, LiquidEngineThrustChamber]):
             external_pressure: External pressure [Pa].
             expansion_ratio: Expansion ratio.
             k_exhaust: Two-phase isentropic coefficient.
-            other_losses: Additional losses not covered by specific mechanisms [%].
+            other_losses: Additional losses not covered by specific mechanisms,
+                as a fraction in [0, 1].
 
         Returns:
             Instantaneous thrust coefficient.

--- a/machwave/simulation.py
+++ b/machwave/simulation.py
@@ -18,13 +18,14 @@ class InternalBallisticsSimulationParams:
         d_t: Time step.
         igniter_pressure: Igniter pressure.
         external_pressure: External pressure.
-        other_losses: Additional losses not covered by specific loss mechanisms [%].
+        other_losses: Additional losses not covered by specific loss mechanisms,
+            as a fraction in [0, 1] (e.g. 0.12 for 12%).
     """
 
     d_t: float
     igniter_pressure: float
     external_pressure: float
-    other_losses: float = 12.0
+    other_losses: float = 0.12
 
 
 def _get_motor_state_class(motor: Motor) -> type[MotorState]:

--- a/machwave/states/liquid_engine.py
+++ b/machwave/states/liquid_engine.py
@@ -3,8 +3,8 @@ import numpy as np
 import machwave.core.conversions as conversions
 import machwave.core.performance as performance
 from machwave.core.compressible_flow.losses import (
-    get_kinetics_percentage_loss,
-    get_nozzle_divergent_percentage_loss,
+    get_kinetics_loss_fraction,
+    get_nozzle_divergent_loss_fraction,
     get_overall_nozzle_efficiency,
 )
 from machwave.core.compressible_flow.nozzle import (
@@ -154,10 +154,10 @@ class LiquidEngineState(MotorState):
         self.exit_pressure.append(exit_pressure)
 
         chamber_pressure_psi = conversions.convert_pa_to_psi(new_chamber_pressure)
-        divergent_loss = get_nozzle_divergent_percentage_loss(
+        divergent_loss = get_nozzle_divergent_loss_fraction(
             divergent_angle=nz.divergent_angle,
         )
-        kinetics_loss = get_kinetics_percentage_loss(
+        kinetics_loss = get_kinetics_loss_fraction(
             i_sp_th_frozen=props.i_sp_frozen,
             i_sp_th_shifting=props.i_sp_shifting,
             chamber_pressure_psi=chamber_pressure_psi,

--- a/machwave/states/solid_motor.py
+++ b/machwave/states/solid_motor.py
@@ -163,15 +163,15 @@ class SolidMotorState(states_base.MotorState):
 
         chamber_pressure_psi = conversions.convert_pa_to_psi(new_chamber_pressure)
         throat_diameter_inch = conversions.convert_meter_to_inch(nozzle.throat_diameter)
-        divergent_loss = losses.get_nozzle_divergent_percentage_loss(
+        divergent_loss = losses.get_nozzle_divergent_loss_fraction(
             divergent_angle=nozzle.divergent_angle,
         )
-        kinetics_loss = losses.get_kinetics_percentage_loss(
+        kinetics_loss = losses.get_kinetics_loss_fraction(
             i_sp_th_frozen=propellant_properties.i_sp_frozen,
             i_sp_th_shifting=propellant_properties.i_sp_shifting,
             chamber_pressure_psi=chamber_pressure_psi,
         )
-        boundary_layer_loss = losses.get_boundary_layer_percentage_loss(
+        boundary_layer_loss = losses.get_boundary_layer_loss_fraction(
             chamber_pressure_psi=chamber_pressure_psi,
             throat_diameter_inch=throat_diameter_inch,
             expansion_ratio=nozzle.expansion_ratio,
@@ -179,7 +179,7 @@ class SolidMotorState(states_base.MotorState):
             c_1=nozzle.c_1,
             c_2=nozzle.c_2,
         )
-        two_phase_loss = losses.get_two_phase_flow_percentage_loss(
+        two_phase_loss = losses.get_two_phase_flow_loss_fraction(
             chamber_pressure_psi=chamber_pressure_psi,
             mass_fraction_of_condensed_phase=propellant_properties.qsi_chamber,
             expansion_ratio=nozzle.expansion_ratio,
@@ -274,17 +274,13 @@ class SolidMotorState(states_base.MotorState):
         print("\nNOZZLE DESIGN")
         print(f" Average nozzle efficiency: {np.mean(self.nozzle_efficiency):.3%}")
         print(f" Average overall efficiency: {np.mean(self.overall_efficiency):.3%}")
+        print(f" Divergent nozzle loss fraction: {np.mean(self.divergent_loss):.3%}")
+        print(f" Average kinetics loss fraction: {np.mean(self.kinetics_loss):.3%}")
         print(
-            f" Divergent nozzle correction factor: {np.mean(self.divergent_loss):.3f}%"
+            f" Average boundary layer loss fraction: {np.mean(self.boundary_layer_loss):.3%}"
         )
         print(
-            f" Average kinetics correction factor: {np.mean(self.kinetics_loss):.3f}%"
-        )
-        print(
-            f" Average boundary layer correction factor: {np.mean(self.boundary_layer_loss):.3f}%"
-        )
-        print(
-            f" Average two-phase flow correction factor: {np.mean(self.two_phase_loss):.3f}%"
+            f" Average two-phase flow loss fraction: {np.mean(self.two_phase_loss):.3%}"
         )
 
     @property

--- a/tests/test_core/test_compressible_flow/test_losses.py
+++ b/tests/test_core/test_compressible_flow/test_losses.py
@@ -6,82 +6,81 @@ pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 
 
 @pytest.mark.parametrize(
-    "divergent_angle, expected_correction_factor",
+    "divergent_angle, expected_loss_fraction",
     [
-        (0.0, 0.0),
-        (2.0, 0.03),
-        (4.0, 0.12),
-        (6.0, 0.28),
-        (8.0, 0.49),
-        (10.0, 0.76),
-        (12.0, 1.10),
-        (15.0, 1.70),
-        (20.0, 3.02),
-        (24.0, 4.33),
+        (0.0, 0.0000),
+        (2.0, 0.0003),
+        (4.0, 0.0012),
+        (6.0, 0.0028),
+        (8.0, 0.0049),
+        (10.0, 0.0076),
+        (12.0, 0.0110),
+        (15.0, 0.0170),
+        (20.0, 0.0302),
+        (24.0, 0.0433),
     ],
 )
-def test_get_nozzle_divergent_correction_factor(
-    divergent_angle, expected_correction_factor
-):
+def test_get_nozzle_divergent_loss_fraction(divergent_angle, expected_loss_fraction):
     """
-    Parameters obtained from Sutton.
+    Parameters obtained from Sutton (originally tabulated as percentages,
+    here divided by 100 to match the fraction convention).
     """
-    divergent_loss = losses.get_nozzle_divergent_percentage_loss(
+    divergent_loss = losses.get_nozzle_divergent_loss_fraction(
         divergent_angle=divergent_angle
     )
-    assert divergent_loss == pytest.approx(expected_correction_factor, abs=1e-2)
+    assert divergent_loss == pytest.approx(expected_loss_fraction, abs=1e-4)
 
 
 @pytest.mark.parametrize(
-    "i_sp_th_frozen, i_sp_th_shifting, chamber_pressure_psi, expected_correction_factor",
+    "i_sp_th_frozen, i_sp_th_shifting, chamber_pressure_psi, expected_loss_fraction",
     [
-        (152.4, 154.1, 150.0, 0.37),  # KNDX @ 150 psi, no pressure damping
-        (152.4, 154.1, 200.0, 0.37),  # KNDX @ 200 psi, pressure = threshold
-        (152.4, 154.1, 210.0, 0.35),  # KNDX @ 210 psi
-        (152.4, 154.1, 1000.0, 0.07),  # KNDX @ 1000 psi
-        (250.0, 300.0, 320.0, 3.47),  # large Isp @ 320 psi
+        (152.4, 154.1, 150.0, 0.0037),  # KNDX @ 150 psi, no pressure damping
+        (152.4, 154.1, 200.0, 0.0037),  # KNDX @ 200 psi, pressure = threshold
+        (152.4, 154.1, 210.0, 0.0035),  # KNDX @ 210 psi
+        (152.4, 154.1, 1000.0, 0.0007),  # KNDX @ 1000 psi
+        (250.0, 300.0, 320.0, 0.0347),  # large Isp @ 320 psi
         (250.0, 250.0, 200.0, 0.0),  # same frozen/shifting Isp
         (250.0, 250.0, 1000.0, 0.0),  # same frozen/shifting Isp
         (300.0, 300.0, 200.0, 0.0),  # same frozen/shifting Isp
         (300.0, 300.0, 1000.0, 0.0),  # same frozen/shifting Isp
     ],
 )
-def test_get_kinetics_correction_factor(
-    i_sp_th_frozen, i_sp_th_shifting, chamber_pressure_psi, expected_correction_factor
+def test_get_kinetics_loss_fraction(
+    i_sp_th_frozen, i_sp_th_shifting, chamber_pressure_psi, expected_loss_fraction
 ):
-    kinetics_loss = losses.get_kinetics_percentage_loss(
+    kinetics_loss = losses.get_kinetics_loss_fraction(
         i_sp_th_frozen=i_sp_th_frozen,
         i_sp_th_shifting=i_sp_th_shifting,
         chamber_pressure_psi=chamber_pressure_psi,
     )
-    assert kinetics_loss == pytest.approx(expected_correction_factor, abs=1e-2)
+    assert kinetics_loss == pytest.approx(expected_loss_fraction, abs=1e-4)
 
 
 @pytest.mark.parametrize(
-    "chamber_pressure_psi, throat_diam_in, expansion_ratio, time_s, c1, c2, expected_boundary_layer_loss",
+    "chamber_pressure_psi, throat_diam_in, expansion_ratio, time_s, c1, c2, expected_loss_fraction",
     [
         # Ordinary nozzle, t = 0, maximal transient term
-        (1000.0, 1.0, 9.0, 0.0, 0.00365, 0.000937, 2.75051564250),
+        (1000.0, 1.0, 9.0, 0.0, 0.00365, 0.000937, 0.0275051564250),
         # Ordinary nozzle, t = 2 s, exponential decay kicks in
-        (1000.0, 1.0, 9.0, 2.0, 0.00365, 0.000937, 2.06205742153),
+        (1000.0, 1.0, 9.0, 2.0, 0.00365, 0.000937, 0.0206205742153),
         # Ordinary nozzle, expansion ratio = 15 increases wall area
-        (1000.0, 1.0, 15.0, 0.0, 0.00365, 0.000937, 3.01456514418),
+        (1000.0, 1.0, 15.0, 0.0, 0.00365, 0.000937, 0.0301456514418),
         # Steel nozzle, higher pressure, smaller throat, C2 = 0
-        (2000.0, 0.5, 12.0, 1.0, 0.00506, 0.000000, 7.99213939195),
+        (2000.0, 0.5, 12.0, 1.0, 0.00506, 0.000000, 0.0799213939195),
         # Steel nozzle, low pressure, large throat, expansion ratio < 9 reduces factor
-        (500.0, 2.0, 8.0, 10.0, 0.00365, 0.000937, 0.72918524795),
+        (500.0, 2.0, 8.0, 10.0, 0.00365, 0.000937, 0.00729185247950),
     ],
 )
-def test_get_boundary_layer_correction_factor(
+def test_get_boundary_layer_loss_fraction(
     chamber_pressure_psi,
     throat_diam_in,
     expansion_ratio,
     time_s,
     c1,
     c2,
-    expected_boundary_layer_loss,
+    expected_loss_fraction,
 ):
-    boundary_layer_loss = losses.get_boundary_layer_percentage_loss(
+    boundary_layer_loss = losses.get_boundary_layer_loss_fraction(
         chamber_pressure_psi=chamber_pressure_psi,
         throat_diameter_inch=throat_diam_in,
         expansion_ratio=expansion_ratio,
@@ -90,7 +89,7 @@ def test_get_boundary_layer_correction_factor(
         c_2=c2,
     )
 
-    assert boundary_layer_loss == pytest.approx(expected_boundary_layer_loss, abs=1e-9)
+    assert boundary_layer_loss == pytest.approx(expected_loss_fraction, abs=1e-11)
 
 
 @pytest.mark.parametrize(
@@ -127,34 +126,34 @@ def test_get_two_phase_phase_loss_particle_size(
         "d_throat_in",
         "l_char_in",
         "mock_particle_um",
-        "expected_eta_tp",
+        "expected_loss_fraction",
     ),
     [
         # - xi >= 0.09 branch
         # throat < 1 in
-        (150.0, 0.12, 9.0, 0.8, 20.0, 5.0, 7.7083257633896425),
+        (150.0, 0.12, 9.0, 0.8, 20.0, 5.0, 0.077083257633896425),
         # 1 in <= throat < 2 in
-        (200.0, 0.12, 10.0, 1.5, 20.0, 6.0, 5.081089868159106),
+        (200.0, 0.12, 10.0, 1.5, 20.0, 6.0, 0.05081089868159106),
         # throat >= 2 in, particle < 4 µm
-        (250.0, 0.12, 12.0, 3.0, 20.0, 3.0, 1.6621488765966366),
+        (250.0, 0.12, 12.0, 3.0, 20.0, 3.0, 0.016621488765966366),
         # throat >= 2 in, 4 µm <= particle <= 8 µm
-        (250.0, 0.12, 12.0, 3.0, 20.0, 6.0, 3.4185173799418895),
+        (250.0, 0.12, 12.0, 3.0, 20.0, 6.0, 0.034185173799418895),
         # throat >= 2 in, particle > 8 µm
-        (250.0, 0.12, 12.0, 3.0, 20.0, 9.0, 3.7947076355546048),
+        (250.0, 0.12, 12.0, 3.0, 20.0, 9.0, 0.037947076355546048),
         # - xi < 0.09 branch
         # throat < 1 in
-        (150.0, 0.05, 9.0, 0.8, 20.0, 5.0, 3.708669962078615),
+        (150.0, 0.05, 9.0, 0.8, 20.0, 5.0, 0.03708669962078615),
         # 1 in <= throat < 2 in
-        (200.0, 0.05, 10.0, 1.5, 20.0, 6.0, 2.4446405026319503),
+        (200.0, 0.05, 10.0, 1.5, 20.0, 6.0, 0.024446405026319503),
         # throat >= 2 in, particle < 4 µm
-        (250.0, 0.05, 12.0, 3.0, 20.0, 3.0, 0.7967177893556986),
+        (250.0, 0.05, 12.0, 3.0, 20.0, 3.0, 0.007967177893556986),
         # throat >= 2 in, 4 µm <= particle <= 8 µm
-        (250.0, 0.05, 12.0, 3.0, 20.0, 6.0, 1.644734941282387),
+        (250.0, 0.05, 12.0, 3.0, 20.0, 6.0, 0.01644734941282387),
         # throat >= 2 in, particle > 8 µm
-        (250.0, 0.05, 12.0, 3.0, 20.0, 9.0, 1.820912334005975),
+        (250.0, 0.05, 12.0, 3.0, 20.0, 9.0, 0.01820912334005975),
     ],
 )
-def test_get_two_phase_flow_correction_factor(
+def test_get_two_phase_flow_loss_fraction(
     monkeypatch,
     chamber_psi,
     xi,
@@ -162,7 +161,7 @@ def test_get_two_phase_flow_correction_factor(
     d_throat_in,
     l_char_in,
     mock_particle_um,
-    expected_eta_tp,
+    expected_loss_fraction,
 ):
     # Patch the private helper to return a controlled particle size.
     monkeypatch.setattr(
@@ -171,7 +170,7 @@ def test_get_two_phase_flow_correction_factor(
         lambda *_a, **_kw: mock_particle_um,
     )
 
-    eta_tp = losses.get_two_phase_flow_percentage_loss(
+    two_phase_loss = losses.get_two_phase_flow_loss_fraction(
         chamber_pressure_psi=chamber_psi,
         mass_fraction_of_condensed_phase=xi,
         expansion_ratio=eps,
@@ -179,15 +178,15 @@ def test_get_two_phase_flow_correction_factor(
         characteristic_length_inch=l_char_in,  # value irrelevant after patch
     )
 
-    assert eta_tp == pytest.approx(expected_eta_tp, abs=1e-12)
+    assert two_phase_loss == pytest.approx(expected_loss_fraction, abs=1e-14)
 
 
 @pytest.mark.parametrize(
     "divergent_loss, kinetics_loss, boundary_layer_loss, two_phase_loss, expected_efficiency",
     [
         (0.0, 0.0, 0.0, 0.0, 1.0),  # all zero, upper-bound edge case
-        (2, 3, 4, 5, 0.86),  # typical values
-        (25, 25, 25, 25, 0.0),  # lower-bound edge case (sums 1.0)
+        (0.02, 0.03, 0.04, 0.05, 0.86),  # typical values
+        (0.25, 0.25, 0.25, 0.25, 0.0),  # lower-bound edge case (sums to 1.0)
     ],
 )
 def test_get_overall_nozzle_efficiency_valid(
@@ -198,7 +197,7 @@ def test_get_overall_nozzle_efficiency_valid(
     expected_efficiency,
 ):
     """
-    Ensures the overall efficiency equals the arithmetic sum and
+    Ensures the overall efficiency equals one minus the arithmetic sum and
     respects decorator-enforced [0, 1] bounds.
     """
     overall_efficiency = losses.get_overall_nozzle_efficiency(
@@ -206,7 +205,7 @@ def test_get_overall_nozzle_efficiency_valid(
         kinetics_loss=kinetics_loss,
         boundary_layer_loss=boundary_layer_loss,
         two_phase_loss=two_phase_loss,
-        other_losses=0,
+        other_losses=0.0,
     )
 
     assert overall_efficiency == pytest.approx(expected_efficiency, abs=1e-12)
@@ -214,41 +213,41 @@ def test_get_overall_nozzle_efficiency_valid(
 
 def test_get_overall_nozzle_efficiency_out_of_bounds():
     """
-    When the sum exceeds 1, the @check_bounds decorator should raise.
+    When the sum of loss fractions exceeds 1, the @check_bounds decorator should raise.
     """
     with pytest.raises((ValueError, AssertionError)):
         # Sum = 1.10, outside allowed range.
         losses.get_overall_nozzle_efficiency(
-            divergent_loss=40,
-            kinetics_loss=30,
-            boundary_layer_loss=20,
-            two_phase_loss=20,
-            other_losses=0,
+            divergent_loss=0.40,
+            kinetics_loss=0.30,
+            boundary_layer_loss=0.20,
+            two_phase_loss=0.20,
+            other_losses=0.0,
         )
 
 
 @pytest.mark.parametrize(
     (
-        "loss_bl_pct",
-        "loss_div_pct",
-        "loss_kin_pct",
-        "loss_tp_pct",
+        "loss_bl",
+        "loss_div",
+        "loss_kin",
+        "loss_tp",
         "expected_eta_cf",
     ),
     [
-        # Table 4-5 columns (transcribed)
-        (1.5, 1.7, 0.2, 2.1, 0.945),  # A Bates
-        (2.0, 1.7, 0.2, 2.0, 0.941),  # B Bates
-        (1.7, 1.7, 0.2, 1.2, 0.952),  # A Bates (NF)
-        (0.4, 1.7, 0.3, 0.3, 0.973),  # Antares 1
-        (0.9, 3.0, 0.3, 2.1, 0.937),  # Spartan 2
+        # Table 4-5 columns (transcribed from percentages to fractions)
+        (0.015, 0.017, 0.002, 0.021, 0.945),  # A Bates
+        (0.020, 0.017, 0.002, 0.020, 0.941),  # B Bates
+        (0.017, 0.017, 0.002, 0.012, 0.952),  # A Bates (NF)
+        (0.004, 0.017, 0.003, 0.003, 0.973),  # Antares 1
+        (0.009, 0.030, 0.003, 0.021, 0.937),  # Spartan 2
     ],
 )
 def test_table_4_5_simplified_method(
-    loss_bl_pct,
-    loss_div_pct,
-    loss_kin_pct,
-    loss_tp_pct,
+    loss_bl,
+    loss_div,
+    loss_kin,
+    loss_tp,
     expected_eta_cf,
 ):
     """
@@ -256,11 +255,11 @@ def test_table_4_5_simplified_method(
     JANNAF/AFRPL-TR-75-36 Table 4-5.
     """
     eta_cf = losses.get_overall_nozzle_efficiency(
-        divergent_loss=loss_div_pct,
-        kinetics_loss=loss_kin_pct,
-        boundary_layer_loss=loss_bl_pct,
-        two_phase_loss=loss_tp_pct,
-        other_losses=0,
+        divergent_loss=loss_div,
+        kinetics_loss=loss_kin,
+        boundary_layer_loss=loss_bl,
+        two_phase_loss=loss_tp,
+        other_losses=0.0,
     )
 
     assert eta_cf == pytest.approx(expected_eta_cf, abs=1e-3)

--- a/tests/test_simulations/test_liquid_engine_simulation.py
+++ b/tests/test_simulations/test_liquid_engine_simulation.py
@@ -110,7 +110,7 @@ def _build_1kn_lre() -> tuple[motors.LiquidEngine, InternalBallisticsSimulationP
         d_t=1e-4,
         igniter_pressure=1e6,
         external_pressure=1e5,
-        other_losses=12.0,
+        other_losses=0.12,
     )
     return motor, params
 

--- a/tests/test_simulations/test_solid_motor_simulation.py
+++ b/tests/test_simulations/test_solid_motor_simulation.py
@@ -68,7 +68,7 @@ def _build_apcp_motor() -> tuple[motors.SolidMotor, InternalBallisticsSimulation
         d_t=0.01,
         igniter_pressure=1e6,
         external_pressure=1e5,
-        other_losses=12.0,
+        other_losses=0.12,
     )
     return motor, params
 
@@ -115,7 +115,7 @@ def _build_kappa_rnakka_motor() -> tuple[
         d_t=0.001,
         igniter_pressure=1e6,
         external_pressure=1e5,
-        other_losses=12.0,
+        other_losses=0.12,
     )
     return motor, params
 
@@ -160,7 +160,7 @@ def _build_nero_motor() -> tuple[motors.SolidMotor, InternalBallisticsSimulation
         d_t=0.01,
         igniter_pressure=1e6,
         external_pressure=1e5,
-        other_losses=12.0,
+        other_losses=0.12,
     )
     return motor, params
 


### PR DESCRIPTION
Closes #170.

## Summary
- Renames `get_X_percentage_loss` → `get_X_loss_fraction` in `machwave.core.compressible_flow.losses`, with each function dividing by 100 at the source so all losses are fractions in `[0, 1]`.
- `get_overall_nozzle_efficiency` now consumes fractions directly (no more `/100`); bounds and typical ranges in `losses.py` are expressed as fractions.
- `InternalBallisticsSimulationParams.other_losses` default is `0.12` (fraction) rather than `12.0` (percent); the docstring spells out the convention.
- `Motor.get_thrust_coefficient_correction_factor` and the `LiquidEngine.get_thrust_coefficient` `other_losses` argument are now fractions.
- All call sites in `states/`, all examples, and all tests are migrated. `SolidMotorState.print_results` uses `:.3%` formatting now that losses are fractions.
- Module-level docstring in `losses.py` documents the convention so the next person doesn't have to reverse-engineer it.

## Test plan
- [x] `pytest` (566 passed)