### PR TITLE
Add GitHub issue/PR templates and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @felipebogaertsm

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+---
+name: Bug report
+about: Report a defect in Machwave
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Description
+
+A clear description of what the bug is.
+
+## Reproduction steps
+
+Minimal steps to reproduce the behaviour. A short Python snippet is ideal:
+
+```python
+# paste minimal repro here
+```
+
+## Expected behaviour
+
+What you expected to happen.
+
+## Actual behaviour
+
+What actually happened. Include the full traceback if there is one.
+
+## Simulation context
+
+If the bug surfaces in a simulation, please describe what was being modelled:
+
+- Engine type: solid motor / liquid engine / hybrid / other
+- Feed system (if liquid): pressure-fed / pump-fed / stacked tank / other
+- Grain geometry (if solid): BATES / star / finocyl / custom / other
+- Propellant: name or composition
+- Relevant simulation parameters: time step, chamber pressure, mixture ratio, etc.
+
+## Environment
+
+- Machwave version: (output of `python -c "import machwave; print(machwave.__version__)"`)
+- Python version:
+- Operating system and version:
+- Installation method: `pip install machwave` / editable install from source / other
+
+## Additional context
+
+Logs, screenshots, plots, or links that help diagnose the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Suggest a new capability or enhancement for Machwave
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+What is the user-facing problem or limitation? Who runs into it and when?
+
+## Proposed solution
+
+What you would like Machwave to do. Sketch the public API or workflow if you can.
+
+## Scope
+
+What is in scope for this request, and what is explicitly out of scope? This
+helps keep the resulting pull request focused.
+
+## Alternatives considered
+
+Other approaches you thought about, and why the proposed solution is preferable.
+
+## Additional context
+
+References to papers, textbooks, similar tools, or prior issues that motivate
+the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+A short description of what this pull request changes and why.
+
+## Linked issue
+
+Closes #
+
+## Test plan
+
+- [ ] `make check` passes (format, lint, typecheck)
+- [ ] `make test` passes
+- [ ] New or updated tests cover the change
+- [ ] Manual verification steps (describe below, if any)
+
+## Documentation
+
+- [ ] Public API or user-facing behaviour is documented in `docs/` or docstrings
+- [ ] Not applicable (internal change only)
+
+## Additional notes
+
+Anything reviewers should pay particular attention to: tradeoffs, follow-ups,
+or context that is not obvious from the diff.


### PR DESCRIPTION
## Summary
- Add bug report and feature request issue templates under `.github/ISSUE_TEMPLATE/`
- Add `.github/PULL_REQUEST_TEMPLATE.md` with summary, linked issue, test plan, and documentation sections
- Add `.github/CODEOWNERS` routing all paths to @felipebogaertsm so pull requests automatically request review

Closes #163.

## Test plan
- [x] Open a draft issue from each template and confirm the form renders
- [x] Open a draft pull request and confirm the template prefills
- [x] Confirm CODEOWNERS auto-requests review on a follow-up pull request