### PR TITLE
156: Add pytest-benchmark suite and CI regression gate for simulation loops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,44 @@ jobs:
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  benchmark:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Check whether the base commit already has a benchmark suite
+        id: base_has_benchmarks
+        run: |
+          if git cat-file -e ${{ github.event.pull_request.base.sha }}:tests/benchmarks/test_simulation_loop.py 2>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Benchmark base branch
+        if: steps.base_has_benchmarks.outputs.exists == 'true'
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }}
+          make install-dev
+          uv run pytest tests/benchmarks --benchmark-only --benchmark-save=base
+      - name: Restore pull request branch
+        if: steps.base_has_benchmarks.outputs.exists == 'true'
+        run: |
+          git checkout ${{ github.event.pull_request.head.sha }}
+          make install-dev
+      - name: Benchmark pull request branch and compare against base
+        if: steps.base_has_benchmarks.outputs.exists == 'true'
+        run: uv run pytest tests/benchmarks --benchmark-only --benchmark-compare=base --benchmark-compare-fail=median:25%
+      - name: Benchmark pull request branch (no base available yet)
+        if: steps.base_has_benchmarks.outputs.exists != 'true'
+        run: |
+          make install-dev
+          uv run pytest tests/benchmarks --benchmark-only

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-dev install-docs install-hooks test publish build verify-version check format-check lint typecheck format generate-umls coverage docs docs-serve docs-deploy clean
+.PHONY: install install-dev install-docs install-hooks test benchmark publish build verify-version check format-check lint typecheck format generate-umls coverage docs docs-serve docs-deploy clean
 
 install:
 	@uv sync
@@ -25,6 +25,8 @@ verify-version:
 	echo "Version verified: $$PKG_VERSION"
 test:
 	@uv run pytest
+benchmark:
+	@uv run pytest tests/benchmarks --benchmark-only --benchmark-columns=min,median,mean,stddev,rounds
 publish:
 	@$(MAKE) build
 	@twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "pytest",
     "pylint>=3.3.5,<5.0.0",
     "py2puml>=0.10.0,<0.12.0",
+    "pytest-benchmark>=5.0.0,<6.0.0",
     "pytest-cov>=6.2.1,<8.0.0",
     "polyfactory>=3.1.0,<4.0.0",
     "rocketpy>=1.11.0,<2.0.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 python_files = test_*.py
 python_functions = test_*
 testpaths = tests
+addopts = --benchmark-skip

--- a/tests/benchmarks/test_simulation_loop.py
+++ b/tests/benchmarks/test_simulation_loop.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import dataclasses
+import warnings
+
+import pytest
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from machwave.simulation import InternalBallisticsSimulation
+from tests.test_simulations import motor_builders
+
+
+def _run_simulation_silently(simulation: InternalBallisticsSimulation) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        simulation.run()
+
+
+@pytest.mark.benchmark(group="simulation-loop")
+def test_solid_motor_simulation_loop(benchmark: BenchmarkFixture) -> None:
+    def setup() -> tuple[tuple[InternalBallisticsSimulation], dict[str, object]]:
+        motor, params = motor_builders.build_kappa_rnakka_motor()
+        params = dataclasses.replace(params, d_t=0.01)
+        simulation = InternalBallisticsSimulation(motor=motor, params=params)
+        return (simulation,), {}
+
+    benchmark.pedantic(
+        _run_simulation_silently,
+        setup=setup,
+        rounds=5,
+        iterations=1,
+        warmup_rounds=0,
+    )
+
+
+@pytest.mark.benchmark(group="simulation-loop")
+def test_liquid_engine_simulation_loop(benchmark: BenchmarkFixture) -> None:
+    def setup() -> tuple[tuple[InternalBallisticsSimulation], dict[str, object]]:
+        motor, params = motor_builders.build_1kn_lre()
+        params = dataclasses.replace(params, d_t=4e-4)
+        simulation = InternalBallisticsSimulation(motor=motor, params=params)
+        return (simulation,), {}
+
+    benchmark.pedantic(
+        _run_simulation_silently,
+        setup=setup,
+        rounds=3,
+        iterations=1,
+        warmup_rounds=0,
+    )

