### PR TITLE
221: Use live oxidizer-to-fuel ratio in BiliquidPropellant evaluation

### DIFF
--- a/docs/api/models/propellants/categories.md
+++ b/docs/api/models/propellants/categories.md
@@ -5,6 +5,6 @@ Propellant type classes.
 - `SolidPropellant` — Defined by component mass fractions, pre-computed or CEA-evaluated thermochemical properties, and a `burn_rate_map` encoding St. Robert’s law coefficients ($r = a \cdot P_0^n$) across pressure ranges. Call `get_burn_rate(P_0)` to obtain instantaneous regression rate.
 - `BiliquidPropellant` — Defined by exactly two components (oxidizer + fuel) and an O/F mass ratio. Thermochemical properties are evaluated at the specified O/F.
 
-Both extend the `Propellant` base class and implement `evaluate(chamber_pressure, expansion_ratio)` to return a `ThermochemicalProperties` dataclass.
+Both extend the `Propellant` base class and implement `evaluate(chamber_pressure, expansion_ratio, mixture_ratio=None)` to return a `ThermochemicalProperties` dataclass. The optional `mixture_ratio` overrides the propellant's stored ratio per-call — `LiquidEngineState` uses this to feed the live $\dot{m}_{ox} / \dot{m}_{fuel}$ each step.
 
 ::: machwave.models.propellants.categories

--- a/docs/theory/mass_balance.md
+++ b/docs/theory/mass_balance.md
@@ -220,10 +220,13 @@ used in §2.2 — with \(\dot{m}_{in} = \dot{m}_{fuel} + \dot{m}_{ox}\), \(C_d =
 and chamber-state \(\{T_0, R, k\}\) — and integrated with the same RK4 solver as §2.2.
 
 The thermochemical state \(\{T_0, R, k\}\) is evaluated by NASA-CEA at each step from
-the current \(P_0\) and the design expansion ratio, then held constant within the
-RK4 sub-stages — an explicit lag that is acceptable because chamber properties are
+the current \(P_0\), the design expansion ratio, and the instantaneous mixture ratio
+\(\dot{m}_{ox} / \dot{m}_{fuel}\). The result is held constant within the RK4
+sub-stages — an explicit lag that is acceptable because chamber properties are
 only weakly pressure-dependent (cf. Sutton & Biblarz §5.4 on equilibrium
-thermochemistry).
+thermochemistry). Before flow develops the formulation's design O/F is used as
+the seed; after one tank empties the last evaluated properties are reused for
+the chamber-pressure decay.
 
 ### 2.3.6 Modelling Assumptions and Limitations
 

--- a/examples/1kn_lre.py
+++ b/examples/1kn_lre.py
@@ -44,7 +44,7 @@ def main():
         name=f"{OXIDIZER_NAME}/{FUEL_NAME}",
         components=[oxidizer, fuel],
         combustion_efficiency=0.98,
-        of_ratio=1.9495,
+        oxidizer_to_fuel_ratio=1.9495,
     )
 
     fuel_tank = tanks.Tank(

--- a/examples/liquid_propellant_composition.py
+++ b/examples/liquid_propellant_composition.py
@@ -26,7 +26,7 @@ def main() -> None:
         name="LOX/LH2",
         components=[lox, lh2],
         combustion_efficiency=0.99,
-        of_ratio=6.0,
+        oxidizer_to_fuel_ratio=6.0,
     )
 
     chamber_pressure_range = np.linspace(1e5, 10e6, 100)

