### PR TITLE
Extract feed-system component specifications and restructure feed_systems package

### DIFF
--- a/docs/api/core/interpolation.md
+++ b/docs/api/core/interpolation.md
@@ -1,0 +1,31 @@
+# core.interpolation
+
+Generic interpolation utilities for tabulated curves used across machwave.
+
+## `BoundedCubicSpline`
+
+Many parts of machwave consume property curves as small tables — pump head versus volumetric flow, burn rate versus pressure, nozzle area versus axial station. `BoundedCubicSpline` wraps such a table in a cubic spline that:
+
+1. **Interpolates between knots with a cubic spline.** Smooth derivatives matter when the curve is composed with downstream solvers (RK4 step, root-finder on injector–chamber balance, etc.).
+2. **Refuses to extrapolate.** [`scipy.interpolate.CubicSpline`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.CubicSpline.html) is constructed with `extrapolate=False`, and the class additionally raises `ValueError` for any input outside `[x_points[0], x_points[-1]]`. A simulation that drifts off the calibrated domain fails loudly rather than producing fabricated values.
+
+The constructor rejects malformed tables eagerly: the two sequences must be one-dimensional, the same length, contain at least two knots, and `x_points` must be strictly increasing. The inclusive domain bounds are exposed via the `domain` property.
+
+### Example
+
+```python
+from machwave.core.interpolation import BoundedCubicSpline
+
+efficiency_curve = BoundedCubicSpline(
+    x_points=[0.5, 1.0, 1.5, 2.0],
+    y_points=[0.55, 0.65, 0.62, 0.50],
+)
+
+efficiency_curve.domain   # → (0.5, 2.0)
+efficiency_curve(1.2)     # → smooth spline value
+efficiency_curve(3.0)     # raises ValueError — outside [0.5, 2.0]
+```
+
+---
+
+::: machwave.core.interpolation

--- a/docs/api/models/feed_systems.md
+++ b/docs/api/models/feed_systems.md
@@ -1,9 +1,49 @@
 # models.feed_systems
 
-Feed system models for liquid rocket engines. Defines how propellant is delivered from tanks to the combustion chamber.
+Feed-system models for liquid rocket engines. The package describes how
+propellant is delivered from the tanks to the combustion chamber, and is
+organised around three concerns:
 
-The base `FeedSystem` class abstracts mass flow rate and tank pressure calculations. `StackedTankPressureFedFeedSystem` implements a pressure-fed configuration with oxidizer and fuel lines, accounting for line losses and piston pressure drops.
+| Concern | Where it lives | What it contains |
+| --- | --- | --- |
+| Contract | `feed_systems.base` | The abstract [`FeedSystem`][machwave.models.feed_systems.base.FeedSystem] interface every cycle must satisfy. |
+| Cycle implementations | [`feed_systems.cycles`](feed_systems/cycles.md) | One module per cycle topology (pressure-fed today; electric-pump, gas-generator, expander, staged-combustion to follow). |
+| Shared component descriptions | [`feed_systems.components`](feed_systems/components.md) | Static descriptions of pumps, turbines, gas generators, regenerative jackets, plus a tabulated-curve helper that cycle implementations consume. |
+| Tank thermodynamics | [`feed_systems.tanks`](feed_systems/tanks.md) | Two-phase tank model backed by CoolProp. |
 
-See [tanks](feed_systems/tanks.md) for the tank thermodynamic model.
+## The `FeedSystem` contract
+
+Every cycle implementation extends [`FeedSystem`][machwave.models.feed_systems.base.FeedSystem] and exposes four methods used by the simulation loop:
+
+- `get_mass_flow_ox(chamber_pressure, *, discharge_coefficient=None, injector_area=None) -> float`
+- `get_mass_flow_fuel(chamber_pressure, *, discharge_coefficient=None, injector_area=None) -> float`
+- `get_oxidizer_tank_pressure() -> float`
+- `get_fuel_tank_pressure() -> float`
+
+`discharge_coefficient` and `injector_area` are keyword-only with `None` defaults: pressure-fed cycles need them to evaluate the injector orifice equation, while turbopump cycles that schedule mass flow from pump-curve solutions do not. Keeping the keywords on the abstract base means a single call site in the integrator works against either kind of cycle.
+
+The concrete propellant mass-flow consumer is [`machwave.simulation.liquid.states.LiquidEngineState.run_timestep`][machwave.simulation.liquid.states.LiquidEngineState.run_timestep], which always passes the keywords explicitly — code calling these methods should follow the same pattern.
+
+## Public surface
+
+Importing from `machwave.models.feed_systems` exposes the abstract base, every concrete cycle, and the `components` sub-package:
+
+```python
+from machwave.models.feed_systems import (
+    FeedSystem,
+    StackedTankPressureFedFeedSystem,
+    components,
+)
+
+pump_spec = components.PumpSpec(
+    name="oxidizer pump",
+    isentropic_efficiency=0.7,
+    pressure_rise=5.0e6,
+    volumetric_flow_design=2.0e-3,
+    shaft_speed_design=3000.0,
+)
+```
+
+The top-level `machwave` package additionally re-exports `feed_systems` as a shortcut, so `from machwave import feed_systems` and `feed_systems.StackedTankPressureFedFeedSystem` work identically.
 
 ::: machwave.models.feed_systems

