### PR TITLE
Parametrize throat discharge coefficient on Nozzle

### DIFF
--- a/machwave/models/thrust_chamber/nozzle.py
+++ b/machwave/models/thrust_chamber/nozzle.py
@@ -13,6 +13,7 @@ class Nozzle:
         expansion_ratio,
         c_1: float = 0.00506,
         c_2: float = 0.0,
+        discharge_coefficient: float = 1.0,
     ) -> None:
         self.inlet_diameter = inlet_diameter
         self.throat_diameter = throat_diameter
@@ -27,6 +28,7 @@ class Nozzle:
         # Thick-walled solid steel nozzle: c_1 = 0.005060, c_2 = 0.000000
         self.c_1 = c_1
         self.c_2 = c_2
+        self.discharge_coefficient = discharge_coefficient
 
     @property
     def outlet_diameter(self):

--- a/machwave/states/liquid_engine.py
+++ b/machwave/states/liquid_engine.py
@@ -146,6 +146,7 @@ class LiquidEngineState(MotorState):
             k=props.k_chamber,
             R=props.R_chamber,
             flame_temperature=props.adiabatic_flame_temperature,
+            discharge_coefficient=nz.discharge_coefficient,
         )[0]
         self.chamber_pressure.append(new_chamber_pressure)
         exit_pressure = get_exit_pressure(

--- a/machwave/states/solid_motor.py
+++ b/machwave/states/solid_motor.py
@@ -151,6 +151,7 @@ class SolidMotorState(states_base.MotorState):
             k=propellant_properties.k_chamber,
             R=propellant_properties.R_chamber,
             flame_temperature=propellant_properties.adiabatic_flame_temperature,
+            discharge_coefficient=nozzle.discharge_coefficient,
         )[0]
         self.chamber_pressure.append(new_chamber_pressure)
         self.exit_pressure.append(

--- a/tests/test_models/test_propulsion/test_nozzle.py
+++ b/tests/test_models/test_propulsion/test_nozzle.py
@@ -79,3 +79,19 @@ class TestNozzleGeometry:
         n = Nozzle(50.8e-3, 25.4e-3, 15, 45, 4, c_1=0.003650, c_2=0.000937)
         assert n.c_1 == pytest.approx(0.003650, rel=1e-3)
         assert n.c_2 == pytest.approx(0.000937, rel=1e-3)
+
+    def test_default_discharge_coefficient(self, nozzle):
+        """Throat discharge coefficient defaults to 1.0 (ideal nozzle)."""
+        assert nozzle.discharge_coefficient == pytest.approx(1.0, rel=1e-9)
+
+    def test_custom_discharge_coefficient(self):
+        """Throat discharge coefficient can be overridden."""
+        n = Nozzle(
+            inlet_diameter=50.8e-3,
+            throat_diameter=25.4e-3,
+            divergent_angle=15,
+            convergent_angle=45,
+            expansion_ratio=4,
+            discharge_coefficient=0.95,
+        )
+        assert n.discharge_coefficient == pytest.approx(0.95, rel=1e-9)


### PR DESCRIPTION
## Summary
- Adds a `discharge_coefficient: float = 1.0` field to the shared `Nozzle` model.
- Threads `nozzle.discharge_coefficient` through to `compute_chamber_pressure_mass_balance` from both the Solid Rocket Motor and Liquid Rocket Engine state classes; previously both relied on the helper's 1.0 default.

## Why
The issue framed this as "Solid Rocket Motor exposes a throat discharge coefficient; Liquid Rocket Engine hard-codes 1," but in fact neither side passed one — both defaulted to 1.0 in `compute_chamber_pressure_mass_balance`. Adding the field on the shared `Nozzle` resolves the Liquid Rocket Engine gap and keeps the two motor types symmetric without an extra Liquid Rocket Engine-specific argument.

## Test plan
- [x] `pytest tests/test_models/test_propulsion/test_nozzle.py` (new default + override assertions)
- [x] `pytest tests/test_simulations/test_liquid_engine_simulation.py tests/test_simulations/test_solid_motor_simulation.py` (existing end-to-end ballistics simulations still pass with the default of 1.0)

Closes #138.