--- a/tests/test_simulations/motor_builders.py
+++ b/tests/test_simulations/motor_builders.py
@@ -1,0 +1,211 @@
+"""Shared motor + simulation-params builders for end-to-end simulation tests
+and benchmarks.
+
+These configurations mirror the example scripts under examples/ (apcp_motor,
+kappa_rnakka, nero_motor, 1kn_lre) but are duplicated here so tests stay
+independent of the example layer.
+"""
+
+from __future__ import annotations
+
+from machwave.models import grain as grain_models
+from machwave.models import motors
+from machwave.models.propellants.formulations import solid as solid_propellants
+from machwave.simulation import InternalBallisticsSimulationParams
+from tests.factories import (
+    BatesSegmentFactory,
+    BiliquidPropellantFactory,
+    BipropellantInjectorFactory,
+    CombustionChamberFactory,
+    FuelComponentFactory,
+    LiquidEngineFactory,
+    LiquidEngineThrustChamberFactory,
+    NozzleFactory,
+    OxidizerComponentFactory,
+    SolidMotorFactory,
+    SolidMotorThrustChamberFactory,
+    StackedTankPressureFedFeedSystemFactory,
+    TankFactory,
+)
+
+
+def build_apcp_motor() -> tuple[motors.SolidMotor, InternalBallisticsSimulationParams]:
+    """MIT Cherry Limeade APCP motor with five identical BATES segments."""
+    grain = grain_models.Grain(spacing=0.01)
+    bates_segment = BatesSegmentFactory.build(
+        outer_diameter=0.085, core_diameter=0.035, length=0.150
+    )
+    for _ in range(5):
+        grain.add_segment(bates_segment)
+
+    thrust_chamber = SolidMotorThrustChamberFactory.build(
+        nozzle=NozzleFactory.build(
+            inlet_diameter=0.080,
+            throat_diameter=0.022,
+            divergent_angle=12,
+            convergent_angle=45,
+            expansion_ratio=8,
+        ),
+        combustion_chamber=CombustionChamberFactory.build(
+            casing_inner_diameter=95.25e-3,
+            casing_outer_diameter=101.6e-3,
+            thermal_liner_thickness=3e-3,
+            internal_length=grain.total_length + 0.01,
+        ),
+        dry_mass=6.0,
+        center_of_gravity_coordinate=(0.35, 0.0, 0.0),
+    )
+    motor = SolidMotorFactory.build(
+        grain=grain,
+        propellant=solid_propellants.MIT_CHERRY_LIMEADE,
+        thrust_chamber=thrust_chamber,
+    )
+    params = InternalBallisticsSimulationParams(
+        d_t=0.01,
+        igniter_pressure=1e6,
+        external_pressure=1e5,
+        other_losses=0.12,
+    )
+    return motor, params
+
+
+def build_kappa_rnakka_motor() -> tuple[
+    motors.SolidMotor, InternalBallisticsSimulationParams
+]:
+    """Richard Nakka's Kappa motor (KNDX, four BATES segments)."""
+    grain = grain_models.Grain(spacing=5e-3)
+    bates_segment = BatesSegmentFactory.build(
+        outer_diameter=55e-3, core_diameter=19e-3, length=101.6e-3
+    )
+    for _ in range(4):
+        grain.add_segment(bates_segment)
+
+    thrust_chamber = SolidMotorThrustChamberFactory.build(
+        nozzle=NozzleFactory.build(
+            inlet_diameter=40e-3,
+            throat_diameter=12.8e-3,
+            divergent_angle=12,
+            convergent_angle=25,
+            expansion_ratio=11,
+        ),
+        combustion_chamber=CombustionChamberFactory.build(
+            casing_inner_diameter=60e-3,
+            casing_outer_diameter=64e-3,
+            thermal_liner_thickness=1e-3,
+            internal_length=grain.total_length + 5e-3,
+        ),
+        center_of_gravity_coordinate=(0.035, 0.0, 0.0),
+    )
+    motor = SolidMotorFactory.build(
+        grain=grain,
+        propellant=solid_propellants.KNDX,
+        thrust_chamber=thrust_chamber,
+    )
+    params = InternalBallisticsSimulationParams(
+        d_t=0.001,
+        igniter_pressure=1e6,
+        external_pressure=1e5,
+        other_losses=0.12,
+    )
+    return motor, params
+
+
+def build_nero_motor() -> tuple[motors.SolidMotor, InternalBallisticsSimulationParams]:
+    """Supernova Rocketry Nero motor (KNDX, four BATES segments)."""
+    grain = grain_models.Grain(spacing=10e-3)
+    bates_segment = BatesSegmentFactory.build(
+        outer_diameter=41e-3, core_diameter=15e-3, length=67.5e-3
+    )
+    for _ in range(4):
+        grain.add_segment(bates_segment)
+
+    thrust_chamber = SolidMotorThrustChamberFactory.build(
+        nozzle=NozzleFactory.build(
+            inlet_diameter=43e-3,
+            throat_diameter=9.5e-3,
+            divergent_angle=12,
+            convergent_angle=40,
+            expansion_ratio=8,
+        ),
+        combustion_chamber=CombustionChamberFactory.build(
+            casing_inner_diameter=44.5e-3,
+            casing_outer_diameter=50.8e-3,
+            thermal_liner_thickness=1e-3,
+            internal_length=grain.total_length + 10e-3,
+        ),
+        center_of_gravity_coordinate=(0.04, 0.0, 0.0),
+    )
+    motor = SolidMotorFactory.build(
+        grain=grain,
+        propellant=solid_propellants.KNDX,
+        thrust_chamber=thrust_chamber,
+    )
+    params = InternalBallisticsSimulationParams(
+        d_t=0.01,
+        igniter_pressure=1e6,
+        external_pressure=1e5,
+        other_losses=0.12,
+    )
+    return motor, params
+
+
+def build_1kn_lre() -> tuple[motors.LiquidEngine, InternalBallisticsSimulationParams]:
+    """1 kN-class N2O / Ethanol biliquid engine (HalfCat Sphinx-like)."""
+    oxidizer = OxidizerComponentFactory.build(initial_temperature=300.0)
+    fuel = FuelComponentFactory.build(initial_temperature=300.0)
+    propellant = BiliquidPropellantFactory.build(
+        components=[oxidizer, fuel],
+        oxidizer_to_fuel_ratio=1.9495,
+    )
+
+    feed_system = StackedTankPressureFedFeedSystemFactory.build(
+        oxidizer_tank=TankFactory.build(
+            fluid_name="N2O",
+            volume=3.80e-3,
+            temperature=300,
+            initial_fluid_mass=2.78,
+        ),
+        fuel_tank=TankFactory.build(
+            fluid_name="ETHANOL",
+            volume=2.0e-3,
+            temperature=300,
+            initial_fluid_mass=1.55,
+        ),
+        oxidizer_line_diameter=7.925e-3,
+        oxidizer_line_length=0.5,
+        fuel_line_diameter=5.715e-3,
+        fuel_line_length=0.5,
+        piston_loss=1e5,
+    )
+
+    thrust_chamber = LiquidEngineThrustChamberFactory.build(
+        nozzle=NozzleFactory.build(
+            inlet_diameter=55e-3,
+            throat_diameter=25.4e-3,
+            divergent_angle=12,
+            convergent_angle=45,
+            expansion_ratio=4,
+        ),
+        injector=BipropellantInjectorFactory.build(),
+        combustion_chamber=CombustionChamberFactory.build(
+            casing_inner_diameter=70e-3,
+            casing_outer_diameter=76e-3,
+            internal_length=13e-3,
+            thermal_liner_thickness=2e-3,
+        ),
+    )
+
+    motor = LiquidEngineFactory.build(
+        propellant=propellant,
+        feed_system=feed_system,
+        thrust_chamber=thrust_chamber,
+        oxidizer_tank_cog=0.5,
+        fuel_tank_cog=0.4,
+    )
+    params = InternalBallisticsSimulationParams(
+        d_t=1e-4,
+        igniter_pressure=1e6,
+        external_pressure=1e5,
+        other_losses=0.12,
+    )
+    return motor, params

