### PR TITLE
244: Removed contours functions from geometric to new module inside fmm

### DIFF
--- a/machwave/core/geometric.py
+++ b/machwave/core/geometric.py
@@ -1,5 +1,4 @@
 import numpy as np
-from skimage import measure
 
 
 def get_circle_area(diameter: float) -> float:
@@ -70,46 +69,3 @@ def get_cylinder_volume(diameter: float, length: float) -> float:
         The volume of the cylinder.
     """
     return np.pi * length * (diameter**2) / 4
-
-
-def get_contours(
-    map: np.typing.NDArray[np.float64], map_dist: float, *args, **kwargs
-) -> list[np.typing.NDArray[np.float64]]:
-    """
-    Finds contours in a 2D array at a specified iso-value (map_dist).
-
-    Args:
-        map: The 2D NumPy array (float64) from which to extract contours.
-        map_dist: The iso-value level at which to trace contours.
-        *args: Additional positional arguments passed to skimage.measure.find_contours.
-        **kwargs: Additional keyword arguments passed to skimage.measure.find_contours.
-
-    Returns:
-        A list of float64 arrays, where each array represents a contour.
-        Each contour array is typically shaped (N, 2) with (row, col) coordinates.
-    """
-    return measure.find_contours(map, map_dist, fully_connected="low", *args, **kwargs)
-
-
-def get_length(contour: np.ndarray, map_size: int, tolerance: float = 3.0) -> float:
-    """
-    Returns the total length of all segments in a contour that aren't within
-    'tolerance' of the edge of a circle with diameter 'map_size'.
-
-    Args:
-        contour: The contour array.
-        map_size: The size of the map.
-        tolerance: The tolerance value. Defaults to 3.0.
-
-    Returns:
-        The total length of the segments.
-    """
-    offset = np.roll(contour.T, 1, axis=1)
-    lengths = np.linalg.norm(contour.T - offset, axis=0)
-
-    center_offset = np.array([[map_size / 2, map_size / 2]])
-    radius = np.linalg.norm(contour - center_offset, axis=1)
-
-    valid = radius < (map_size / 2) - tolerance
-
-    return np.sum(lengths[valid])

--- a/machwave/models/grain/fmm/_2d.py
+++ b/machwave/models/grain/fmm/_2d.py
@@ -6,11 +6,7 @@ from numpy.typing import NDArray
 from scipy.interpolate import interp1d
 from scipy.signal import savgol_filter
 
-from machwave.core.geometric import (
-    get_circle_area,
-    get_contours,
-    get_length,
-)
+from machwave.core.geometric import get_circle_area
 from machwave.core.mechanics import (
     get_center_of_gravity,
     get_moment_of_inertia_tensor,
@@ -19,6 +15,7 @@ from machwave.models.grain import GrainGeometryError, GrainSegment2D
 from machwave.models.grain.base import InhibitedSurfaces
 
 from .base import FMMGrainSegment
+from .contours import get_contours, get_length
 
 
 class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
@@ -86,7 +83,6 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
         Return a list of contour arrays for the given web distance.
         Each contour is typically an (N,2) array of (row, col) points.
         """
-        # get_contours is imported from machwave.core.math.geometric
         map_dist = self.normalize(web_distance)
         return get_contours(self.get_regression_map(), map_dist)
 

--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -5,11 +5,7 @@ import numpy as np
 from numpy.typing import NDArray
 from scipy.interpolate import interp1d
 
-from machwave.core.geometric import (
-    get_circle_area,
-    get_contours,
-    get_length,
-)
+from machwave.core.geometric import get_circle_area
 from machwave.core.mechanics import (
     get_center_of_gravity,
     get_moment_of_inertia_tensor,
@@ -18,6 +14,7 @@ from machwave.models.grain import GrainGeometryError, GrainSegment3D
 from machwave.models.grain.base import InhibitedSurfaces
 
 from .base import FMMGrainSegment
+from .contours import get_contours, get_length
 
 
 class FMMGrainSegment3D(FMMGrainSegment, GrainSegment3D, ABC):

--- a/machwave/models/grain/fmm/contours.py
+++ b/machwave/models/grain/fmm/contours.py
@@ -1,0 +1,45 @@
+import numpy as np
+from skimage import measure
+
+
+def get_contours(
+    map: np.typing.NDArray[np.float64], map_dist: float, *args, **kwargs
+) -> list[np.typing.NDArray[np.float64]]:
+    """
+    Finds contours in a 2D array at a specified iso-value (map_dist).
+
+    Args:
+        map: The 2D NumPy array (float64) from which to extract contours.
+        map_dist: The iso-value level at which to trace contours.
+        *args: Additional positional arguments passed to skimage.measure.find_contours.
+        **kwargs: Additional keyword arguments passed to skimage.measure.find_contours.
+
+    Returns:
+        A list of float64 arrays, where each array represents a contour.
+        Each contour array is typically shaped (N, 2) with (row, col) coordinates.
+    """
+    return measure.find_contours(map, map_dist, fully_connected="low", *args, **kwargs)
+
+
+def get_length(contour: np.ndarray, map_size: int, tolerance: float = 3.0) -> float:
+    """
+    Returns the total length of all segments in a contour that aren't within
+    'tolerance' of the edge of a circle with diameter 'map_size'.
+
+    Args:
+        contour: The contour array.
+        map_size: The size of the map.
+        tolerance: The tolerance value. Defaults to 3.0.
+
+    Returns:
+        The total length of the segments.
+    """
+    offset = np.roll(contour.T, 1, axis=1)
+    lengths = np.linalg.norm(contour.T - offset, axis=0)
+
+    center_offset = np.array([[map_size / 2, map_size / 2]])
+    radius = np.linalg.norm(contour - center_offset, axis=1)
+
+    valid = radius < (map_size / 2) - tolerance
+
+    return np.sum(lengths[valid])


### PR DESCRIPTION
## Summary

Moved the 2 functions related to contours from `machwave.core.geometric` to `machwave.models.grain.fmm.contours`. Updated the imports.

## Linked issue

Closes #244 

## Test plan

- [x] `make check` passes (format, lint, typecheck)
- [x] `make test` passes

## Documentation

- [x] Public API or user-facing behaviour is documented in `docs/` or docstrings
- [x] Not applicable (internal change only)

## Additional notes

-