--- a/machwave/models/propellants/categories/base.py
+++ b/machwave/models/propellants/categories/base.py
@@ -80,13 +80,17 @@ class Propellant(abc.ABC):
         pass
 
     def evaluate(
-        self, chamber_pressure: float, expansion_ratio: float = 8.0
+        self,
+        chamber_pressure: float,
+        expansion_ratio: float = 8.0,
+        mixture_ratio: float | None = None,
     ) -> ThermochemicalProperties:
         """Evaluate thermochemical properties at given conditions.
 
         Args:
             chamber_pressure: Chamber pressure [Pa].
             expansion_ratio: Nozzle area ratio (Ae/At).
+            mixture_ratio: Ratio of the propellant mixture.
 
         Returns:
             ThermochemicalProperties.
@@ -98,22 +102,30 @@ class Propellant(abc.ABC):
         service = self.thermochemical_service
 
         adiabatic_flame_temperature = service.get_adiabatic_flame_temperature(
-            chamber_pressure=chamber_pressure
+            chamber_pressure=chamber_pressure, mixture_ratio=mixture_ratio
         )
 
         molecular_weight_chamber, k_chamber = service.get_chamber_properties(
-            chamber_pressure=chamber_pressure, expansion_ratio=expansion_ratio
+            chamber_pressure=chamber_pressure,
+            expansion_ratio=expansion_ratio,
+            mixture_ratio=mixture_ratio,
         )
 
         molecular_weight_exhaust, k_exhaust = service.get_exhaust_properties(
-            chamber_pressure=chamber_pressure, expansion_ratio=expansion_ratio
+            chamber_pressure=chamber_pressure,
+            expansion_ratio=expansion_ratio,
+            mixture_ratio=mixture_ratio,
         )
 
         i_sp_frozen, i_sp_shifting = service.get_specific_impulse(
-            chamber_pressure=chamber_pressure, expansion_ratio=expansion_ratio
+            chamber_pressure=chamber_pressure,
+            expansion_ratio=expansion_ratio,
+            mixture_ratio=mixture_ratio,
         )
         qsi_chamber, qsi_exhaust = service.get_condensed_phase_fractions(
-            chamber_pressure=chamber_pressure, expansion_ratio=expansion_ratio
+            chamber_pressure=chamber_pressure,
+            expansion_ratio=expansion_ratio,
+            mixture_ratio=mixture_ratio,
         )
 
         properties = ThermochemicalProperties(

--- a/machwave/models/propellants/categories/biliquid.py
+++ b/machwave/models/propellants/categories/biliquid.py
@@ -18,7 +18,7 @@ class BiliquidPropellant(Propellant):
         components: list[PropellantComponent] | None = None,
         combustion_efficiency: float = 0.95,
         properties: ThermochemicalProperties | None = None,
-        of_ratio: float | None = None,
+        oxidizer_to_fuel_ratio: float | None = None,
     ):
         """Initialize biliquid propellant.
 
@@ -27,7 +27,9 @@ class BiliquidPropellant(Propellant):
             components: Chemical components (should be exactly 2: oxidizer and fuel).
             combustion_efficiency: Efficiency factor (0-1).
             properties: Pre-defined thermochemical properties (optional).
-            of_ratio: Oxidizer-to-fuel mass ratio.
+            oxidizer_to_fuel_ratio: Oxidizer-to-fuel mass ratio for this
+                formulation. Callers may pass a different per-call value to
+                ``evaluate()`` to evaluate at a non-design operating point.
         """
         super().__init__(
             name=name,
@@ -35,9 +37,21 @@ class BiliquidPropellant(Propellant):
             combustion_efficiency=combustion_efficiency,
         )
         self.properties = properties
-        self.of_ratio = of_ratio
+        self.oxidizer_to_fuel_ratio = oxidizer_to_fuel_ratio
         self.oxidizer_tank_density: float = 0.0
         self.fuel_tank_density: float = 0.0
+
+    def evaluate(
+        self,
+        chamber_pressure: float,
+        expansion_ratio: float = 8.0,
+        oxidizer_to_fuel_ratio: float | None = None,
+    ) -> ThermochemicalProperties:
+        return super().evaluate(
+            chamber_pressure=chamber_pressure,
+            expansion_ratio=expansion_ratio,
+            mixture_ratio=oxidizer_to_fuel_ratio,
+        )
 
     def _validate_components(self):
         """Validate biliquid has exactly 2 components: oxidizer and fuel.
@@ -83,5 +97,5 @@ class BiliquidPropellant(Propellant):
         return create_cea_service(
             oxidizer_name=oxidizer.name,
             fuel_name=fuel.name,
-            oxidizer_to_fuel_ratio=self.of_ratio,
+            oxidizer_to_fuel_ratio=self.oxidizer_to_fuel_ratio,
         )

--- a/machwave/models/propellants/categories/biliquid.py
+++ b/machwave/models/propellants/categories/biliquid.py
@@ -28,8 +28,9 @@ class BiliquidPropellant(Propellant):
             combustion_efficiency: Efficiency factor (0-1).
             properties: Pre-defined thermochemical properties (optional).
             oxidizer_to_fuel_ratio: Oxidizer-to-fuel mass ratio for this
