### PR TITLE
Fix StackedTankPressureFedFeedSystem fuel tank pressure (#133)

### DIFF
--- a/machwave/models/feed_systems/pressure_fed.py
+++ b/machwave/models/feed_systems/pressure_fed.py
@@ -114,6 +114,10 @@ class StackedTankPressureFedFeedSystem(FeedSystem):
 
     def get_fuel_tank_pressure(self) -> float:
         """
-        Returns the tank pressure [Pa].
+        Returns the fuel-side upstream pressure [Pa].
+
+        In a stacked-tank system the fuel is pressurized by the oxidizer
+        through the piston, so the fuel-side pressure is the oxidizer tank
+        pressure minus the piston pressure loss.
         """
-        return self.fuel_tank.get_pressure()
+        return self.get_oxidizer_tank_pressure() - self.piston_loss

--- a/machwave/states/liquid_engine.py
+++ b/machwave/states/liquid_engine.py
@@ -62,10 +62,10 @@ class LiquidEngineState(MotorState):
         self.nozzle_correction_factor: SimulationArray = [1.0]
 
         self.fuel_tank_pressure: SimulationArray = [
-            motor.feed_system.fuel_tank.get_pressure()
+            motor.feed_system.get_fuel_tank_pressure()
         ]
         self.oxidizer_tank_pressure: SimulationArray = [
-            motor.feed_system.oxidizer_tank.get_pressure()
+            motor.feed_system.get_oxidizer_tank_pressure()
         ]
 
     def get_m_dot_in(self) -> float:


### PR DESCRIPTION
## Summary
- Closes #133.
- `StackedTankPressureFedFeedSystem.get_fuel_tank_pressure` now returns the fuel-side upstream pressure (`oxidizer_tank_pressure − piston_loss`) instead of the fuel fluid's saturation pressure.
- `LiquidEngineState` now seeds the initial `fuel_tank_pressure` / `oxidizer_tank_pressure` samples through the feed system instead of reading the tanks directly, so t=0 matches the rest of the trace (was previously the only sample still showing the old saturation-pressure value).
- Mass-flow calculation already used the correct upstream pressure, so this only affects the plotted/recorded `fuel_tank_pressure` trace.

## Test plan
- [x] `pytest tests/test_simulations/test_liquid_engine_simulation.py tests/test_models/test_propulsion/test_motors/test_cog.py` — 13/13 pass.
- [x] Re-ran the 1 kN example: across all 35 820 samples, `oxidizer_tank_pressure − fuel_tank_pressure == piston_loss` (= 0.1 MPa) exactly, including t=0. Fuel pressure trace now sits at ~5.78 MPa instead of ~9 kPa.