--- a/tests/test_simulations/test_liquid_engine_simulation.py
+++ b/tests/test_simulations/test_liquid_engine_simulation.py
@@ -1,9 +1,8 @@
 """End-to-end integration tests for LiquidEngine internal ballistics
 simulations.
 
-The motor configuration below mirrors the one in examples/1kn_lre.py
-(the lone biliquid example) but is duplicated here so the tests stay
-independent of the example layer.
+The motor configuration lives in tests/test_simulations/motor_builders.py so
+it can be reused by benchmarks under tests/benchmarks/.
 """
 
 from __future__ import annotations
@@ -12,91 +11,17 @@ import numpy as np
 import pytest
 
 from machwave.models import motors
-from machwave.simulation import InternalBallisticsSimulationParams
 from machwave.simulation.liquid import LiquidEngineState, LiquidSimulationResult
-from tests.factories import (
-    BiliquidPropellantFactory,
-    BipropellantInjectorFactory,
-    CombustionChamberFactory,
-    FuelComponentFactory,
-    LiquidEngineFactory,
-    LiquidEngineThrustChamberFactory,
-    NozzleFactory,
-    OxidizerComponentFactory,
-    StackedTankPressureFedFeedSystemFactory,
-    TankFactory,
-)
+from tests.test_simulations import motor_builders
 from tests.test_simulations.conftest import (
     assert_recorded_arrays_aligned,
     run_simulation,
 )
 
 