-                formulation. Callers may pass a different per-call value to
-                ``evaluate()`` to evaluate at a non-design operating point.
+                formulation. Used as the default mixture_ratio at the
+                thermochemical service layer; callers can override per-call
+                via ``evaluate(mixture_ratio=...)``.
         """
         super().__init__(
             name=name,
@@ -40,18 +41,6 @@ class BiliquidPropellant(Propellant):
         self.oxidizer_to_fuel_ratio = oxidizer_to_fuel_ratio
         self.oxidizer_tank_density: float = 0.0
         self.fuel_tank_density: float = 0.0
-
-    def evaluate(
-        self,
-        chamber_pressure: float,
-        expansion_ratio: float = 8.0,
-        oxidizer_to_fuel_ratio: float | None = None,
-    ) -> ThermochemicalProperties:
-        return super().evaluate(
-            chamber_pressure=chamber_pressure,
-            expansion_ratio=expansion_ratio,
-            mixture_ratio=oxidizer_to_fuel_ratio,
-        )
 
     def _validate_components(self):
         """Validate biliquid has exactly 2 components: oxidizer and fuel.

--- a/machwave/models/propellants/categories/solid.py
+++ b/machwave/models/propellants/categories/solid.py
@@ -139,7 +139,10 @@ class SolidPropellant(Propellant):
             )
 
     def evaluate(
-        self, chamber_pressure: float, expansion_ratio: float = 8.0
+        self,
+        chamber_pressure: float,
+        expansion_ratio: float = 8.0,
+        mixture_ratio: float | None = None,
     ) -> ThermochemicalProperties:
         """Evaluate thermochemical properties.
 
@@ -150,6 +153,8 @@ class SolidPropellant(Propellant):
         Args:
             chamber_pressure: Chamber pressure [Pa].
             expansion_ratio: Nozzle area expansion ratio (Ae/At).
+            mixture_ratio: Per-call mixture ratio override (unused for solid
+                formulations; accepted for parent-class compatibility).
 
         Returns:
             Pre-defined or calculated properties.
@@ -159,7 +164,7 @@ class SolidPropellant(Propellant):
         """
         if self._properties is not None:
             return self._properties
-        return super().evaluate(chamber_pressure, expansion_ratio)
+        return super().evaluate(chamber_pressure, expansion_ratio, mixture_ratio)
 
     @property
     def ideal_density(self) -> float:

--- a/machwave/models/propellants/formulations/base.py
+++ b/machwave/models/propellants/formulations/base.py
@@ -161,7 +161,7 @@ def _create_propellant(
             components=components,
             combustion_efficiency=data.get("combustion_efficiency", 0.98),
             properties=properties,
-            of_ratio=data.get("of_ratio"),
+            oxidizer_to_fuel_ratio=data.get("oxidizer_to_fuel_ratio"),
         )
     else:
         raise ValueError(f"Unsupported mixture_type: {mixture_type}")

--- a/machwave/models/propellants/formulations/biliquid/lox_lh2_6_0.json
+++ b/machwave/models/propellants/formulations/biliquid/lox_lh2_6_0.json
@@ -21,6 +21,6 @@
       "temperature": 298.15
     }
   ],
-  "of_ratio": 6.0,
+  "oxidizer_to_fuel_ratio": 6.0,
   "combustion_efficiency": 0.98
 }

--- a/machwave/services/cea.py
+++ b/machwave/services/cea.py
@@ -173,26 +173,36 @@ class RocketCEAService:
         self.cea_obj = cea_obj
         self.oxidizer_to_fuel_ratio = oxidizer_to_fuel_ratio
 
-    def get_adiabatic_flame_temperature(self, chamber_pressure: float) -> float:
+    def _resolve_mixture_ratio(self, mixture_ratio: float | None) -> float | None:
+        if mixture_ratio is not None:
+            return mixture_ratio
+        return self.oxidizer_to_fuel_ratio
+
+    def get_adiabatic_flame_temperature(
+        self, chamber_pressure: float, mixture_ratio: float | None = None
+    ) -> float:
         """Get adiabatic flame temperature [K]."""
         chamber_pressure_psi = convert_pa_to_psi(chamber_pressure)
-        if self.oxidizer_to_fuel_ratio is not None:
-            temp_rankine = self.cea_obj.get_Tcomb(
-                Pc=chamber_pressure_psi, MR=self.oxidizer_to_fuel_ratio
-            )
+        mr = self._resolve_mixture_ratio(mixture_ratio)
+        if mr is not None:
+            temp_rankine = self.cea_obj.get_Tcomb(Pc=chamber_pressure_psi, MR=mr)
         else:
             temp_rankine = self.cea_obj.get_Tcomb(Pc=chamber_pressure_psi)
         return convert_rankine_to_kelvin(temp_rankine)
 
     def get_chamber_properties(
-        self, chamber_pressure: float, expansion_ratio: float
+        self,
+        chamber_pressure: float,
+        expansion_ratio: float,
+        mixture_ratio: float | None = None,
     ) -> tuple[float, float]:
         """Get chamber molecular weight [kg/mol] and isentropic exponent."""
         chamber_pressure_psi = convert_pa_to_psi(chamber_pressure)