--- a/docs/api/models/feed_systems/components.md
+++ b/docs/api/models/feed_systems/components.md
@@ -1,0 +1,96 @@
+# models.feed_systems.components
+
+Static, immutable descriptions of the physical components a feed-system cycle is built from. The classes in this sub-package do not contain integration state and never mutate during a simulation — they sit alongside propellant definitions as part of the engine *configuration*. Cycle implementations in [`machwave.models.feed_systems.cycles`](cycles.md) read these specifications and combine them with the live tank state and chamber conditions to compute mass flow, head rise, and shaft power.
+
+Every spec is implemented as a `@dataclass(frozen=True, kw_only=True)` with `__post_init__` validation, mirroring the convention used by [`ThermochemicalProperties`][machwave.models.propellants.properties.ThermochemicalProperties]. Construction with an out-of-range value raises `ValueError` at the call site rather than producing nonsensical numbers downstream.
+
+Specs that carry property *curves* (e.g. pump head versus volumetric flow, turbine efficiency versus pressure ratio) wrap their tabulated data in [`machwave.core.interpolation.BoundedCubicSpline`](../../core/interpolation.md), which raises rather than extrapolating outside the calibrated knots.
+
+## When you need which spec
+
+| Cycle topology | Needs | Why |
+| --- | --- | --- |
+| Pressure-fed (stacked, regulated, blowdown) | nothing in this package | The injector orifice equation and tank pressure are sufficient. |
+| Electric-pump | [`PumpSpec`](#pumpspec) | Each pump still needs design-point data even though the drive is electric, because head rise is interpolated from the pump curve. |
+| Gas-generator | [`PumpSpec`](#pumpspec), [`TurbineSpec`](#turbinespec), [`GasGeneratorSpec`](#gasgeneratorspec) | The gas generator burns a small fraction of the propellants to drive the turbine, which in turn drives the pumps. |
+| Expander | [`PumpSpec`](#pumpspec), [`TurbineSpec`](#turbinespec), [`RegenerativeJacketSpec`](#regenerativejacketspec) | Heat absorbed by the coolant in the jacket vaporises one propellant; that vapor drives the turbine. |
+| Staged combustion | [`PumpSpec`](#pumpspec), [`TurbineSpec`](#turbinespec), [`GasGeneratorSpec`](#gasgeneratorspec) (as preburner), [`RegenerativeJacketSpec`](#regenerativejacketspec) | The full pre-combusted flow is routed through the turbine and then into the main chamber. |
+
+See Sutton & Biblarz, *Rocket Propulsion Elements* (Wiley, 2017), chapter 10, and Huzel & Huang, *Modern Engineering for Design of Liquid-Propellant Rocket Engines* (AIAA, 1992), chapter 6, for the underlying engine-cycle theory these specs describe.
+
+---
+
+## `PumpSpec`
+
+Captures a propellant pump at its design point. The fields are deliberately limited to what a cycle integrator needs to evaluate head rise and shaft power from a single operating point — anything that varies with operating condition (head-flow curve, NPSH margin) belongs in a [`BoundedCubicSpline`](../../core/interpolation.md) and stored alongside the spec by the cycle that owns it.
+
+| Field | Units | Constraint |
+| --- | --- | --- |
+| `name` | — | Free-form identifier used in logs and reports. |
+| `isentropic_efficiency` | — | $\eta_p \in (0, 1]$ |
+| `pressure_rise` | Pa | Strictly positive |
+| `volumetric_flow_design` | m³/s | Strictly positive |
+| `shaft_speed_design` | rad/s | Strictly positive |
+
+Shaft power at the design point follows directly from the fields, assuming an incompressible working fluid:
+
+\[
+\dot{W}_{\text{shaft}} = \frac{\dot{V} \cdot \Delta P}{\eta_p}
+\]
+
+---
+
+## `TurbineSpec`
+
+Captures a turbine at its design point. Cycle integrators evaluate the specific work extracted from the working fluid using the inlet temperature and pressure ratio, then deliver the resulting shaft power to the coupled pump(s).
+
+| Field | Units | Constraint |
+| --- | --- | --- |
+| `name` | — | Free-form identifier. |
+| `isentropic_efficiency` | — | $\eta_t \in (0, 1]$ |
+| `pressure_ratio` | — | $\pi_t > 1$ |
+| `inlet_temperature_design` | K | Strictly positive |
+| `mass_flow_design` | kg/s | Strictly positive |
+
+Isentropic specific work for a perfect gas across the turbine:
+
+\[
+w_t = c_p \cdot T_{t,\text{in}} \cdot \left[1 - \pi_t^{-(\gamma - 1)/\gamma}\right] \cdot \eta_t
+\]
+
+`mass_flow_design` is recorded for sizing checks: the cycle solver verifies that the working-fluid mass flow it computes (for a gas generator, the burned fraction; for an expander, the regen flow) stays close to the design point used to specify the turbine.
+
+---
+
+## `GasGeneratorSpec`
+
+Describes the gas generator that drives the turbine in a gas-generator-cycle engine or the preburner in a staged-combustion engine. The defining design choice is the operating mixture ratio, which is held well off-stoichiometric so the combustion-product temperature stays below uncooled turbine-blade metal limits.
+
+| Field | Units | Constraint |
+| --- | --- | --- |
+| `name` | — | Free-form identifier. |
+| `mixture_ratio` | — | Strictly positive (oxidizer/fuel mass ratio). |
+| `chamber_pressure` | Pa | Strictly positive |
+| `gas_temperature` | K | Must lie in `[GAS_TEMPERATURE_MINIMUM_KELVIN, GAS_TEMPERATURE_MAXIMUM_KELVIN]` (300 K – 1500 K). |
+| `mass_flow` | kg/s | Strictly positive |
+
+The temperature bounds exist to catch unit-confusion bugs and configurations that would silently melt a real turbine — they are intentionally wider than any well-designed gas generator would run, but narrow enough to reject obvious mistakes.
+
+---
+
+## `RegenerativeJacketSpec`
+
+Describes a regenerative cooling jacket wrapping the combustion chamber and nozzle. One propellant — typically the fuel, sometimes the oxidizer in oxidizer-rich cycles — is routed through cooling passages to absorb heat from the chamber walls before injection. The jacket therefore acts simultaneously as a heat exchanger and a pressure-loss component in the feed train.
+
+| Field | Units | Constraint |
+| --- | --- | --- |
+| `name` | — | Free-form identifier. |
+| `pressure_drop` | Pa | Non-negative |
+| `coolant_temperature_rise` | K | Strictly positive |
+| `heat_pickup` | W | Non-negative |
+
+`heat_pickup` and `coolant_temperature_rise` are not independent — once a coolant mass flow is fixed they are linked by $\dot{Q} = \dot{m} \cdot c_p \cdot \Delta T$. Both are stored because the cycle solver needs `heat_pickup` to compute the turbine inlet enthalpy in an expander cycle, and `coolant_temperature_rise` to verify the jacket is not over-pushed thermally.
+
+---
+
+::: machwave.models.feed_systems.components

--- a/docs/api/models/feed_systems/components.md
+++ b/docs/api/models/feed_systems/components.md
@@ -64,17 +64,17 @@ w_t = c_p \cdot T_{t,\text{in}} \cdot \left[1 - \pi_t^{-(\gamma - 1)/\gamma}\rig
 
 ## `GasGeneratorSpec`
 
-Describes the gas generator that drives the turbine in a gas-generator-cycle engine or the preburner in a staged-combustion engine. The defining design choice is the operating mixture ratio, which is held well off-stoichiometric so the combustion-product temperature stays below uncooled turbine-blade metal limits.
+Describes the gas generator that drives the turbine in a gas-generator-cycle engine or the preburner in a staged-combustion engine. The defining design choice is the operating mixture ratio, which is typically held well off-stoichiometric so the combustion-product temperature stays below the metal limits of the downstream turbine (whether uncooled or actively cooled).
 
 | Field | Units | Constraint |
 | --- | --- | --- |
 | `name` | — | Free-form identifier. |
 | `mixture_ratio` | — | Strictly positive (oxidizer/fuel mass ratio). |
 | `chamber_pressure` | Pa | Strictly positive |
-| `gas_temperature` | K | Must lie in `[GAS_TEMPERATURE_MINIMUM_KELVIN, GAS_TEMPERATURE_MAXIMUM_KELVIN]` (300 K – 1500 K). |
+| `gas_temperature` | K | Strictly positive |
 | `mass_flow` | kg/s | Strictly positive |
 
-The temperature bounds exist to catch unit-confusion bugs and configurations that would silently melt a real turbine — they are intentionally wider than any well-designed gas generator would run, but narrow enough to reject obvious mistakes.
+Cooled, uncooled, and research configurations operate over a wide temperature range, so `gas_temperature` is only checked for physical positivity; the caller is responsible for selecting a value compatible with the turbine they are driving.
 
 ---
 

--- a/docs/api/models/feed_systems/cycles.md
+++ b/docs/api/models/feed_systems/cycles.md
@@ -1,0 +1,62 @@
+# models.feed_systems.cycles
+
+Concrete feed-system cycle implementations. A *cycle* is the topology that determines how propellant is pressurised on its way from the tanks to the injector — pressure stored in the tanks themselves, electrically driven pumps, turbine-driven pumps powered by a small bleed-off combustor, and so on. Each module in this sub-package implements one topology and conforms to the [`FeedSystem`][machwave.models.feed_systems.base.FeedSystem] contract so the simulation loop can treat them interchangeably.
+
+## Available cycles
+
+- [`StackedTankPressureFedFeedSystem`](#stackedtankpressurefedfeedsystem) — Pressure-fed engine with the oxidizer tank stacked directly above a piston-separated fuel tank. Tank pressure provides both propellants' driving head.
+
+Additional cycles are under active development as separate work items: electric-pump, gas-generator, expander, and staged-combustion. When they land, they will reuse the dataclasses in [`feed_systems.components`](components.md) to describe their pumps, turbines, gas generators, and regenerative jackets.
+
+## How cycles compose with the rest of the engine
+
+```
+┌──────────────┐  ┌──────────────────────┐  ┌──────────┐  ┌──────────┐
+│ tanks.Tank   │──│ feed_systems.cycles  │──│ injector │──│ chamber  │
+│ (two-phase)  │  │  (this sub-package)  │  │          │  │          │
+└──────────────┘  └──────────────────────┘  └──────────┘  └──────────┘
+                       ▲           ▲
+                       │           │
+                  feed_systems.components
+                  (pump/turbine/gas-generator
+                   /regenerative-jacket specs)
+```
+
+The cycle reads tank state via the [`Tank`][machwave.models.feed_systems.tanks.base.Tank] instances it was constructed with, and combines that state with any [component specs](components.md) it owns to evaluate mass flow through the injector. The simulation step lives in [`LiquidEngineState.run_timestep`][machwave.simulation.liquid.states.LiquidEngineState.run_timestep], which calls `get_mass_flow_ox` and `get_mass_flow_fuel` once per integration step with the current `chamber_pressure` and the injector geometry from the [`BipropellantInjector`][machwave.models.thrust_chamber.injector.BipropellantInjector].
+
+---
+
+## `StackedTankPressureFedFeedSystem`
+
+A bipropellant pressure-fed engine in which the oxidizer and fuel tanks are arranged as a single vertical stack separated by a piston. The oxidizer tank pressure pressurises both propellants — directly for the oxidizer, and indirectly for the fuel through the piston. Pressure loss across the piston is captured by `piston_loss`.
+
+**Construction**
+
+```python
+from machwave.models.feed_systems import StackedTankPressureFedFeedSystem
+from machwave.models.feed_systems.tanks import Tank
+
+feed_system = StackedTankPressureFedFeedSystem(
+    oxidizer_line_diameter=0.010,    # m
+    oxidizer_line_length=0.5,        # m
+    fuel_line_diameter=0.008,        # m
+    fuel_line_length=0.5,            # m
+    fuel_tank=Tank("Ethanol", volume=0.008, temperature=298.0, initial_fluid_mass=3.0),
+    oxidizer_tank=Tank("N2O",   volume=0.010, temperature=298.0, initial_fluid_mass=5.0),
+    piston_loss=0.0,                  # Pa
+)
+```
+
+**Mass-flow model.** Each propellant's mass flow is evaluated with the injector orifice equation via `get_mass_flow_orifice` (in [`machwave.core.incompressible_flow`](../../core.md)):
+
+\[
+\dot{m} = C_d \cdot A \cdot \sqrt{2 \rho \left(P_\text{up} - P_\text{down}\right)}
+\]
+
+with $P_\text{up}$ equal to the oxidizer tank pressure for the oxidizer branch and to `oxidizer_tank_pressure - piston_loss` for the fuel branch, $P_\text{down}$ equal to `chamber_pressure`, and $\rho$ the saturated-liquid density returned by [`Tank.get_density`][machwave.models.feed_systems.tanks.base.Tank.get_density].
+
+Line geometry (`oxidizer_line_diameter`, `oxidizer_line_length`, `fuel_line_diameter`, `fuel_line_length`) is currently stored on the instance for downstream issues that will add feedline pressure drop, but is not consumed by the mass-flow model itself yet.
+
+---
+
+::: machwave.models.feed_systems.cycles

--- a/docs/theory/mass_balance.md
+++ b/docs/theory/mass_balance.md
@@ -160,7 +160,7 @@ Each tank is modelled as a **two-phase isothermal vessel** (constant \(T\), satu
 pinning when liquid is present, ideal-gas vapour when only vapour remains; cf. Huzel &
 Huang Ch. 8 for tank thermodynamics). Properties come from CoolProp; details in
 [`Tank`][machwave.models.feed_systems.tanks.base.Tank] and the orchestrating
-[`StackedTankPressureFedFeedSystem`][machwave.models.feed_systems.pressure_fed.StackedTankPressureFedFeedSystem].
+[`StackedTankPressureFedFeedSystem`][machwave.models.feed_systems.cycles.stacked_tank_pressure_fed.StackedTankPressureFedFeedSystem].
 
 ### 2.3.3 Stoichiometric Limiting-Reagent Adjustment
 

--- a/machwave/core/interpolation.py
+++ b/machwave/core/interpolation.py
@@ -1,0 +1,68 @@
+"""Generic interpolation utilities for tabulated curves used across machwave."""
+
+from collections.abc import Sequence
+
+import numpy as np
+from scipy.interpolate import CubicSpline
+
+
+class BoundedCubicSpline:
+    """Cubic-spline interpolant that does not extrapolate outside its domain."""
+
+    def __init__(
+        self,
+        x_points: Sequence[float],
+        y_points: Sequence[float],
+    ) -> None:
+        """Construct the spline from a table of knots.
+
+        Args:
+            x_points: Strictly increasing knot locations along the independent
+                axis. Must contain at least two entries.
+            y_points: Dependent values at each knot. Must have the same length
+                as `x_points`.
+
+        Raises:
+            ValueError: If the inputs are not one-dimensional sequences of
+                equal length, if fewer than two knots are supplied, or if
+                `x_points` is not strictly increasing.
+        """
+        x_array = np.asarray(x_points, dtype=float)
+        y_array = np.asarray(y_points, dtype=float)
+
+        if x_array.ndim != 1 or y_array.ndim != 1 or x_array.shape != y_array.shape:
+            raise ValueError(
+                "x_points and y_points must be one-dimensional sequences of equal length"
+            )
+        if x_array.size < 2:
+            raise ValueError("BoundedCubicSpline needs at least two knots")
+        if not np.all(np.diff(x_array) > 0):
+            raise ValueError("x_points must be strictly increasing")
+
+        self._spline = CubicSpline(x_array, y_array, extrapolate=False)
+        self._domain_minimum = float(x_array[0])
+        self._domain_maximum = float(x_array[-1])
+
+    @property
+    def domain(self) -> tuple[float, float]:
+        """Return the inclusive `(minimum, maximum)` bounds of the spline."""
+        return (self._domain_minimum, self._domain_maximum)
+
+    def __call__(self, value: float) -> float:
+        """Return the interpolated value at `value`.
+
+        Args:
+            value: Independent-axis input at which to evaluate the spline.
+
+        Returns:
+            Interpolated dependent value.
+
+        Raises:
+            ValueError: If `value` is outside the inclusive `domain`.
+        """
+        if value < self._domain_minimum or value > self._domain_maximum:
+            raise ValueError(
+                f"input {value} is outside "
+                f"[{self._domain_minimum}, {self._domain_maximum}]"
+            )
+        return float(self._spline(value))

--- a/machwave/core/interpolation.py
+++ b/machwave/core/interpolation.py
@@ -1,5 +1,3 @@
-"""Generic interpolation utilities for tabulated curves used across machwave."""
-
 from collections.abc import Sequence
 
 import numpy as np
@@ -7,7 +5,7 @@ from scipy.interpolate import CubicSpline
 
 
 class BoundedCubicSpline:
-    """Cubic-spline interpolant that does not extrapolate outside its domain."""
+    """Cubic spline interpolant that does not extrapolate outside its domain."""
 
     def __init__(
         self,

--- a/machwave/models/feed_systems/__init__.py
+++ b/machwave/models/feed_systems/__init__.py
@@ -1,5 +1,5 @@
 from machwave.models.feed_systems.base import FeedSystem
-from machwave.models.feed_systems.pressure_fed import (
+from machwave.models.feed_systems.cycles.stacked_tank_pressure_fed import (
     StackedTankPressureFedFeedSystem,
 )
 

--- a/machwave/models/feed_systems/__init__.py
+++ b/machwave/models/feed_systems/__init__.py
@@ -1,3 +1,4 @@
+from machwave.models.feed_systems import components
 from machwave.models.feed_systems.base import FeedSystem
 from machwave.models.feed_systems.cycles.stacked_tank_pressure_fed import (
     StackedTankPressureFedFeedSystem,
@@ -6,4 +7,5 @@ from machwave.models.feed_systems.cycles.stacked_tank_pressure_fed import (
 __all__ = [
     "FeedSystem",
     "StackedTankPressureFedFeedSystem",
+    "components",
 ]

--- a/machwave/models/feed_systems/base.py
+++ b/machwave/models/feed_systems/base.py
@@ -10,6 +10,10 @@ class FeedSystem(ABC):
     This class is responsible for determining oxidizer and fuel mass flows as a function of tank/pressurant states,
     pumps (if any), and current chamber conditions. Subclasses must implement the abstract methods to specify the
     actual flow calculations.
+
+    The mass-flow methods accept `discharge_coefficient` and `injector_area` as keyword-only arguments with
+    `None` defaults. Pressure-fed cycles require both to evaluate the injector orifice equation. Cycles that
+    schedule mass flow from pump curves or other internal logic can ignore them.
     """
 
     def __init__(self, fuel_tank: Tank, oxidizer_tank: Tank):
@@ -27,13 +31,43 @@ class FeedSystem(ABC):
         return self.fuel_tank.fluid_mass + self.oxidizer_tank.fluid_mass
 
     @abstractmethod
-    def get_mass_flow_ox(self, *args, **kwargs) -> float:
-        """Compute and return the current oxidizer mass flow rate [kg/s]."""
+    def get_mass_flow_ox(
+        self,
+        chamber_pressure: float,
+        *,
+        discharge_coefficient: float | None = None,
+        injector_area: float | None = None,
+    ) -> float:
+        """Compute and return the current oxidizer mass flow rate [kg/s].
+
+        Args:
+            chamber_pressure: Chamber pressure [Pa].
+            discharge_coefficient: Oxidizer injector discharge coefficient (dimensionless).
+            injector_area: Effective flow area for the oxidizer injector [m^2].
+
+        Returns:
+            Oxidizer mass flow rate [kg/s].
+        """
         pass
 
     @abstractmethod
-    def get_mass_flow_fuel(self, *args, **kwargs) -> float:
-        """Compute and return the current fuel mass flow rate [kg/s]."""
+    def get_mass_flow_fuel(
+        self,
+        chamber_pressure: float,
+        *,
+        discharge_coefficient: float | None = None,
+        injector_area: float | None = None,
+    ) -> float:
+        """Compute and return the current fuel mass flow rate [kg/s].
+
+        Args:
+            chamber_pressure: Chamber pressure [Pa].
+            discharge_coefficient: Fuel injector discharge coefficient (dimensionless).
+            injector_area: Effective flow area for the fuel injector [m^2].
+
+        Returns:
+            Fuel mass flow rate [kg/s].
+        """
         pass
 
     @abstractmethod

--- a/machwave/models/feed_systems/components/__init__.py
+++ b/machwave/models/feed_systems/components/__init__.py
@@ -1,0 +1,15 @@
+"""Shared component specifications consumed by feed-system cycle implementations."""
+
+from machwave.models.feed_systems.components.gas_generator import GasGeneratorSpec
+from machwave.models.feed_systems.components.pump import PumpSpec
+from machwave.models.feed_systems.components.regenerative_jacket import (
+    RegenerativeJacketSpec,
+)
+from machwave.models.feed_systems.components.turbine import TurbineSpec
+
+__all__ = [
+    "GasGeneratorSpec",
+    "PumpSpec",
+    "RegenerativeJacketSpec",
+    "TurbineSpec",
+]

--- a/machwave/models/feed_systems/components/gas_generator.py
+++ b/machwave/models/feed_systems/components/gas_generator.py
@@ -1,32 +1,17 @@
-"""Gas-generator specification dataclass shared by gas-generator-cycle feed systems."""
-
 import dataclasses
-
-GAS_TEMPERATURE_MINIMUM_KELVIN = 300.0
-GAS_TEMPERATURE_MAXIMUM_KELVIN = 1500.0
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GasGeneratorSpec:
-    """Static description of a gas generator driving a turbopump turbine.
-
-    A gas generator burns a small fraction of the propellants at a low mixture
-    ratio so the resulting working fluid stays below turbine metal limits. The
-    fields below describe the combustion product stream delivered to the
-    turbine inlet at the design point.
+    """Gas generator driving a turbopump turbine.
 
     Attributes:
-        name: Human-readable identifier used in logs and reports.
-        mixture_ratio: Oxidizer-to-fuel mass ratio in the gas generator
-            (dimensionless). Must be strictly positive.
-        chamber_pressure: Combustion chamber pressure of the gas generator
-            [Pa]. Must be strictly positive.
-        gas_temperature: Combustion-product total temperature delivered to the
-            turbine inlet [K]. Must lie in
-            `[GAS_TEMPERATURE_MINIMUM_KELVIN, GAS_TEMPERATURE_MAXIMUM_KELVIN]`
-            to stay below typical uncooled turbine blade limits.
-        mass_flow: Total propellant mass flow through the gas generator
-            [kg/s]. Must be strictly positive.
+        name: Identifier used in logs and reports.
+        mixture_ratio: Oxidizer to fuel mass ratio in the gas generator (>0).
+        chamber_pressure: Combustion chamber pressure of the gas generator [Pa] (>0).
+        gas_temperature: Combustion total temperature delivered to the turbine inlet
+            [K] (>0).
+        mass_flow: Total propellant mass flow through the gas generator [kg/s] (>0).
 
     Raises:
         ValueError: If any field is outside its valid physical range.
@@ -49,15 +34,9 @@ class GasGeneratorSpec:
                 "chamber_pressure must be strictly positive, "
                 f"got {self.chamber_pressure}"
             )
-        if not (
-            GAS_TEMPERATURE_MINIMUM_KELVIN
-            <= self.gas_temperature
-            <= GAS_TEMPERATURE_MAXIMUM_KELVIN
-        ):
+        if self.gas_temperature <= 0.0:
             raise ValueError(
-                "gas_temperature must be in the interval "
-                f"[{GAS_TEMPERATURE_MINIMUM_KELVIN}, "
-                f"{GAS_TEMPERATURE_MAXIMUM_KELVIN}] K, got {self.gas_temperature}"
+                f"gas_temperature must be strictly positive, got {self.gas_temperature}"
             )
         if self.mass_flow <= 0.0:
             raise ValueError(

--- a/machwave/models/feed_systems/components/gas_generator.py
+++ b/machwave/models/feed_systems/components/gas_generator.py
@@ -1,0 +1,65 @@
+"""Gas-generator specification dataclass shared by gas-generator-cycle feed systems."""
+
+import dataclasses
+
+GAS_TEMPERATURE_MINIMUM_KELVIN = 300.0
+GAS_TEMPERATURE_MAXIMUM_KELVIN = 1500.0
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class GasGeneratorSpec:
+    """Static description of a gas generator driving a turbopump turbine.
+
+    A gas generator burns a small fraction of the propellants at a low mixture
+    ratio so the resulting working fluid stays below turbine metal limits. The
+    fields below describe the combustion product stream delivered to the
+    turbine inlet at the design point.
+
+    Attributes:
+        name: Human-readable identifier used in logs and reports.
+        mixture_ratio: Oxidizer-to-fuel mass ratio in the gas generator
+            (dimensionless). Must be strictly positive.
+        chamber_pressure: Combustion chamber pressure of the gas generator
+            [Pa]. Must be strictly positive.
+        gas_temperature: Combustion-product total temperature delivered to the
+            turbine inlet [K]. Must lie in
+            `[GAS_TEMPERATURE_MINIMUM_KELVIN, GAS_TEMPERATURE_MAXIMUM_KELVIN]`
+            to stay below typical uncooled turbine blade limits.
+        mass_flow: Total propellant mass flow through the gas generator
+            [kg/s]. Must be strictly positive.
+
+    Raises:
+        ValueError: If any field is outside its valid physical range.
+    """
+
+    name: str
+    mixture_ratio: float
+    chamber_pressure: float
+    gas_temperature: float
+    mass_flow: float
+
+    def __post_init__(self) -> None:
+        """Validate that every field lies in its physical range."""
+        if self.mixture_ratio <= 0.0:
+            raise ValueError(
+                f"mixture_ratio must be strictly positive, got {self.mixture_ratio}"
+            )
+        if self.chamber_pressure <= 0.0:
+            raise ValueError(
+                "chamber_pressure must be strictly positive, "
+                f"got {self.chamber_pressure}"
+            )
+        if not (
+            GAS_TEMPERATURE_MINIMUM_KELVIN
+            <= self.gas_temperature
+            <= GAS_TEMPERATURE_MAXIMUM_KELVIN
+        ):
+            raise ValueError(
+                "gas_temperature must be in the interval "
+                f"[{GAS_TEMPERATURE_MINIMUM_KELVIN}, "
+                f"{GAS_TEMPERATURE_MAXIMUM_KELVIN}] K, got {self.gas_temperature}"
+            )
+        if self.mass_flow <= 0.0:
+            raise ValueError(
+                f"mass_flow must be strictly positive, got {self.mass_flow}"
+            )

--- a/machwave/models/feed_systems/components/pump.py
+++ b/machwave/models/feed_systems/components/pump.py
@@ -1,27 +1,18 @@
-"""Pump specification dataclass shared by turbopump-based feed-system cycles."""
-
 import dataclasses
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class PumpSpec:
-    """Static description of a propellant pump used by turbopump cycles.
-
-    The values describe the pump at its design point. Cycle implementations
-    consume these together with operating-point data (mass flow, density,
-    rotational speed) to compute the actual head rise and power draw.
+    """Propellant pump used by turbopump cycles.
 
     Attributes:
-        name: Human-readable identifier used in logs and reports.
+        name: Identifier used in logs and reports.
         isentropic_efficiency: Ratio of isentropic enthalpy rise to actual
-            enthalpy rise (dimensionless). Must lie in the half-open interval
-            `(0, 1]`.
-        pressure_rise: Design-point pressure rise across the pump [Pa]. Must
-            be strictly positive.
-        volumetric_flow_design: Design-point volumetric flow through the pump
-            [m^3/s]. Must be strictly positive.
-        shaft_speed_design: Design-point shaft angular speed [rad/s]. Must be
-            strictly positive.
+            enthalpy rise. Must lie between 0 and 1.
+        pressure_rise: Pressure rise across the pump [Pa] (>0).
+        volumetric_flow_design: Volumetric flow through the pump
+            [m^3/s] (>0).
+        shaft_speed_design: Shaft angular speed [rad/s] (>0).
 
     Raises:
         ValueError: If any field is outside its valid physical range.

--- a/machwave/models/feed_systems/components/pump.py
+++ b/machwave/models/feed_systems/components/pump.py
@@ -1,0 +1,56 @@
+"""Pump specification dataclass shared by turbopump-based feed-system cycles."""
+
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class PumpSpec:
+    """Static description of a propellant pump used by turbopump cycles.
+
+    The values describe the pump at its design point. Cycle implementations
+    consume these together with operating-point data (mass flow, density,
+    rotational speed) to compute the actual head rise and power draw.
+
+    Attributes:
+        name: Human-readable identifier used in logs and reports.
+        isentropic_efficiency: Ratio of isentropic enthalpy rise to actual
+            enthalpy rise (dimensionless). Must lie in the half-open interval
+            `(0, 1]`.
+        pressure_rise: Design-point pressure rise across the pump [Pa]. Must
+            be strictly positive.
+        volumetric_flow_design: Design-point volumetric flow through the pump
+            [m^3/s]. Must be strictly positive.
+        shaft_speed_design: Design-point shaft angular speed [rad/s]. Must be
+            strictly positive.
+
+    Raises:
+        ValueError: If any field is outside its valid physical range.
+    """
+
+    name: str
+    isentropic_efficiency: float
+    pressure_rise: float
+    volumetric_flow_design: float
+    shaft_speed_design: float
+
+    def __post_init__(self) -> None:
+        """Validate that every field lies in its physical range."""
+        if not (0.0 < self.isentropic_efficiency <= 1.0):
+            raise ValueError(
+                "isentropic_efficiency must be in the interval (0, 1], "
+                f"got {self.isentropic_efficiency}"
+            )
+        if self.pressure_rise <= 0.0:
+            raise ValueError(
+                f"pressure_rise must be strictly positive, got {self.pressure_rise}"
+            )
+        if self.volumetric_flow_design <= 0.0:
+            raise ValueError(
+                "volumetric_flow_design must be strictly positive, "
+                f"got {self.volumetric_flow_design}"
+            )
+        if self.shaft_speed_design <= 0.0:
+            raise ValueError(
+                "shaft_speed_design must be strictly positive, "
+                f"got {self.shaft_speed_design}"
+            )

--- a/machwave/models/feed_systems/components/regenerative_jacket.py
+++ b/machwave/models/feed_systems/components/regenerative_jacket.py
@@ -1,0 +1,47 @@
+"""Regenerative-jacket specification dataclass shared by expander and staged-combustion cycles."""
+
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class RegenerativeJacketSpec:
+    """Static description of a regenerative cooling jacket around the chamber and nozzle.
+
+    Expander and staged-combustion cycles route one propellant through a
+    cooling jacket to absorb heat from the combustion chamber and nozzle walls.
+    The fields below describe the design-point operating condition the cycle
+    integrator can lean on when sizing downstream turbomachinery.
+
+    Attributes:
+        name: Human-readable identifier used in logs and reports.
+        pressure_drop: Total coolant pressure drop across the jacket [Pa]. Must
+            be non-negative.
+        coolant_temperature_rise: Coolant total-temperature rise from jacket
+            inlet to outlet [K]. Must be strictly positive.
+        heat_pickup: Heat power absorbed by the coolant across the jacket [W].
+            Must be non-negative.
+
+    Raises:
+        ValueError: If any field is outside its valid physical range.
+    """
+
+    name: str
+    pressure_drop: float
+    coolant_temperature_rise: float
+    heat_pickup: float
+
+    def __post_init__(self) -> None:
+        """Validate that every field lies in its physical range."""
+        if self.pressure_drop < 0.0:
+            raise ValueError(
+                f"pressure_drop must be non-negative, got {self.pressure_drop}"
+            )
+        if self.coolant_temperature_rise <= 0.0:
+            raise ValueError(
+                "coolant_temperature_rise must be strictly positive, "
+                f"got {self.coolant_temperature_rise}"
+            )
+        if self.heat_pickup < 0.0:
+            raise ValueError(
+                f"heat_pickup must be non-negative, got {self.heat_pickup}"
+            )

--- a/machwave/models/feed_systems/components/regenerative_jacket.py
+++ b/machwave/models/feed_systems/components/regenerative_jacket.py
@@ -1,25 +1,16 @@
-"""Regenerative-jacket specification dataclass shared by expander and staged-combustion cycles."""
-
 import dataclasses
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class RegenerativeJacketSpec:
-    """Static description of a regenerative cooling jacket around the chamber and nozzle.
-
-    Expander and staged-combustion cycles route one propellant through a
-    cooling jacket to absorb heat from the combustion chamber and nozzle walls.
-    The fields below describe the design-point operating condition the cycle
-    integrator can lean on when sizing downstream turbomachinery.
+    """Regenerative cooling component around the chamber and nozzle.
 
     Attributes:
-        name: Human-readable identifier used in logs and reports.
-        pressure_drop: Total coolant pressure drop across the jacket [Pa]. Must
-            be non-negative.
-        coolant_temperature_rise: Coolant total-temperature rise from jacket
-            inlet to outlet [K]. Must be strictly positive.
-        heat_pickup: Heat power absorbed by the coolant across the jacket [W].
-            Must be non-negative.
+        name: Identifier used in logs and reports.
+        pressure_drop: Total coolant pressure drop across the jacket [Pa] (>0).
+        coolant_temperature_rise: Coolant total temperature rise from jacket
+            inlet to outlet [K] (>0).
+        heat_pickup: Heat power absorbed by the coolant across the jacket [W] (>=0).
 
     Raises:
         ValueError: If any field is outside its valid physical range.
@@ -32,9 +23,9 @@ class RegenerativeJacketSpec:
 
     def __post_init__(self) -> None:
         """Validate that every field lies in its physical range."""
-        if self.pressure_drop < 0.0:
+        if self.pressure_drop <= 0.0:
             raise ValueError(
-                f"pressure_drop must be non-negative, got {self.pressure_drop}"
+                f"pressure_drop must be strictly positive, got {self.pressure_drop}"
             )
         if self.coolant_temperature_rise <= 0.0:
             raise ValueError(

--- a/machwave/models/feed_systems/components/turbine.py
+++ b/machwave/models/feed_systems/components/turbine.py
@@ -1,0 +1,57 @@
+"""Turbine specification dataclass shared by turbopump-based feed-system cycles."""
+
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class TurbineSpec:
+    """Static description of a turbine used by turbopump cycles.
+
+    The values describe the turbine at its design point. Cycle implementations
+    consume these together with the working-fluid conditions to compute the
+    actual shaft power delivered to the coupled pump.
+
+    Attributes:
+        name: Human-readable identifier used in logs and reports.
+        isentropic_efficiency: Ratio of actual specific work extracted to the
+            isentropic specific work available across the turbine
+            (dimensionless). Must lie in the half-open interval `(0, 1]`.
+        pressure_ratio: Ratio of turbine inlet total pressure to outlet total
+            pressure (dimensionless). Must be strictly greater than one.
+        inlet_temperature_design: Design-point total temperature at the turbine
+            inlet [K]. Must be strictly positive.
+        mass_flow_design: Design-point mass flow through the turbine [kg/s].
+            Must be strictly positive.
+
+    Raises:
+        ValueError: If any field is outside its valid physical range.
+    """
+
+    name: str
+    isentropic_efficiency: float
+    pressure_ratio: float
+    inlet_temperature_design: float
+    mass_flow_design: float
+
+    def __post_init__(self) -> None:
+        """Validate that every field lies in its physical range."""
+        if not (0.0 < self.isentropic_efficiency <= 1.0):
+            raise ValueError(
+                "isentropic_efficiency must be in the interval (0, 1], "
+                f"got {self.isentropic_efficiency}"
+            )
+        if self.pressure_ratio <= 1.0:
+            raise ValueError(
+                "pressure_ratio must be strictly greater than one, "
+                f"got {self.pressure_ratio}"
+            )
+        if self.inlet_temperature_design <= 0.0:
+            raise ValueError(
+                "inlet_temperature_design must be strictly positive, "
+                f"got {self.inlet_temperature_design}"
+            )
+        if self.mass_flow_design <= 0.0:
+            raise ValueError(
+                "mass_flow_design must be strictly positive, "
+                f"got {self.mass_flow_design}"
+            )

--- a/machwave/models/feed_systems/components/turbine.py
+++ b/machwave/models/feed_systems/components/turbine.py
@@ -1,27 +1,19 @@
-"""Turbine specification dataclass shared by turbopump-based feed-system cycles."""
-
 import dataclasses
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class TurbineSpec:
-    """Static description of a turbine used by turbopump cycles.
-
-    The values describe the turbine at its design point. Cycle implementations
-    consume these together with the working-fluid conditions to compute the
-    actual shaft power delivered to the coupled pump.
+    """Turbine used by turbopump cycles.
 
     Attributes:
-        name: Human-readable identifier used in logs and reports.
+        name: Identifier used in logs and reports.
         isentropic_efficiency: Ratio of actual specific work extracted to the
-            isentropic specific work available across the turbine
-            (dimensionless). Must lie in the half-open interval `(0, 1]`.
+            isentropic specific work available across the turbine. Must be between 0
+            and 1.
         pressure_ratio: Ratio of turbine inlet total pressure to outlet total
-            pressure (dimensionless). Must be strictly greater than one.
-        inlet_temperature_design: Design-point total temperature at the turbine
-            inlet [K]. Must be strictly positive.
-        mass_flow_design: Design-point mass flow through the turbine [kg/s].
-            Must be strictly positive.
+            pressure. Greater than 1.
+        inlet_temperature_design: Total temperature at the turbine inlet [K] (>0).
+        mass_flow_design: Mass flow through the turbine [kg/s] (>0).
 
     Raises:
         ValueError: If any field is outside its valid physical range.

--- a/machwave/models/feed_systems/cycles/__init__.py
+++ b/machwave/models/feed_systems/cycles/__init__.py
@@ -1,0 +1,15 @@
+"""Concrete feed-system cycle implementations.
+
+Each module in this package implements one cycle topology (pressure-fed,
+electric-pump, gas-generator, expander, staged combustion, ...). Cycles consume
+the shared component specifications in `machwave.models.feed_systems.components`
+and conform to the `machwave.models.feed_systems.base.FeedSystem` contract.
+"""
+
+from machwave.models.feed_systems.cycles.stacked_tank_pressure_fed import (
+    StackedTankPressureFedFeedSystem,
+)
+
+__all__ = [
+    "StackedTankPressureFedFeedSystem",
+]

--- a/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
+++ b/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
@@ -48,8 +48,9 @@ class StackedTankPressureFedFeedSystem(FeedSystem):
     def get_mass_flow_ox(
         self,
         chamber_pressure: float,
-        discharge_coefficient: float,
-        injector_area: float,
+        *,
+        discharge_coefficient: float | None = None,
+        injector_area: float | None = None,
     ) -> float:
         """
         Compute the current oxidizer mass flow rate via get_mass_flow_orifice().
@@ -61,7 +62,16 @@ class StackedTankPressureFedFeedSystem(FeedSystem):
 
         Returns:
             Oxidizer mass flow rate [kg/s].
+
+        Raises:
+            ValueError: If `discharge_coefficient` or `injector_area` is None.
         """
+        if discharge_coefficient is None or injector_area is None:
+            raise ValueError(
+                "StackedTankPressureFedFeedSystem.get_mass_flow_ox requires "
+                "discharge_coefficient and injector_area"
+            )
+
         p_up = self.get_oxidizer_tank_pressure()
         p_down = chamber_pressure
         oxidizer_density = self.oxidizer_tank.get_density()
@@ -77,8 +87,9 @@ class StackedTankPressureFedFeedSystem(FeedSystem):
     def get_mass_flow_fuel(
         self,
         chamber_pressure: float,
-        discharge_coefficient: float,
-        injector_area: float,
+        *,
+        discharge_coefficient: float | None = None,
+        injector_area: float | None = None,
     ) -> float:
         """
         Compute the current fuel mass flow rate via get_mass_flow_orifice().
@@ -91,7 +102,16 @@ class StackedTankPressureFedFeedSystem(FeedSystem):
 
         Returns:
             Fuel mass flow rate [kg/s].
+
+        Raises:
+            ValueError: If `discharge_coefficient` or `injector_area` is None.
         """
+        if discharge_coefficient is None or injector_area is None:
+            raise ValueError(
+                "StackedTankPressureFedFeedSystem.get_mass_flow_fuel requires "
+                "discharge_coefficient and injector_area"
+            )
+
         p_up = self.get_oxidizer_tank_pressure() - self.piston_loss
         p_down = chamber_pressure
         fuel_density = self.fuel_tank.get_density()

--- a/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
+++ b/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
@@ -1,7 +1,6 @@
 from machwave.core.incompressible_flow import get_mass_flow_orifice
+from machwave.models.feed_systems.base import FeedSystem
 from machwave.models.feed_systems.tanks import Tank
-
-from .base import FeedSystem
 
 
 class StackedTankPressureFedFeedSystem(FeedSystem):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - core:
           - Overview: api/core.md
           - compressible_flow: api/core/compressible_flow.md
+          - interpolation: api/core/interpolation.md
           - mass_balance: api/core/mass_balance.md
           - solvers: api/core/solvers.md
           - structural: api/core/structural.md
@@ -64,6 +65,8 @@ nav:
           - Overview: api/models.md
           - feed_systems:
               - Overview: api/models/feed_systems.md
+              - components: api/models/feed_systems/components.md
+              - cycles: api/models/feed_systems/cycles.md
               - tanks: api/models/feed_systems/tanks.md
           - grain:
               - Overview: api/models/grain.md

--- a/tests/test_core/test_interpolation.py
+++ b/tests/test_core/test_interpolation.py
@@ -1,0 +1,89 @@
+"""Tests for the bounded cubic-spline interpolant in `machwave.core.interpolation`."""
+
+import math
+
+import pytest
+
+from machwave.core import interpolation
+
+
+def test_bounded_cubic_spline_returns_knot_values_at_knots():
+    """At each knot the spline must return the tabulated dependent value."""
+    spline = interpolation.BoundedCubicSpline([0.0, 1.0, 2.0], [0.0, 1.0, 4.0])
+
+    assert spline(0.0) == pytest.approx(0.0)
+    assert spline(1.0) == pytest.approx(1.0)
+    assert spline(2.0) == pytest.approx(4.0)
+
+
+def test_bounded_cubic_spline_returns_finite_value_at_interior_point():
+    """Interpolating between knots must yield a finite floating-point value."""
+    spline = interpolation.BoundedCubicSpline([0.0, 1.0, 2.0], [0.0, 1.0, 4.0])
+
+    value = spline(0.5)
+
+    assert isinstance(value, float)
+    assert math.isfinite(value)
+
+
+def test_bounded_cubic_spline_exposes_domain_bounds():
+    """The `domain` property must report `(x_min, x_max)` of the input knots."""
+    spline = interpolation.BoundedCubicSpline([0.0, 1.0, 2.0], [0.0, 1.0, 4.0])
+
+    assert spline.domain == (0.0, 2.0)
+
+
+def test_bounded_cubic_spline_rejects_non_strictly_increasing_x_with_duplicate():
+    """A repeated x knot must be rejected because the spline is undefined."""
+    with pytest.raises(ValueError, match="strictly increasing"):
+        interpolation.BoundedCubicSpline([0.0, 1.0, 1.0], [0.0, 1.0, 2.0])
+
+
+def test_bounded_cubic_spline_rejects_decreasing_x():
+    """A decreasing x sequence must be rejected."""
+    with pytest.raises(ValueError, match="strictly increasing"):
+        interpolation.BoundedCubicSpline([2.0, 1.0, 0.0], [0.0, 1.0, 2.0])
+
+
+def test_bounded_cubic_spline_rejects_mismatched_lengths():
+    """`x_points` and `y_points` must have the same length."""
+    with pytest.raises(ValueError, match="equal length"):
+        interpolation.BoundedCubicSpline([0.0, 1.0, 2.0], [0.0, 1.0])
+
+
+def test_bounded_cubic_spline_rejects_fewer_than_two_knots():
+    """A single knot is insufficient to define an interpolant."""
+    with pytest.raises(ValueError, match="at least two knots"):
+        interpolation.BoundedCubicSpline([0.0], [0.0])
+
+
+def test_bounded_cubic_spline_rejects_two_dimensional_inputs():
+    """Inputs must be one-dimensional sequences."""
+    with pytest.raises(ValueError, match="one-dimensional"):
+        interpolation.BoundedCubicSpline(
+            [[0.0, 1.0], [2.0, 3.0]], [[0.0, 1.0], [2.0, 3.0]]
+        )
+
+
+def test_bounded_cubic_spline_accepts_inputs_at_domain_boundaries():
+    """Calling exactly at `x_min` and `x_max` must not raise."""
+    spline = interpolation.BoundedCubicSpline([0.0, 1.0, 2.0], [0.0, 1.0, 4.0])
+
+    assert spline(0.0) == pytest.approx(0.0)
+    assert spline(2.0) == pytest.approx(4.0)
+
+
+def test_bounded_cubic_spline_rejects_input_below_domain_minimum():
+    """Inputs below `x_min` must raise rather than extrapolate."""
+    spline = interpolation.BoundedCubicSpline([0.0, 1.0, 2.0], [0.0, 1.0, 4.0])
+
+    with pytest.raises(ValueError, match="outside"):
+        spline(-1e-9)
+
+
+def test_bounded_cubic_spline_rejects_input_above_domain_maximum():
+    """Inputs above `x_max` must raise rather than extrapolate."""
+    spline = interpolation.BoundedCubicSpline([0.0, 1.0, 2.0], [0.0, 1.0, 4.0])
+
+    with pytest.raises(ValueError, match="outside"):
+        spline(2.0 + 1e-9)

--- a/tests/test_models/test_propulsion/test_feed_systems/test_components/test_specs.py
+++ b/tests/test_models/test_propulsion/test_feed_systems/test_components/test_specs.py
@@ -1,0 +1,177 @@
+"""Construction and validation tests for the feed-system component specifications."""
+
+import dataclasses
+
+import pytest
+
+from machwave.models.feed_systems.components import (
+    GasGeneratorSpec,
+    PumpSpec,
+    RegenerativeJacketSpec,
+    TurbineSpec,
+)
+
+
+def _valid_pump_spec_kwargs() -> dict:
+    """Return a dictionary of valid keyword arguments for `PumpSpec`."""
+    return dict(
+        name="oxidizer pump",
+        isentropic_efficiency=0.7,
+        pressure_rise=5.0e6,
+        volumetric_flow_design=2.0e-3,
+        shaft_speed_design=3000.0,
+    )
+
+
+def _valid_turbine_spec_kwargs() -> dict:
+    """Return a dictionary of valid keyword arguments for `TurbineSpec`."""
+    return dict(
+        name="oxidizer turbine",
+        isentropic_efficiency=0.65,
+        pressure_ratio=20.0,
+        inlet_temperature_design=900.0,
+        mass_flow_design=1.5,
+    )
+
+
+def _valid_gas_generator_spec_kwargs() -> dict:
+    """Return a dictionary of valid keyword arguments for `GasGeneratorSpec`."""
+    return dict(
+        name="gas generator",
+        mixture_ratio=0.3,
+        chamber_pressure=8.0e6,
+        gas_temperature=900.0,
+        mass_flow=2.0,
+    )
+
+
+def _valid_regenerative_jacket_spec_kwargs() -> dict:
+    """Return a dictionary of valid keyword arguments for `RegenerativeJacketSpec`."""
+    return dict(
+        name="chamber jacket",
+        pressure_drop=1.0e6,
+        coolant_temperature_rise=200.0,
+        heat_pickup=5.0e6,
+    )
+
+
+def test_pump_spec_constructs_with_valid_values():
+    """A `PumpSpec` with valid fields must construct without error."""
+    spec = PumpSpec(**_valid_pump_spec_kwargs())
+
+    assert spec.name == "oxidizer pump"
+    assert spec.isentropic_efficiency == pytest.approx(0.7)
+
+
+def test_turbine_spec_constructs_with_valid_values():
+    """A `TurbineSpec` with valid fields must construct without error."""
+    spec = TurbineSpec(**_valid_turbine_spec_kwargs())
+
+    assert spec.name == "oxidizer turbine"
+    assert spec.pressure_ratio == pytest.approx(20.0)
+
+
+def test_gas_generator_spec_constructs_with_valid_values():
+    """A `GasGeneratorSpec` with valid fields must construct without error."""
+    spec = GasGeneratorSpec(**_valid_gas_generator_spec_kwargs())
+
+    assert spec.name == "gas generator"
+    assert spec.mixture_ratio == pytest.approx(0.3)
+
+
+def test_regenerative_jacket_spec_constructs_with_valid_values():
+    """A `RegenerativeJacketSpec` with valid fields must construct without error."""
+    spec = RegenerativeJacketSpec(**_valid_regenerative_jacket_spec_kwargs())
+
+    assert spec.name == "chamber jacket"
+    assert spec.coolant_temperature_rise == pytest.approx(200.0)
+
+
+def test_pump_spec_rejects_efficiency_above_one():
+    """Isentropic efficiency above one is unphysical and must raise."""
+    kwargs = _valid_pump_spec_kwargs()
+    kwargs["isentropic_efficiency"] = 1.5
+
+    with pytest.raises(ValueError, match="isentropic_efficiency"):
+        PumpSpec(**kwargs)
+
+
+def test_pump_spec_rejects_non_positive_pressure_rise():
+    """A non-positive pressure rise is unphysical and must raise."""
+    kwargs = _valid_pump_spec_kwargs()
+    kwargs["pressure_rise"] = 0.0
+
+    with pytest.raises(ValueError, match="pressure_rise"):
+        PumpSpec(**kwargs)
+
+
+def test_turbine_spec_rejects_pressure_ratio_at_or_below_one():
+    """A turbine with pressure ratio of one or less produces no work and must raise."""
+    kwargs = _valid_turbine_spec_kwargs()
+    kwargs["pressure_ratio"] = 1.0
+
+    with pytest.raises(ValueError, match="pressure_ratio"):
+        TurbineSpec(**kwargs)
+
+
+def test_gas_generator_spec_rejects_temperature_above_metal_limit():
+    """A gas-generator temperature above the documented limit must raise."""
+    kwargs = _valid_gas_generator_spec_kwargs()
+    kwargs["gas_temperature"] = 5000.0
+
+    with pytest.raises(ValueError, match="gas_temperature"):
+        GasGeneratorSpec(**kwargs)
+
+
+def test_gas_generator_spec_rejects_non_positive_mixture_ratio():
+    """A non-positive mixture ratio is unphysical and must raise."""
+    kwargs = _valid_gas_generator_spec_kwargs()
+    kwargs["mixture_ratio"] = 0.0
+
+    with pytest.raises(ValueError, match="mixture_ratio"):
+        GasGeneratorSpec(**kwargs)
+
+
+def test_regenerative_jacket_spec_rejects_negative_pressure_drop():
+    """A negative pressure drop across the jacket is unphysical and must raise."""
+    kwargs = _valid_regenerative_jacket_spec_kwargs()
+    kwargs["pressure_drop"] = -1.0
+
+    with pytest.raises(ValueError, match="pressure_drop"):
+        RegenerativeJacketSpec(**kwargs)
+
+
+def test_regenerative_jacket_spec_rejects_non_positive_temperature_rise():
+    """The coolant must always heat up across the jacket; zero rise must raise."""
+    kwargs = _valid_regenerative_jacket_spec_kwargs()
+    kwargs["coolant_temperature_rise"] = 0.0
+
+    with pytest.raises(ValueError, match="coolant_temperature_rise"):
+        RegenerativeJacketSpec(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "spec_class, kwargs_builder, field_name, new_value",
+    [
+        (PumpSpec, _valid_pump_spec_kwargs, "name", "modified pump"),
+        (TurbineSpec, _valid_turbine_spec_kwargs, "name", "modified turbine"),
+        (
+            GasGeneratorSpec,
+            _valid_gas_generator_spec_kwargs,
+            "name",
+            "modified gas generator",
+        ),
+        (
+            RegenerativeJacketSpec,
+            _valid_regenerative_jacket_spec_kwargs,
+            "name",
+            "modified jacket",
+        ),
+    ],
+)
+def test_specs_are_frozen(spec_class, kwargs_builder, field_name, new_value):
+    """Specs must be immutable so simulations cannot mutate shared configurations."""
+    spec = spec_class(**kwargs_builder())
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(spec, field_name, new_value)

--- a/tests/test_models/test_propulsion/test_feed_systems/test_components/test_specs.py
+++ b/tests/test_models/test_propulsion/test_feed_systems/test_components/test_specs.py
@@ -114,10 +114,10 @@ def test_turbine_spec_rejects_pressure_ratio_at_or_below_one():
         TurbineSpec(**kwargs)
 
 
-def test_gas_generator_spec_rejects_temperature_above_metal_limit():
-    """A gas-generator temperature above the documented limit must raise."""
+def test_gas_generator_spec_rejects_non_positive_gas_temperature():
+    """A non-positive gas-generator temperature is unphysical and must raise."""
     kwargs = _valid_gas_generator_spec_kwargs()
-    kwargs["gas_temperature"] = 5000.0
+    kwargs["gas_temperature"] = 0.0
 
     with pytest.raises(ValueError, match="gas_temperature"):
         GasGeneratorSpec(**kwargs)


### PR DESCRIPTION
Closes #268.

## Summary

- Restructured `machwave/models/feed_systems/` to make room for tier-2 cycle implementations. Pressure-fed cycle moved into a new `cycles/` subpackage as `stacked_tank_pressure_fed.py`; future cycles (electric-pump, gas-generator, expander, staged combustion — issues #237 / #255 / #256 / #257 / #259) will sit alongside it.
- Tightened the `FeedSystem` abstract contract. The `(*args, **kwargs)` wildcards on `get_mass_flow_ox` / `get_mass_flow_fuel` are replaced with `chamber_pressure: float, *, discharge_coefficient: float | None = None, injector_area: float | None = None`. Pressure-fed cycles still require both keyword arguments; cycles that schedule mass flow from pump curves can ignore them. All call sites already use kwargs, so no caller changes are needed.
- Added a shared `components/` subpackage with four frozen, validated dataclasses: `PumpSpec`, `TurbineSpec`, `GasGeneratorSpec`, and `RegenerativeJacketSpec`. Each validates its fields in `__post_init__` so out-of-range configurations fail at construction. They are configuration only — no cycle consumes them yet.
- Added `machwave.core.interpolation.BoundedCubicSpline`, a cubic-spline wrapper that refuses to extrapolate outside its calibrated knots. Lives in `core` because the same helper is useful across the codebase (pump curves, burn-rate tables, nozzle area distributions). Built on `scipy.interpolate.CubicSpline` with `extrapolate=False` plus an explicit domain check in `__call__`.
- Documentation: rewrote the `feed_systems` overview, added dedicated pages for `feed_systems.components`, `feed_systems.cycles`, and `core.interpolation`, and wired them into the mkdocs nav.

## Test plan

- [x] `pytest tests/` — 643 passed, 2 skipped.
- [x] `mkdocs build --strict` — clean, no warnings.
- [x] Manual import check: `from machwave.models.feed_systems import FeedSystem, StackedTankPressureFedFeedSystem, components` resolves.
- [x] `tests/test_models/test_propulsion/test_feed_systems/test_components/test_specs.py` covers smoke construction, validation rejection, and frozen-instance checks for every spec.
- [x] `tests/test_core/test_interpolation.py` covers knot values, interior interpolation, domain property, input validation, domain-edge inclusion, and extrapolation refusal.