-def _build_1kn_lre() -> tuple[motors.LiquidEngine, InternalBallisticsSimulationParams]:
-    """1 kN-class N2O / Ethanol biliquid engine (HalfCat Sphinx-like)."""
-    oxidizer = OxidizerComponentFactory.build(initial_temperature=300.0)
-    fuel = FuelComponentFactory.build(initial_temperature=300.0)
-    propellant = BiliquidPropellantFactory.build(
-        components=[oxidizer, fuel],
-        oxidizer_to_fuel_ratio=1.9495,
-    )
-
-    feed_system = StackedTankPressureFedFeedSystemFactory.build(
-        oxidizer_tank=TankFactory.build(
-            fluid_name="N2O",
-            volume=3.80e-3,
-            temperature=300,
-            initial_fluid_mass=2.78,
-        ),
-        fuel_tank=TankFactory.build(
-            fluid_name="ETHANOL",
-            volume=2.0e-3,
-            temperature=300,
-            initial_fluid_mass=1.55,
-        ),
-        oxidizer_line_diameter=7.925e-3,
-        oxidizer_line_length=0.5,
-        fuel_line_diameter=5.715e-3,
-        fuel_line_length=0.5,
-        piston_loss=1e5,
-    )
-
-    thrust_chamber = LiquidEngineThrustChamberFactory.build(
-        nozzle=NozzleFactory.build(
-            inlet_diameter=55e-3,
-            throat_diameter=25.4e-3,
-            divergent_angle=12,
-            convergent_angle=45,
-            expansion_ratio=4,
-        ),
-        injector=BipropellantInjectorFactory.build(),
-        combustion_chamber=CombustionChamberFactory.build(
-            casing_inner_diameter=70e-3,
-            casing_outer_diameter=76e-3,
-            internal_length=13e-3,
-            thermal_liner_thickness=2e-3,
-        ),
-    )
-
-    motor = LiquidEngineFactory.build(
-        propellant=propellant,
-        feed_system=feed_system,
-        thrust_chamber=thrust_chamber,
-        oxidizer_tank_cog=0.5,
-        fuel_tank_cog=0.4,
-    )
-    params = InternalBallisticsSimulationParams(
-        d_t=1e-4,
-        igniter_pressure=1e6,
-        external_pressure=1e5,
-        other_losses=0.12,
-    )
-    return motor, params
-
-
 @pytest.fixture(scope="module")
 def simulated_motor_and_result() -> tuple[motors.LiquidEngine, LiquidSimulationResult]:
-    motor, params = _build_1kn_lre()
+    motor, params = motor_builders.build_1kn_lre()
     return motor, run_simulation(motor, params)
 
 