-        if self.oxidizer_to_fuel_ratio is not None:
+        mr = self._resolve_mixture_ratio(mixture_ratio)
+        if mr is not None:
             mw_g, k = self.cea_obj.get_Chamber_MolWt_gamma(
                 Pc=chamber_pressure_psi,
-                MR=self.oxidizer_to_fuel_ratio,
+                MR=mr,
                 eps=expansion_ratio,
             )
         else:
@@ -202,15 +212,19 @@ class RocketCEAService:
         return mw_g / 1000.0, k
 
     def get_exhaust_properties(
-        self, chamber_pressure: float, expansion_ratio: float
+        self,
+        chamber_pressure: float,
+        expansion_ratio: float,
+        mixture_ratio: float | None = None,
     ) -> tuple[float, float]:
         """Get exhaust molecular weight [kg/mol] and isentropic exponent (frozen flow)."""
         chamber_pressure_psi = convert_pa_to_psi(chamber_pressure)
+        mr = self._resolve_mixture_ratio(mixture_ratio)
 
-        if self.oxidizer_to_fuel_ratio is not None:
+        if mr is not None:
             mw_g, k = self.cea_obj.get_exit_MolWt_gamma(
                 Pc=chamber_pressure_psi,
-                MR=self.oxidizer_to_fuel_ratio,
+                MR=mr,
                 eps=expansion_ratio,
                 frozen=1,
             )
@@ -223,10 +237,10 @@ class RocketCEAService:
         # requesting frozen exit k. Fall back to equilibrium exit k, and
         # if that is still invalid, fall back to throat k.
         if k <= 1.0:
-            if self.oxidizer_to_fuel_ratio is not None:
+            if mr is not None:
                 mw_g, k = self.cea_obj.get_exit_MolWt_gamma(
                     Pc=chamber_pressure_psi,
-                    MR=self.oxidizer_to_fuel_ratio,
+                    MR=mr,
                     eps=expansion_ratio,
                     frozen=0,
                 )
@@ -235,10 +249,10 @@ class RocketCEAService:
                     Pc=chamber_pressure_psi, eps=expansion_ratio, frozen=0
                 )
         if k <= 1.0:
-            if self.oxidizer_to_fuel_ratio is not None:
+            if mr is not None:
                 mw_g, k = self.cea_obj.get_Throat_MolWt_gamma(
                     Pc=chamber_pressure_psi,
-                    MR=self.oxidizer_to_fuel_ratio,
+                    MR=mr,
                     eps=expansion_ratio,
                 )
             else:
@@ -249,21 +263,25 @@ class RocketCEAService:
         return mw_g / 1000.0, k
 
     def get_specific_impulse(
-        self, chamber_pressure: float, expansion_ratio: float
+        self,
+        chamber_pressure: float,
+        expansion_ratio: float,
+        mixture_ratio: float | None = None,
     ) -> tuple[float, float]:
         """Get specific impulse [s]: (frozen, shifting)."""
         chamber_pressure_psi = convert_pa_to_psi(chamber_pressure)
+        mr = self._resolve_mixture_ratio(mixture_ratio)
 
-        if self.oxidizer_to_fuel_ratio is not None:
+        if mr is not None:
             isp_frozen = self.cea_obj.get_Isp(
                 Pc=chamber_pressure_psi,
-                MR=self.oxidizer_to_fuel_ratio,
+                MR=mr,
                 eps=expansion_ratio,
                 frozen=1,
             )
             isp_shifting = self.cea_obj.get_Isp(
                 Pc=chamber_pressure_psi,
-                MR=self.oxidizer_to_fuel_ratio,
+                MR=mr,
                 eps=expansion_ratio,
                 frozen=0,
             )
@@ -277,17 +295,24 @@ class RocketCEAService:
         return isp_frozen, isp_shifting
 
     def get_condensed_phase_fractions(
-        self, chamber_pressure: float, expansion_ratio: float
+        self,
+        chamber_pressure: float,
+        expansion_ratio: float,
+        mixture_ratio: float | None = None,
     ) -> tuple[float, float]:
         """Get condensed phase mass fractions: (chamber, exhaust)."""
         chamber_pressure_psi = convert_pa_to_psi(chamber_pressure)
