### PR TITLE
Drop forced design oxidizer-to-fuel coupling at exhaustion

### DIFF
--- a/machwave/states/liquid_engine.py
+++ b/machwave/states/liquid_engine.py
@@ -113,18 +113,9 @@ class LiquidEngineState(MotorState):
         assert oxidizer_to_fuel_ratio is not None
         cons_f = m_dot_fuel * d_t
         cons_o = m_dot_ox * d_t
-        if cons_f >= self.fuel_mass[-1]:
-            cons_f = self.fuel_mass[-1]
-            cons_o = oxidizer_to_fuel_ratio * cons_f
+        if cons_f >= self.fuel_mass[-1] or cons_o >= self.oxidizer_mass[-1]:
             self.end_burn = True
             self.burn_time = self.t[-1]
-        elif cons_o >= self.oxidizer_mass[-1]:
-            cons_o = self.oxidizer_mass[-1]
-            cons_f = cons_o / oxidizer_to_fuel_ratio
-            self.end_burn = True
-            self.burn_time = self.t[-1]
-        m_dot_fuel = cons_f / d_t
-        m_dot_ox = cons_o / d_t
         self._m_dot_fuel = m_dot_fuel
         self._m_dot_ox = m_dot_ox
 

--- a/tests/test_simulations/test_liquid_engine_simulation.py
+++ b/tests/test_simulations/test_liquid_engine_simulation.py
@@ -130,6 +130,9 @@ def test_propellant_masses_are_monotone_non_increasing(
             f"{series_name} increased between steps; max delta={diffs.max():.3e}"
         )
         assert series[-1] <= series[0]
+        assert (series >= -1e-9).all(), (
+            f"{series_name} went negative; min={series.min():.3e}"
+        )
 
 
 def test_chamber_pressure_and_thrust_are_physically_plausible(


### PR DESCRIPTION
## Summary

- When a tank ran dry, [machwave/states/liquid_engine.py:116-127](machwave/states/liquid_engine.py#L116-L127) was forcing the surviving propellant's consumption to match the design oxidizer-to-fuel ratio. Now that the chamber-pressure ODE evaluates at the live mass-flow ratio (#221), that override is non-physical — a real bipropellant engine keeps each injector flowing per its own orifice equation until shutdown; the mixture ratio swings off design at burnout.
- The override was also unclamped against remaining tank mass, so when the live ratio diverged from the design ratio the recorded `oxidizer_mass` / `fuel_mass` series could go negative while the `Tank` object silently clamped its own state to zero (#223). The 1 kN N₂O/Ethanol example happens to land on the safe side, but the bug was latent for any sizing where the inequality flipped.
- Each consumption now stays at its orifice-equation value, already capped by the `min(...)` clamps just above. Burn ends when either tank is depleted.
- The propellant-mass test now asserts non-negativity in addition to monotonicity — the previous `(diffs <= 1e-9)` check only caught increases, not a single large drop into negative territory.

Closes #222.
Closes #223.

## Test plan

- [x] `pytest tests/test_simulations/test_liquid_engine_simulation.py` (9 passed, including the burnout cases and `test_propellant_masses_are_monotone_non_increasing` with its new non-negativity check)
- [x] Full suite: `pytest tests/` (607 passed)