### PR TITLE
Simplify thrust_coefficient_plot subplot construction

### DIFF
--- a/machwave/services/plots/internal_ballistics.py
+++ b/machwave/services/plots/internal_ballistics.py
@@ -174,35 +174,26 @@ def thrust_coefficient_plot(
     Returns:
         Plotly Figure.
     """
-    if show_efficiency:
-        fig = plotly.subplots.make_subplots(specs=[[{"secondary_y": True}]])
-    else:
-        fig = go.Figure()
+    fig = plotly.subplots.make_subplots(specs=[[{"secondary_y": True}]])
 
-    (
-        fig.add_trace
-        if not show_efficiency
-        else lambda *a, **k: fig.add_trace(*a, **k, secondary_y=False)
-    )(
+    fig.add_trace(
         go.Scatter(
             x=time,
             y=thrust_coefficient_ideal,
             mode="lines",
             name="Cf (ideal)",
-        )
+        ),
+        secondary_y=False,
     )
 
-    (
-        fig.add_trace
-        if not show_efficiency
-        else lambda *a, **k: fig.add_trace(*a, **k, secondary_y=False)
-    )(
+    fig.add_trace(
         go.Scatter(
             x=time,
             y=thrust_coefficient_real,
             mode="lines",
             name="Cf (real)",
-        )
+        ),
+        secondary_y=False,
     )
 
     if show_efficiency:

--- a/tests/test_services/test_internal_ballistics_plots.py
+++ b/tests/test_services/test_internal_ballistics_plots.py
@@ -1,0 +1,58 @@
+"""Tests for plotting helpers in machwave.services.plots.internal_ballistics."""
+
+import numpy as np
+import plotly.graph_objects as go
+
+from machwave.services.plots.internal_ballistics import thrust_coefficient_plot
+
+
+class TestThrustCoefficientPlot:
+    """Test the thrust_coefficient_plot helper."""
+
+    def test_returns_figure_with_efficiency(self):
+        """With show_efficiency=True, the figure has Cf_ideal, Cf_real, and η."""
+        time = np.linspace(0, 1.0, 10)
+        cf_ideal = np.linspace(1.5, 1.6, 10)
+        cf_real = np.linspace(1.4, 1.5, 10)
+
+        fig = thrust_coefficient_plot(time, cf_ideal, cf_real, show_efficiency=True)
+
+        assert isinstance(fig, go.Figure)
+        trace_names = [trace.name for trace in fig.data]
+        assert trace_names == ["Cf (ideal)", "Cf (real)", "η = Cf_real / Cf_ideal"]
+
+        # The η trace should be on the secondary y-axis (yaxis2);
+        # the Cf traces should remain on the primary y-axis.
+        cf_ideal_trace, cf_real_trace, eta_trace = fig.data
+        assert cf_ideal_trace.yaxis == "y"
+        assert cf_real_trace.yaxis == "y"
+        assert eta_trace.yaxis == "y2"
+
+        np.testing.assert_allclose(eta_trace.y, cf_real / cf_ideal)
+
+    def test_returns_figure_without_efficiency(self):
+        """With show_efficiency=False, only the Cf traces are present."""
+        time = np.linspace(0, 1.0, 10)
+        cf_ideal = np.linspace(1.5, 1.6, 10)
+        cf_real = np.linspace(1.4, 1.5, 10)
+
+        fig = thrust_coefficient_plot(time, cf_ideal, cf_real, show_efficiency=False)
+
+        assert isinstance(fig, go.Figure)
+        trace_names = [trace.name for trace in fig.data]
+        assert trace_names == ["Cf (ideal)", "Cf (real)"]
+
+        for trace in fig.data:
+            assert trace.yaxis == "y"
+
+    def test_efficiency_handles_zero_ideal_cf(self):
+        """Division-by-zero in η is masked to NaN rather than raising."""
+        time = np.array([0.0, 0.5, 1.0])
+        cf_ideal = np.array([0.0, 1.5, 1.6])
+        cf_real = np.array([0.0, 1.4, 1.5])
+
+        fig = thrust_coefficient_plot(time, cf_ideal, cf_real, show_efficiency=True)
+
+        eta_trace = fig.data[2]
+        assert np.isnan(eta_trace.y[0])
+        np.testing.assert_allclose(eta_trace.y[1:], cf_real[1:] / cf_ideal[1:])


### PR DESCRIPTION
## Summary
- Always build the figure with `make_subplots(specs=[[{"secondary_y": True}]])` and add the Cf traces with explicit `secondary_y=False`, replacing the conditional-lambda pattern at `internal_ballistics.py:182-222`.
- The `show_efficiency=False` case still works — the secondary y-axis simply stays empty.
- Side note: the original `show_efficiency=False` path was actually broken — `fig.update_yaxes(..., secondary_y=False)` raised `Exception: In order to reference traces by row and column, you must first use plotly.tools.make_subplots ...` on a plain `go.Figure`. This refactor fixes that latent bug.

Closes #177

## Test plan
- [x] Render `thrust_coefficient_plot` with `show_efficiency=True` and confirm η appears on the secondary axis. — 3 traces (Cf ideal, Cf real on `y`; η on `y2`); `yaxis2` titled "Efficiency η [-]".
- [x] Render `thrust_coefficient_plot` with `show_efficiency=False` and confirm only the Cf traces appear and the layout is unchanged from before. — 2 traces both on `y`; layout/x-axis/y-axis titles match the `True` case; secondary y-axis stays empty.
- [x] Unit tests added in `tests/test_services/test_internal_ballistics_plots.py` cover both branches plus divide-by-zero handling for η.