+        mr = self._resolve_mixture_ratio(mixture_ratio)
 
         qsi_chamber = 0.0
         qsi_exhaust = 0.0
 
         try:
+            kwargs = {"Pc": chamber_pressure_psi, "eps": expansion_ratio, "frozen": 0}
+            if mr is not None:
+                kwargs["MR"] = mr
             species_dict, mass_fractions = self.cea_obj.get_SpeciesMassFractions(
-                Pc=chamber_pressure_psi, eps=expansion_ratio, frozen=0
+                **kwargs
             )
             for species_name, fractions in zip(
                 species_dict.keys(), mass_fractions.values()

--- a/machwave/states/liquid_engine.py
+++ b/machwave/states/liquid_engine.py
@@ -136,7 +136,7 @@ class LiquidEngineState(MotorState):
             self.motor.propellant.properties = self.motor.propellant.evaluate(
                 chamber_pressure=self.chamber_pressure[-1],
                 expansion_ratio=nz.expansion_ratio,
-                oxidizer_to_fuel_ratio=instantaneous_oxidizer_to_fuel_ratio,
+                mixture_ratio=instantaneous_oxidizer_to_fuel_ratio,
             )
         props = self.motor.propellant.properties
         assert props is not None

--- a/machwave/states/liquid_engine.py
+++ b/machwave/states/liquid_engine.py
@@ -109,18 +109,18 @@ class LiquidEngineState(MotorState):
         m_dot_fuel = min(m_dot_fuel, self.fuel_mass[-1] / d_t)
         m_dot_ox = min(m_dot_ox, self.oxidizer_mass[-1] / d_t)
 
-        of = self.motor.propellant.of_ratio
-        assert of is not None
+        oxidizer_to_fuel_ratio = self.motor.propellant.oxidizer_to_fuel_ratio
+        assert oxidizer_to_fuel_ratio is not None
         cons_f = m_dot_fuel * d_t
         cons_o = m_dot_ox * d_t
         if cons_f >= self.fuel_mass[-1]:
             cons_f = self.fuel_mass[-1]
-            cons_o = of * cons_f
+            cons_o = oxidizer_to_fuel_ratio * cons_f
             self.end_burn = True
             self.burn_time = self.t[-1]
         elif cons_o >= self.oxidizer_mass[-1]:
             cons_o = self.oxidizer_mass[-1]
-            cons_f = cons_o / of
+            cons_f = cons_o / oxidizer_to_fuel_ratio
             self.end_burn = True
             self.burn_time = self.t[-1]
         m_dot_fuel = cons_f / d_t
@@ -128,10 +128,16 @@ class LiquidEngineState(MotorState):
         self._m_dot_fuel = m_dot_fuel
         self._m_dot_ox = m_dot_ox
 
-        self.motor.propellant.properties = self.motor.propellant.evaluate(
-            chamber_pressure=self.chamber_pressure[-1],
-            expansion_ratio=nz.expansion_ratio,
-        )
+        if self.propellant_mass[-1] > 0:
+            if m_dot_fuel > 0.0:
+                instantaneous_oxidizer_to_fuel_ratio = m_dot_ox / m_dot_fuel
+            else:
+                instantaneous_oxidizer_to_fuel_ratio = oxidizer_to_fuel_ratio
+            self.motor.propellant.properties = self.motor.propellant.evaluate(
+                chamber_pressure=self.chamber_pressure[-1],
+                expansion_ratio=nz.expansion_ratio,
+                oxidizer_to_fuel_ratio=instantaneous_oxidizer_to_fuel_ratio,
+            )
         props = self.motor.propellant.properties
         assert props is not None
 

--- a/tests/factories/propellants.py
+++ b/tests/factories/propellants.py
@@ -144,7 +144,7 @@ class BiliquidPropellantFactory:
             name="N2O/Ethanol",
             components=component_list,
             combustion_efficiency=0.98,
-            of_ratio=2.0,
+            oxidizer_to_fuel_ratio=2.0,
         )
         kwargs.update(overrides)
         return categories.BiliquidPropellant(**kwargs)

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_base.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_base.py
@@ -273,7 +273,7 @@ class TestCreatePropellant:
         data = {
             "name": "Test Biliquid",
             "combustion_efficiency": 0.98,
-            "of_ratio": 2.5,
+            "oxidizer_to_fuel_ratio": 2.5,
         }
         components = []
         mass_fractions = None
