### PR TITLE
172: Re-export common namespaces at machwave top level

### DIFF
--- a/docs/api/adapters/rocketpy.md
+++ b/docs/api/adapters/rocketpy.md
@@ -25,19 +25,20 @@ The adapter sits after the internal ballistics simulation:
 ## Example
 
 ```python
-from machwave import simulation
+from machwave import (
+    formulations,
+    grain as grain_models,
+    motors,
+    simulation,
+    thrust_chamber as thrust_chamber_models,
+)
 from machwave.adapters.rocketpy import RocketPySolidMotorAdapter
-from machwave.models import grain as grain_models
-from machwave.models import motors
-from machwave.models import thrust_chamber as thrust_chamber_models
-from machwave.models.grain import geometries as grain_geometries
-from machwave.models.propellants.formulations import solid as solid_propellants
 from rocketpy import Environment, Flight, Rocket
 
-propellant = solid_propellants.KNSB_NAKKA
+propellant = formulations.solid.KNSB_NAKKA
 
 grain = grain_models.Grain(spacing=0.01)
-segment = grain_geometries.BatesSegment(
+segment = grain_models.geometries.BatesSegment(
 	outer_diameter=0.085,
 	core_diameter=0.035,
 	length=0.150,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,11 +9,9 @@ Machwave ships with several pre-defined solid propellant formulations. Here we
 use KNDX (potassium nitrate / dextrose):
 
 ```python
-from machwave.models.propellants.formulations import (
-    solid as solid_propellants,
-)
+from machwave import formulations
 
-propellant = solid_propellants.KNDX
+propellant = formulations.solid.KNDX
 ```
 
 For a full list of available solid propellants, see the
@@ -24,12 +22,11 @@ For a full list of available solid propellants, see the
 Create a `Grain` and add one or more segments.
 
 ```python
-from machwave.models import grain as grain_models
-from machwave.models.grain import geometries as grain_geometries
+from machwave import grain as grain_models
 
 grain = grain_models.Grain(spacing=10e-3)  # 10 mm spacing between segments
 