@@ -159,7 +84,7 @@ def test_recorded_per_timestep_arrays_are_aligned(
 
 
 def _build_state_for_burnout_test() -> LiquidEngineState:
-    motor, params = _build_1kn_lre()
+    motor, params = motor_builders.build_1kn_lre()
     return LiquidEngineState(
         motor=motor,
         igniter_pressure=params.igniter_pressure,

--- a/tests/test_simulations/test_solid_motor_simulation.py
+++ b/tests/test_simulations/test_solid_motor_simulation.py
@@ -1,10 +1,7 @@
 """End-to-end integration tests for SolidMotor internal ballistics simulations.
 
-The motor configurations below mirror the ones in the example scripts under
-examples/ (apcp_motor, kappa_rnakka, nero_motor) but are duplicated here so
-the tests stay independent of the example layer. The olympus example is not
-included because it currently fails on a stale BatesSegment(spacing=...) call
-that is not this test's concern.
+The motor configurations live in tests/test_simulations/motor_builders.py so
+they can be reused by benchmarks under tests/benchmarks/.
 """
 
 from __future__ import annotations
@@ -14,143 +11,14 @@ from typing import Callable
 import numpy as np
 import pytest
 
-from machwave.models import grain as grain_models
 from machwave.models import motors
-from machwave.models.propellants.formulations import solid as solid_propellants
 from machwave.simulation import InternalBallisticsSimulationParams
 from machwave.simulation.solid import SolidSimulationResult
-from tests.factories import (
-    BatesSegmentFactory,
-    CombustionChamberFactory,
-    NozzleFactory,
-    SolidMotorFactory,
-    SolidMotorThrustChamberFactory,
-)
+from tests.test_simulations import motor_builders
 from tests.test_simulations.conftest import (
     assert_recorded_arrays_aligned,
     run_simulation,
 )
-
-
-def _build_apcp_motor() -> tuple[motors.SolidMotor, InternalBallisticsSimulationParams]:
-    """MIT Cherry Limeade APCP motor with five identical BATES segments."""
-    grain = grain_models.Grain(spacing=0.01)
-    bates_segment = BatesSegmentFactory.build(
-        outer_diameter=0.085, core_diameter=0.035, length=0.150
-    )
-    for _ in range(5):
-        grain.add_segment(bates_segment)
-
-    thrust_chamber = SolidMotorThrustChamberFactory.build(
-        nozzle=NozzleFactory.build(
-            inlet_diameter=0.080,
-            throat_diameter=0.022,
-            divergent_angle=12,
-            convergent_angle=45,
-            expansion_ratio=8,
-        ),
-        combustion_chamber=CombustionChamberFactory.build(
-            casing_inner_diameter=95.25e-3,
-            casing_outer_diameter=101.6e-3,
-            thermal_liner_thickness=3e-3,
-            internal_length=grain.total_length + 0.01,
-        ),
-        dry_mass=6.0,
-        center_of_gravity_coordinate=(0.35, 0.0, 0.0),
-    )
-    motor = SolidMotorFactory.build(
-        grain=grain,
-        propellant=solid_propellants.MIT_CHERRY_LIMEADE,
-        thrust_chamber=thrust_chamber,
-    )
-    params = InternalBallisticsSimulationParams(
-        d_t=0.01,
-        igniter_pressure=1e6,
-        external_pressure=1e5,
-        other_losses=0.12,
-    )
-    return motor, params
-
-
-def _build_kappa_rnakka_motor() -> tuple[
-    motors.SolidMotor, InternalBallisticsSimulationParams
-]:
-    """Richard Nakka's Kappa motor (KNDX, four BATES segments)."""
-    grain = grain_models.Grain(spacing=5e-3)
-    bates_segment = BatesSegmentFactory.build(
-        outer_diameter=55e-3, core_diameter=19e-3, length=101.6e-3
-    )
-    for _ in range(4):
-        grain.add_segment(bates_segment)
-
-    thrust_chamber = SolidMotorThrustChamberFactory.build(
-        nozzle=NozzleFactory.build(
-            inlet_diameter=40e-3,
-            throat_diameter=12.8e-3,
-            divergent_angle=12,
-            convergent_angle=25,
-            expansion_ratio=11,
-        ),
-        combustion_chamber=CombustionChamberFactory.build(
-            casing_inner_diameter=60e-3,
-            casing_outer_diameter=64e-3,
-            thermal_liner_thickness=1e-3,
-            internal_length=grain.total_length + 5e-3,
-        ),
-        center_of_gravity_coordinate=(0.035, 0.0, 0.0),
-    )
-    motor = SolidMotorFactory.build(
-        grain=grain,
-        propellant=solid_propellants.KNDX,
-        thrust_chamber=thrust_chamber,
-    )
-    params = InternalBallisticsSimulationParams(
-        d_t=0.001,
-        igniter_pressure=1e6,
-        external_pressure=1e5,
-        other_losses=0.12,
-    )
-    return motor, params
-
-
-def _build_nero_motor() -> tuple[motors.SolidMotor, InternalBallisticsSimulationParams]:
-    """Supernova Rocketry Nero motor (KNDX, four BATES segments)."""
-    grain = grain_models.Grain(spacing=10e-3)
-    bates_segment = BatesSegmentFactory.build(
-        outer_diameter=41e-3, core_diameter=15e-3, length=67.5e-3
-    )
-    for _ in range(4):
-        grain.add_segment(bates_segment)
-
-    thrust_chamber = SolidMotorThrustChamberFactory.build(
-        nozzle=NozzleFactory.build(
-            inlet_diameter=43e-3,
-            throat_diameter=9.5e-3,
-            divergent_angle=12,
-            convergent_angle=40,
-            expansion_ratio=8,
-        ),
-        combustion_chamber=CombustionChamberFactory.build(
-            casing_inner_diameter=44.5e-3,
-            casing_outer_diameter=50.8e-3,
-            thermal_liner_thickness=1e-3,
-            internal_length=grain.total_length + 10e-3,
-        ),
-        center_of_gravity_coordinate=(0.04, 0.0, 0.0),
-    )
-    motor = SolidMotorFactory.build(
-        grain=grain,
-        propellant=solid_propellants.KNDX,
-        thrust_chamber=thrust_chamber,
-    )
-    params = InternalBallisticsSimulationParams(
-        d_t=0.01,
-        igniter_pressure=1e6,
-        external_pressure=1e5,
-        other_losses=0.12,
-    )
-    return motor, params
-
 
 SolidMotorBuilder = Callable[
     [], tuple[motors.SolidMotor, InternalBallisticsSimulationParams]
@@ -158,16 +26,16 @@ SolidMotorBuilder = Callable[
 
 
 SOLID_MOTOR_BUILDERS: tuple[SolidMotorBuilder, ...] = (
-    _build_apcp_motor,
-    _build_kappa_rnakka_motor,
-    _build_nero_motor,
+    motor_builders.build_apcp_motor,
+    motor_builders.build_kappa_rnakka_motor,
+    motor_builders.build_nero_motor,
 )
 
 
 @pytest.fixture(
     scope="module",
     params=SOLID_MOTOR_BUILDERS,
-    ids=lambda builder: builder.__name__.removeprefix("_build_"),
+    ids=lambda builder: builder.__name__.removeprefix("build_"),
 )
 def simulation_result(request: pytest.FixtureRequest) -> SolidSimulationResult:
     motor, params = request.param()

--- a/uv.lock
+++ b/uv.lock
@@ -800,6 +800,7 @@ dev = [
     { name = "pylint" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "rocketpy" },
     { name = "ruff" },
@@ -835,6 +836,7 @@ dev = [
     { name = "pylint", specifier = ">=3.3.5,<5.0.0" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-benchmark", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-cov", specifier = ">=6.2.1,<8.0.0" },
     { name = "rocketpy", specifier = ">=1.11.0,<2.0.0" },
     { name = "ruff" },
@@ -1495,6 +1497,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "py2puml"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1579,6 +1590,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add a pytest-benchmark suite covering the solid and liquid internal-ballistics per-timestep loops, plus a CI job that runs the suite on the pull request base and head SHAs and fails on median regressions above 25%.

The benchmarks reuse the motor configurations from the existing integration tests, extracted into `tests/test_simulations/motor_builders.py`. Step sizes are tuned for CI tractability: kappa solid motor at `d_t=0.01` (vs the test's `0.001`) and the 1 kN liquid engine at `d_t=4e-4` (vs the test's `1e-4`). The liquid value sits well inside the explicit RK4 stability region — at `d_t=5e-4` the chamber-pressure integrator blows up and the simulation terminates on step 1. Total impulse at `d_t=4e-4` matches the `d_t=1e-4` reference within 0.01%.

Locally: solid loop ~16 ms median, liquid loop ~25 s median, full suite ~78 s. In CI the comparison job runs the suite twice (base + head) for a total of ~3 minutes.

## Linked issue

Closes #156

## Test plan

- [x] `make check` passes (format, lint, typecheck)
- [x] `make test` passes (24 simulation integration tests after the motor-builder refactor)
- [x] `make benchmark` runs the new suite end-to-end
- [x] Verified benchmarks are skipped by default under `make test` (`--benchmark-skip` in `pytest.ini`)
- [ ] Watch the first PR-after-merge to confirm the comparison flow against a real master baseline

## Documentation

- [x] Not applicable (internal change only — no public API surface)

## Additional notes

- The `benchmark` CI job is configured with `--benchmark-compare-fail=median:25%`. 25% absorbs typical GitHub Actions runner noise (±10–15%) while still catching a real 1.3× slowdown. Tune after observing real CI variance.
- For the first PR through (this one), the base SHA does not yet have `tests/benchmarks/`, so the job skips the comparison and only runs the benchmarks on HEAD — that branch cannot fail on regression. From the next PR onward the gate is active.
- The job will fail the CI check on regression past 25%, but does **not** block merge unless `benchmark` is added to branch-protection required checks. Worth adding once the threshold is dialed in.
- The chamber-pressure mass-balance ODE is stiff at engine startup (time constant ~67 µs for the 1 kN liquid engine), which is why the explicit RK4 stability cliff falls between `d_t=4e-4` and `d_t=5e-4`. A stiff solver (BDF / Rosenbrock / implicit RK) would remove that ceiling — out of scope here but flagging it as latent technical debt.