@@ -286,7 +286,7 @@ class TestCreatePropellant:
         assert isinstance(result, BiliquidPropellant)
         assert result.name == "Test Biliquid"
         assert result.combustion_efficiency == 0.98
-        assert result.of_ratio == 2.5
+        assert result.oxidizer_to_fuel_ratio == 2.5
 
     def test_create_solid_with_default_efficiency(self):
         from machwave.models.propellants.categories import SolidPropellant

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_biliquid.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_biliquid.py
@@ -1,0 +1,65 @@
+import pytest
+
+from machwave.models.propellants import BiliquidPropellant
+from machwave.models.propellants.components import (
+    ComponentRole,
+    PropellantComponent,
+)
+
+
+@pytest.fixture
+def lox_rp1_propellant() -> BiliquidPropellant:
+    oxidizer = PropellantComponent(
+        name="LOX",
+        density=1141.0,
+        chemical_formula={"O": 2},
+        enthalpy=0.0,
+        initial_temperature=298.15,
+        role=ComponentRole.OXIDIZER,
+    )
+    fuel = PropellantComponent(
+        name="RP1",
+        density=820.0,
+        chemical_formula={"C": 12, "H": 26},
+        enthalpy=0.0,
+        initial_temperature=298.15,
+        role=ComponentRole.FUEL,
+    )
+    return BiliquidPropellant(
+        name="LOX/RP1",
+        components=[oxidizer, fuel],
+        oxidizer_to_fuel_ratio=2.5,
+    )
+
+
+class TestBiliquidEvaluateOverride:
+    def test_default_uses_design_ratio(self, lox_rp1_propellant):
+        without_override = lox_rp1_propellant.evaluate(chamber_pressure=3e6)
+        with_design_explicit = lox_rp1_propellant.evaluate(
+            chamber_pressure=3e6,
+            oxidizer_to_fuel_ratio=2.5,
+        )
+        assert without_override.adiabatic_flame_temperature == pytest.approx(
+            with_design_explicit.adiabatic_flame_temperature
+        )
+        assert without_override.i_sp_frozen == pytest.approx(
+            with_design_explicit.i_sp_frozen
+        )
+
+    def test_live_ratio_changes_properties(self, lox_rp1_propellant):
+        design = lox_rp1_propellant.evaluate(chamber_pressure=3e6)
+        off_design = lox_rp1_propellant.evaluate(
+            chamber_pressure=3e6,
+            oxidizer_to_fuel_ratio=1.5,
+        )
+        assert design.adiabatic_flame_temperature != pytest.approx(
+            off_design.adiabatic_flame_temperature
+        )
+        assert design.k_chamber != pytest.approx(off_design.k_chamber)
+        assert design.k_exhaust != pytest.approx(off_design.k_exhaust)
+        assert design.i_sp_frozen != pytest.approx(off_design.i_sp_frozen)
+        assert design.i_sp_shifting != pytest.approx(off_design.i_sp_shifting)
+
+    def test_design_attribute_unchanged_after_evaluate(self, lox_rp1_propellant):
+        lox_rp1_propellant.evaluate(chamber_pressure=3e6, oxidizer_to_fuel_ratio=1.5)
+        assert lox_rp1_propellant.oxidizer_to_fuel_ratio == 2.5

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_biliquid.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_biliquid.py
@@ -32,12 +32,12 @@ def lox_rp1_propellant() -> BiliquidPropellant:
     )
 
 