-bates_segment = grain_geometries.BatesSegment(
+bates_segment = grain_models.geometries.BatesSegment(
     outer_diameter=41e-3,   # 41 mm
     core_diameter=15e-3,    # 15 mm
     length=67.5e-3,         # 67.5 mm
@@ -44,7 +41,7 @@ for _ in range(4):
 The thrust chamber is composed of a **nozzle** and a **combustion chamber**:
 
 ```python
-from machwave.models import thrust_chamber as thrust_chamber_models
+from machwave import thrust_chamber as thrust_chamber_models
 
 nozzle = thrust_chamber_models.Nozzle(
     inlet_diameter=43e-3,
@@ -74,7 +71,7 @@ thrust_chamber = thrust_chamber_models.SolidMotorThrustChamber(
 Combine the grain, propellant, and thrust chamber into a `SolidMotor`:
 
 ```python
-from machwave.models import motors
+from machwave import motors
 
 motor = motors.SolidMotor(
     grain=grain,

--- a/examples/1kn_lre.py
+++ b/examples/1kn_lre.py
@@ -2,8 +2,12 @@
 Sample 1kN biliquid rocket engine, similar to HalfCat's Sphinx.
 """
 
-from machwave.models import feed_systems, motors, propellants
-from machwave.models import thrust_chamber as thrust_chamber_models
+from machwave import (
+    feed_systems,
+    motors,
+    propellants,
+    thrust_chamber as thrust_chamber_models,
+)
 from machwave.models.feed_systems import tanks
 from machwave.services.plots.internal_ballistics import (
     plot_bipropellant_tank_profiles,

--- a/examples/apcp_motor.py
+++ b/examples/apcp_motor.py
@@ -4,24 +4,23 @@ an InternalBallisticsCoupled simulation that includes both
 internal ballistics and atmospheric flight.
 """
 
-from machwave.common.decorators import timing
-from machwave.models import grain as grain_models
-from machwave.models import motors
-from machwave.models import thrust_chamber as thrust_chamber_models
-from machwave.models.grain import geometries as grain_geometries
-from machwave.models.propellants.formulations import (
-    solid as solid_propellants,
+from machwave import (
+    formulations,
+    grain as grain_models,
+    motors,
+    simulation,
+    thrust_chamber as thrust_chamber_models,
 )
+from machwave.common.decorators import timing
 from machwave.services.plots import internal_ballistics as internal_ballistics_plots
-from machwave import simulation
 
 
 @timing
 def main():
-    propellant = solid_propellants.MIT_CHERRY_LIMEADE
+    propellant = formulations.solid.MIT_CHERRY_LIMEADE
 
     grain = grain_models.Grain(spacing=0.01)
-    bates_segment = grain_geometries.BatesSegment(
+    bates_segment = grain_models.geometries.BatesSegment(
         outer_diameter=0.085,
         core_diameter=0.035,
         length=0.150,

--- a/examples/kappa_rnakka.py
+++ b/examples/kappa_rnakka.py
@@ -3,24 +3,23 @@ Example for the Kappa motor, developed by Richard Nakka.
 https://www.nakka-rocketry.net/kappa.html
 """
 
-from machwave.common.decorators import timing
-from machwave.models import grain as grain_models
-from machwave.models import motors
-from machwave.models import thrust_chamber as thrust_chamber_models
-from machwave.models.grain import geometries as grain_geometries
-from machwave.models.propellants.formulations import (
-    solid as solid_propellants,
+from machwave import (
+    formulations,
+    grain as grain_models,
+    motors,
+    simulation,
+    thrust_chamber as thrust_chamber_models,
 )
+from machwave.common.decorators import timing
 from machwave.services.plots import internal_ballistics as internal_ballistics_plots
-from machwave import simulation
 
 
 @timing
 def main():
-    propellant = solid_propellants.KNDX
+    propellant = formulations.solid.KNDX
 
     grain = grain_models.Grain(spacing=5e-3)
-    bates_segment = grain_geometries.BatesSegment(
+    bates_segment = grain_models.geometries.BatesSegment(
         outer_diameter=55e-3,
         core_diameter=19e-3,
         length=101.6e-3,

--- a/examples/nero_motor.py
+++ b/examples/nero_motor.py
@@ -4,24 +4,23 @@ Supernova Rocketry UFJF in 2019. It is a class J KNDX motor with a
 maximum operating pressure of 7 MPa.
 """
 
-from machwave.common.decorators import timing
-from machwave.models import grain as grain_models
-from machwave.models import motors
-from machwave.models import thrust_chamber as thrust_chamber_models
-from machwave.models.grain import geometries as grain_geometries
-from machwave.models.propellants.formulations import (
-    solid as solid_propellants,
+from machwave import (
+    formulations,
+    grain as grain_models,
+    motors,
+    simulation,
+    thrust_chamber as thrust_chamber_models,
 )
+from machwave.common.decorators import timing
 from machwave.services.plots import internal_ballistics as internal_ballistics_plots
-from machwave import simulation
 
 
 @timing
 def main():
-    propellant = solid_propellants.KNDX
+    propellant = formulations.solid.KNDX
 
     grain = grain_models.Grain(spacing=10e-3)
-    bates_segment = grain_geometries.BatesSegment(
+    bates_segment = grain_models.geometries.BatesSegment(
         outer_diameter=41e-3,
         core_diameter=15e-3,
         length=67.5e-3,

--- a/examples/olympus.py
+++ b/examples/olympus.py
@@ -5,30 +5,29 @@ never used in flight. The motor was successfully tested on July 2, 2022, and
 at the time, it was the largest experimental motor ever built in Latin America.
 """
 
-from machwave.common.decorators import timing
-from machwave.models import grain as grain_models
-from machwave.models import motors
-from machwave.models import thrust_chamber as thrust_chamber_models
-from machwave.models.grain import geometries as grain_geometries
-from machwave.models.propellants.formulations import (
-    solid as solid_propellants,
+from machwave import (
+    formulations,
+    grain as grain_models,
+    motors,
+    simulation,
+    thrust_chamber as thrust_chamber_models,
 )
+from machwave.common.decorators import timing
 from machwave.services.plots import internal_ballistics as internal_ballistics_plots
-from machwave import simulation
 
 
 @timing
 def main():
-    propellant = solid_propellants.KNSB_NAKKA
+    propellant = formulations.solid.KNSB_NAKKA
 
     grain = grain_models.Grain()
-    bates_segment_45 = grain_geometries.BatesSegment(
+    bates_segment_45 = grain_models.geometries.BatesSegment(
         outer_diameter=0.116,
         core_diameter=0.045,
         length=0.200,
         spacing=0.01,
     )
-    bates_segment_60 = grain_geometries.BatesSegment(
+    bates_segment_60 = grain_models.geometries.BatesSegment(
         outer_diameter=0.116,
         core_diameter=0.060,
         length=0.200,

--- a/examples/olympus_montecarlo.py
+++ b/examples/olympus_montecarlo.py
@@ -1,25 +1,24 @@
-from machwave import montecarlo
-from machwave.common.decorators import timing
-from machwave.models import grain as grain_models
-from machwave.models import motors
-from machwave.models import thrust_chamber as thrust_chamber_models
-from machwave.models.grain import geometries as grain_geometries
-from machwave.models.propellants.formulations import (
-    solid as solid_propellants,
+from machwave import (
+    formulations,
+    grain as grain_models,
+    montecarlo,
+    motors,
+    simulation,
+    thrust_chamber as thrust_chamber_models,
 )
-from machwave import simulation
+from machwave.common.decorators import timing
 
 MC_SAMPLES = 1000
 
 
 @timing
 def main():
-    propellant = solid_propellants.KNSB_NAKKA
+    propellant = formulations.solid.KNSB_NAKKA
 
     grain = grain_models.Grain()
     for _ in range(4):
         grain.add_segment(
-            grain_geometries.BatesSegment(
+            grain_models.geometries.BatesSegment(
                 outer_diameter=montecarlo.MonteCarloParameter(0.115, spread=0.002),
                 core_diameter=montecarlo.MonteCarloParameter(0.045, spread=0.002),
                 length=montecarlo.MonteCarloParameter(0.200, spread=0.005),
@@ -28,7 +27,7 @@ def main():
         )
     for _ in range(3):
         grain.add_segment(
-            grain_geometries.BatesSegment(
+            grain_models.geometries.BatesSegment(
                 outer_diameter=montecarlo.MonteCarloParameter(0.115, spread=0.002),
                 core_diameter=montecarlo.MonteCarloParameter(0.060, spread=0.002),
                 length=montecarlo.MonteCarloParameter(0.200, spread=0.005),

--- a/examples/rocketpy_srm_simulation.py
+++ b/examples/rocketpy_srm_simulation.py
@@ -8,16 +8,15 @@ This example demonstrates how to:
 3. Run a complete 6DOF flight simulation using RocketPy
 """
 
+from machwave import (
+    formulations,
+    grain as grain_models,
+    motors,
+    simulation,
+    thrust_chamber as thrust_chamber_models,
+)
 from machwave.adapters.rocketpy import RocketPySolidMotorAdapter
 from machwave.common import decorators
-from machwave.models import grain as grain_models
-from machwave.models import motors
-from machwave.models import thrust_chamber as thrust_chamber_models
-from machwave.models.grain import geometries as grain_geometries
-from machwave.models.propellants.formulations import (
-    solid as solid_propellants,
-)
-from machwave import simulation
 from rocketpy import Environment, Flight, Rocket
 
 
@@ -26,10 +25,10 @@ def main():
     # ============================================================================
     # 1. MOTOR SETUP
     # ============================================================================
-    propellant = solid_propellants.KNSB_NAKKA
+    propellant = formulations.solid.KNSB_NAKKA
 
     grain = grain_models.Grain(spacing=0.01)
-    bates_segment = grain_geometries.BatesSegment(
+    bates_segment = grain_models.geometries.BatesSegment(
         outer_diameter=0.085,
         core_diameter=0.035,
         length=0.150,

--- a/machwave/__init__.py
+++ b/machwave/__init__.py
@@ -1,3 +1,22 @@
+from machwave import simulation
 from machwave._version import __version__, __version_tuple__
+from machwave.models import (
+    feed_systems,
+    grain,
+    motors,
+    propellants,
+    thrust_chamber,
+)
+from machwave.models.propellants import formulations
 
-__all__ = ["__version__", "__version_tuple__"]
+__all__ = [
+    "__version__",
+    "__version_tuple__",
+    "feed_systems",
+    "formulations",
+    "grain",
+    "motors",
+    "propellants",
+    "simulation",
+    "thrust_chamber",
+]

--- a/machwave/models/grain/__init__.py
+++ b/machwave/models/grain/__init__.py
@@ -6,6 +6,7 @@ from machwave.models.grain.base import (
     GrainSegment3D,
     InhibitedSurfaces,
 )
+from machwave.models.grain import geometries  # noqa: E402  (must follow base; geometries pulls names from .base)
 
 __all__ = [
     "GrainGeometryError",
@@ -14,4 +15,5 @@ __all__ = [
     "GrainSegment2D",
     "GrainSegment3D",
     "InhibitedSurfaces",
+    "geometries",
 ]

--- a/machwave/models/propellants/formulations/__init__.py
+++ b/machwave/models/propellants/formulations/__init__.py
@@ -1,3 +1,4 @@
+from . import biliquid, solid
 from .base import get_propellant_from_json
 
-__all__ = ["get_propellant_from_json"]
+__all__ = ["biliquid", "get_propellant_from_json", "solid"]

--- a/tests/test_public_api_exports.py
+++ b/tests/test_public_api_exports.py
@@ -1,0 +1,40 @@
+"""
+Locks the top-level ``machwave`` namespace re-exports introduced for issue #172.
+
+These re-exports are user-facing API; if a deep path is renamed or moved, the
+top-level binding must follow.
+"""
+
+import machwave
+import machwave.models.feed_systems
+import machwave.models.grain
+import machwave.models.grain.geometries
+import machwave.models.motors
+import machwave.models.propellants
+import machwave.models.propellants.formulations
+import machwave.models.propellants.formulations.biliquid
+import machwave.models.propellants.formulations.solid
+import machwave.models.thrust_chamber
+import machwave.simulation
+
+
+def test_top_level_namespaces_are_canonical_modules():
+    assert machwave.feed_systems is machwave.models.feed_systems
+    assert machwave.formulations is machwave.models.propellants.formulations
+    assert machwave.grain is machwave.models.grain
+    assert machwave.motors is machwave.models.motors
+    assert machwave.propellants is machwave.models.propellants
+    assert machwave.simulation is machwave.simulation
+    assert machwave.thrust_chamber is machwave.models.thrust_chamber
+
+
+def test_grain_exposes_geometries_subnamespace():
+    assert machwave.grain.geometries is machwave.models.grain.geometries
+
+
+def test_formulations_exposes_solid_and_biliquid():
+    assert machwave.formulations.solid is machwave.models.propellants.formulations.solid
+    assert (
+        machwave.formulations.biliquid
+        is machwave.models.propellants.formulations.biliquid
+    )


### PR DESCRIPTION
## Summary

Re-exports `machwave` modules that are generally useful for the end-user. These are the so called public API. The end user still has access to all the other modules, but quicker access to what he will probably use the most.

## Linked issue

Closes #172 

## Test plan

- [x] `make check` passes (format, lint, typecheck)
- [x] `make test` passes
- [x] New or updated tests cover the change
- [x] Check re-exports auto-complete in the IDE

## Documentation

- [x] Public API or user-facing behaviour is documented in `docs/` or docstrings
- [x] Not applicable (internal change only)

## Additional notes

The public API needs to be expanded or changed with user feedback and new features.