-class TestBiliquidEvaluateOverride:
+class TestBiliquidEvaluateMixtureRatio:
     def test_default_uses_design_ratio(self, lox_rp1_propellant):
         without_override = lox_rp1_propellant.evaluate(chamber_pressure=3e6)
         with_design_explicit = lox_rp1_propellant.evaluate(
             chamber_pressure=3e6,
-            oxidizer_to_fuel_ratio=2.5,
+            mixture_ratio=2.5,
         )
         assert without_override.adiabatic_flame_temperature == pytest.approx(
             with_design_explicit.adiabatic_flame_temperature
@@ -50,7 +50,7 @@ class TestBiliquidEvaluateOverride:
         design = lox_rp1_propellant.evaluate(chamber_pressure=3e6)
         off_design = lox_rp1_propellant.evaluate(
             chamber_pressure=3e6,
-            oxidizer_to_fuel_ratio=1.5,
+            mixture_ratio=1.5,
         )
         assert design.adiabatic_flame_temperature != pytest.approx(
             off_design.adiabatic_flame_temperature
@@ -61,5 +61,5 @@ class TestBiliquidEvaluateOverride:
         assert design.i_sp_shifting != pytest.approx(off_design.i_sp_shifting)
 
     def test_design_attribute_unchanged_after_evaluate(self, lox_rp1_propellant):
-        lox_rp1_propellant.evaluate(chamber_pressure=3e6, oxidizer_to_fuel_ratio=1.5)
+        lox_rp1_propellant.evaluate(chamber_pressure=3e6, mixture_ratio=1.5)
         assert lox_rp1_propellant.oxidizer_to_fuel_ratio == 2.5

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_json_loader.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_json_loader.py
@@ -154,8 +154,12 @@ class TestJSONFormulationLoading:
         assert 0 < propellant.combustion_efficiency <= 1.0, (
             f"{json_file.stem}: Invalid combustion_efficiency"
         )
-        assert propellant.of_ratio is not None, f"{json_file.stem}: Missing O/F ratio"
-        assert propellant.of_ratio > 0, f"{json_file.stem}: Invalid O/F ratio"
+        assert propellant.oxidizer_to_fuel_ratio is not None, (
+            f"{json_file.stem}: Missing O/F ratio"
+        )
+        assert propellant.oxidizer_to_fuel_ratio > 0, (
+            f"{json_file.stem}: Invalid O/F ratio"
+        )
 
         # Verify components have required fields
         has_oxidizer = False

--- a/tests/test_services/test_cea.py
+++ b/tests/test_services/test_cea.py
@@ -524,5 +524,49 @@ def test_generate_card_string_utility():
         generate_card_string([])
 
 
+class TestMixtureRatioOverride:
+    @pytest.fixture
+    def lox_rp1_service(self):
+        return create_cea_service(
+            oxidizer_name="LOX", fuel_name="RP1", oxidizer_to_fuel_ratio=2.5
+        )
+
+    def test_adiabatic_flame_temperature_override(self, lox_rp1_service):
+        baseline = lox_rp1_service.get_adiabatic_flame_temperature(3e6)
+        overridden = lox_rp1_service.get_adiabatic_flame_temperature(
+            3e6, mixture_ratio=1.5
+        )
+        assert baseline != pytest.approx(overridden)
+
+    def test_chamber_properties_override(self, lox_rp1_service):
+        mw_default, k_default = lox_rp1_service.get_chamber_properties(3e6, 8.0)
+        mw_override, k_override = lox_rp1_service.get_chamber_properties(
+            3e6, 8.0, mixture_ratio=1.5
+        )
+        assert (mw_default, k_default) != pytest.approx((mw_override, k_override))
+
+    def test_exhaust_properties_override(self, lox_rp1_service):
+        mw_default, k_default = lox_rp1_service.get_exhaust_properties(3e6, 8.0)
+        mw_override, k_override = lox_rp1_service.get_exhaust_properties(
+            3e6, 8.0, mixture_ratio=1.5
+        )
+        assert (mw_default, k_default) != pytest.approx((mw_override, k_override))
+
+    def test_specific_impulse_override(self, lox_rp1_service):
+        isp_f_default, isp_s_default = lox_rp1_service.get_specific_impulse(3e6, 8.0)
+        isp_f_override, isp_s_override = lox_rp1_service.get_specific_impulse(
+            3e6, 8.0, mixture_ratio=1.5
+        )
+        assert isp_f_default != pytest.approx(isp_f_override)
+        assert isp_s_default != pytest.approx(isp_s_override)
+
+    def test_override_matches_construction_default(self, lox_rp1_service):
+        explicit = lox_rp1_service.get_adiabatic_flame_temperature(
+            3e6, mixture_ratio=2.5
+        )
+        cached = lox_rp1_service.get_adiabatic_flame_temperature(3e6)
+        assert explicit == pytest.approx(cached)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_simulations/test_liquid_engine_simulation.py
+++ b/tests/test_simulations/test_liquid_engine_simulation.py
@@ -175,6 +175,7 @@ def test_live_mixture_ratio_drives_cea(
     simulation_result: SimulationResult,
 ) -> None:
     state = simulation_result.state
+    assert isinstance(state, LiquidEngineState)
     propellant = state.motor.propellant
 
     design_ratio = propellant.oxidizer_to_fuel_ratio
@@ -195,7 +196,7 @@ def test_live_mixture_ratio_drives_cea(
     design_props = propellant.evaluate(
         chamber_pressure=chamber_pressure,
         expansion_ratio=expansion_ratio,
-        oxidizer_to_fuel_ratio=design_ratio,
+        mixture_ratio=design_ratio,
     )
     live_props = propellant.properties
     assert live_props is not None

--- a/tests/test_simulations/test_liquid_engine_simulation.py
+++ b/tests/test_simulations/test_liquid_engine_simulation.py
@@ -39,7 +39,7 @@ def _build_1kn_lre() -> tuple[motors.LiquidEngine, InternalBallisticsSimulationP
     fuel = FuelComponentFactory.build(initial_temperature=300.0)
     propellant = BiliquidPropellantFactory.build(
         components=[oxidizer, fuel],
-        of_ratio=1.9495,
+        oxidizer_to_fuel_ratio=1.9495,
     )
 
     feed_system = StackedTankPressureFedFeedSystemFactory.build(
@@ -169,3 +169,45 @@ def test_recorded_per_timestep_arrays_are_aligned(
             "oxidizer_tank_pressure",
         ),
     )
+
+
+def test_live_mixture_ratio_drives_cea(
+    simulation_result: SimulationResult,
+) -> None:
+    state = simulation_result.state
+    propellant = state.motor.propellant
+
+    design_ratio = propellant.oxidizer_to_fuel_ratio
+    assert design_ratio is not None
+
+    fuel_mass = np.asarray(state.fuel_mass)
+    oxidizer_mass = np.asarray(state.oxidizer_mass)
+    fuel_consumed = -np.diff(fuel_mass)
+    oxidizer_consumed = -np.diff(oxidizer_mass)
+    valid = fuel_consumed > 0
+    live_ratios = oxidizer_consumed[valid] / fuel_consumed[valid]
+    assert np.any(np.abs(live_ratios - design_ratio) > 1e-6), (
+        "Live oxidizer/fuel mass deltas never deviated from the design ratio"
+    )
+
+    chamber_pressure = state.chamber_pressure[len(state.chamber_pressure) // 2]
+    expansion_ratio = state.motor.thrust_chamber.nozzle.expansion_ratio
+    design_props = propellant.evaluate(
+        chamber_pressure=chamber_pressure,
+        expansion_ratio=expansion_ratio,
+        oxidizer_to_fuel_ratio=design_ratio,
+    )
+    live_props = propellant.properties
+    assert live_props is not None
+    assert (
+        live_props.adiabatic_flame_temperature
+        != design_props.adiabatic_flame_temperature
+    )
+
+
+def test_simulation_runs_through_burnout_without_crashing(
+    simulation_result: SimulationResult,
+) -> None:
+    state = simulation_result.state
+    assert state.end_thrust is True
+    assert state.propellant_mass[-1] <= state.propellant_mass[0]


### PR DESCRIPTION
## Summary

- Fixes #221: each timestep of `LiquidEngineState.run_timestep` now feeds the live `m_dot_ox / m_dot_fuel` into RocketCEA instead of the cached design O/F. Flame temperature, `k_chamber`, `k_exhaust`, `i_sp_*`, and condensed-phase fractions reflect the actual instantaneous mixture, removing the bias on the chamber-pressure ODE and thrust curve.
- `RocketCEAService` getters take an optional per-call `mixture_ratio` override that falls back to the cached `oxidizer_to_fuel_ratio`. `Propellant.evaluate` threads it through; `BiliquidPropellant.evaluate` exposes it as `oxidizer_to_fuel_ratio` (the biliquid-specific name).
- Startup before any flow develops seeds CEA with the formulation's `oxidizer_to_fuel_ratio`. Post-burnout (`propellant_mass <= 0`) skips `evaluate()` and reuses the last `ThermochemicalProperties` so the chamber-pressure decay does not divide by zero.

## Test plan

- [x] `pytest tests/test_services/test_cea.py` — five new cases assert the per-call `mixture_ratio` overrides the cached default.
- [x] `pytest tests/test_models/test_propulsion/test_propellants/test_formulations/test_biliquid.py` — three cases verify the biliquid `evaluate()` override (default matches design, off-design moves every output, attribute is not mutated).
- [x] `pytest tests/test_simulations/test_liquid_engine_simulation.py` — two new regressions: live mass deltas diverge from the design ratio, simulation runs through burnout without crashing.
- [x] Full suite: `pytest tests/` (562 fast + 22 simulation tests pass locally).