### PR TITLE
277: Standardize docstrings and tighten RocketPy adapter

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 10%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false

--- a/machwave/adapters/rocketpy/__init__.py
+++ b/machwave/adapters/rocketpy/__init__.py
@@ -1,13 +1,5 @@
-"""RocketPy adapter module for converting machwave motors to RocketPy motor objects."""
-
-from machwave.adapters.rocketpy.base import (
-    RocketPyAdapterError,
-    RocketPyMotorAdapter,
-)
 from machwave.adapters.rocketpy.solid_motor import RocketPySolidMotorAdapter
 
 __all__ = [
-    "RocketPyMotorAdapter",
-    "RocketPyAdapterError",
     "RocketPySolidMotorAdapter",
 ]

--- a/machwave/adapters/rocketpy/base.py
+++ b/machwave/adapters/rocketpy/base.py
@@ -7,7 +7,7 @@ import numpy.typing as npt
 try:
     import rocketpy
     import rocketpy.motors as rocketpy_motors
-except ImportError as e:
+except ImportError as e:  # pragma: no cover - exercised only without rocketpy
     raise ImportError("RocketPy adapters require the `rocketpy` package") from e
 
 if typing.TYPE_CHECKING:

--- a/machwave/adapters/rocketpy/base.py
+++ b/machwave/adapters/rocketpy/base.py
@@ -1,22 +1,18 @@
-"""Base adapter classes for RocketPy motor integration."""
-
 import abc
 import typing
 
 import numpy as np
 import numpy.typing as npt
 
-if typing.TYPE_CHECKING:
-    from rocketpy import Function
+try:
+    import rocketpy
+    import rocketpy.motors as rocketpy_motors
+except ImportError as e:
+    raise ImportError("RocketPy adapters require the `rocketpy` package") from e
 
+if typing.TYPE_CHECKING:
     import machwave.simulation as ib_simulation
     from machwave.models.motors import Motor
-
-
-class RocketPyAdapterError(Exception):
-    """Base exception for RocketPy adapter errors."""
-
-    pass
 
 
 R = typing.TypeVar("R", bound="ib_simulation.SimulationResult")
@@ -27,38 +23,19 @@ INTERPOLATION_METHOD = "linear"
 
 
 class RocketPyMotorAdapter(abc.ABC, typing.Generic[R]):
-    """Abstract base class for RocketPy motor adapters.
+    """
+    Abstract base class for RocketPy motor adapters.
 
-    Dynamically inherits from the appropriate RocketPy Motor class. Subclasses must
-    specify _rocketpy_motor_class to indicate which RocketPy Motor class to adapt to.
+    Subclasses must set `_rocketpy_motor_class` to the name of the RocketPy
+    Motor class they adapt.
     """
 
-    # Subclasses must override this to specify the RocketPy motor class name
     _rocketpy_motor_class: typing.ClassVar[str] = "Motor"
 
-    @staticmethod
-    def _require_rocketpy() -> None:
-        """Ensure rocketpy is available.
-
-        Raises:
-            ImportError: If rocketpy is not installed.
-        """
-        try:
-            import rocketpy  # noqa: F401
-        except ImportError as e:
-            raise ImportError(
-                "RocketPy adapters require the 'rocketpy' package. Install it with: "
-                "pip install rocketpy"
-            ) from e
-
     def __init_subclass__(cls, **kwargs: typing.Any) -> None:
-        """Dynamically inherit from specified RocketPy Motor class when subclass is created."""
+        """Dynamically inherit from specified RocketPy Motor class."""
         super().__init_subclass__(**kwargs)
 
-        cls._require_rocketpy()
-        import rocketpy.motors as rocketpy_motors
-
-        # Get the specific motor class to inherit from
         motor_class_name = cls._rocketpy_motor_class
         if not hasattr(rocketpy_motors, motor_class_name):
             raise AttributeError(
@@ -67,7 +44,6 @@ class RocketPyMotorAdapter(abc.ABC, typing.Generic[R]):
 
         motor_class = getattr(rocketpy_motors, motor_class_name)
 
-        # Dynamically add the specific Motor class to the base classes if not already there
         if not any(
             isinstance(base, type) and issubclass(base, motor_class)
             for base in cls.__bases__
@@ -75,14 +51,13 @@ class RocketPyMotorAdapter(abc.ABC, typing.Generic[R]):
             cls.__bases__ = cls.__bases__ + (motor_class,)
 
     def __init__(self, motor: "Motor", simulation_result: R) -> None:
-        """Initialize the adapter.
+        """
+        Initialize the adapter.
 
         Args:
-            motor: The machwave motor object.
+            motor: The machwave motor.
             simulation_result: The machwave simulation result.
         """
-        self._require_rocketpy()
-
         self.motor = motor
         self.simulation_result = simulation_result
 
@@ -100,8 +75,8 @@ class RocketPyMotorAdapter(abc.ABC, typing.Generic[R]):
         thrust_source = np.column_stack((time, thrust))
 
         # Axial position of the dry mass center of gravity.
-        # Both machwave and RocketPy use nozzle exit as origin, positive toward
-        # the bulkhead ("nozzle_to_combustion_chamber" orientation).
+        # Both machwave and RocketPy use nozzle exit as origin, positive toward the
+        # bulkhead ("nozzle_to_combustion_chamber" orientation).
         center_of_dry_mass_position = (
             thrust_chamber.center_of_gravity_coordinate[0]
             if thrust_chamber.center_of_gravity_coordinate is not None
@@ -123,42 +98,36 @@ class RocketPyMotorAdapter(abc.ABC, typing.Generic[R]):
         }
 
     @property
-    def exhaust_velocity(self) -> "Function":
-        """Exhaust velocity as a function of time.
+    def exhaust_velocity(self) -> rocketpy.Function:
+        """
+        Return exhaust velocity as a function of time.
 
         Computed as total impulse divided by propellant initial mass,
         assumed constant and discretized over the burn time.
 
         Returns:
-            Gas exhaust velocity [m/s] as a function of time.
+            Exhaust velocity [m/s] as a function of time.
         """
-        from rocketpy import Function
-
         v_exh = self.simulation_result.total_impulse / self.propellant_initial_mass
-        return Function(v_exh).set_discrete_based_on_model(self.thrust)  # type: ignore[attr-defined]
+        return rocketpy.Function(v_exh).set_discrete_based_on_model(self.thrust)  # type: ignore[attr-defined]
 
     @property
     def propellant_initial_mass(self) -> float:
-        """Initial mass of propellant.
-
-        Returns:
-            Initial propellant mass [kg].
-        """
+        """Return the initial propellant mass [kg]."""
         return self.simulation_result.initial_propellant_mass
 
     @property
-    def center_of_propellant_mass(self) -> "Function":
-        """Position of propellant center of mass as a function of time.
+    def center_of_propellant_mass(self) -> rocketpy.Function:
+        """
+        Return the propellant center of mass axial position over time.
 
-        Uses pre-computed values from the simulation result.
-        Extracts the x-coordinate (axial position) from the propellant's center of
-        gravity over time.
+        Uses pre-computed values from the simulation result, extracts the
+        x-coordinate (axial position) from the propellant's center of gravity
+        over time.
 
         Returns:
-            Function object with (time, position) data [m].
+            `rocketpy.Function` with (time, position) data [m].
         """
-        from rocketpy import Function
-
         time = self.simulation_result.time
         center_positions = np.asarray(
             self.simulation_result.propellant_cog[:, 0],  # type: ignore[attr-defined]
@@ -172,13 +141,14 @@ class RocketPyMotorAdapter(abc.ABC, typing.Generic[R]):
             center_positions[~mask] = center_positions[last_valid_idx]
 
         data = np.column_stack((time, center_positions))
-        return Function(data)
+        return rocketpy.Function(data)
 
     def _get_inertia_tensor_over_time(self) -> npt.NDArray[np.float64]:
-        """Get pre-computed inertia tensors from the simulation result.
+        """
+        Return pre-computed inertia tensors from the simulation result.
 
         Returns:
-            Array of shape (n_timesteps, 3, 3) containing inertia tensors.
+            Array of shape `(n_timesteps, 3, 3)` containing inertia tensors.
         """
         tensors = np.asarray(
             self.simulation_result.propellant_moi,  # type: ignore[attr-defined]
@@ -195,83 +165,88 @@ class RocketPyMotorAdapter(abc.ABC, typing.Generic[R]):
 
         return tensors
 
-    def _get_propellant_inertia_component(self, i: int, j: int) -> "Function":
-        """Get a specific component of the propellant inertia tensor.
+    def _get_propellant_inertia_component(self, i: int, j: int) -> rocketpy.Function:
+        """
+        Return a single component of the propellant inertia tensor over time.
 
         Args:
             i: First index (0, 1, or 2).
             j: Second index (0, 1, or 2).
 
         Returns:
-            Function object with (time, I_ij) data [kg-m^2].
+            `rocketpy.Function` with (time, I_ij) data [kg-m^2].
         """
-        from rocketpy import Function
-
         time = self.simulation_result.time
         inertia_tensors = self._get_inertia_tensor_over_time()
         I_values = inertia_tensors[:, i, j]
         data = np.column_stack((time, I_values))
-        return Function(data)
+        return rocketpy.Function(data)
 
     @property
-    def propellant_I_11(self) -> "Function":
-        """Inertia tensor I_11 (I_xx) component of the propellant.
+    def propellant_I_11(self) -> rocketpy.Function:
+        """
+        Return inertia tensor `I_11` (`I_xx`) of the propellant over time.
 
         Inertia relative to the e_1 axis (perpendicular to motor body axis), centered at
         the instantaneous propellant center of mass.
 
         Returns:
-            Function object with (time, I_11) data [kg-m^2].
+            `rocketpy.Function` with (time, I_11) data [kg-m^2].
         """
         return self._get_propellant_inertia_component(0, 0)
 
     @property
-    def propellant_I_12(self) -> "Function":
-        """Inertia tensor I_12 (I_xy) component of the propellant.
+    def propellant_I_12(self) -> rocketpy.Function:
+        """
+        Return inertia tensor `I_12` (`I_xy`) of the propellant over time.
 
         Returns:
-            Function object with (time, I_12) data [kg-m^2].
+            `rocketpy.Function` with (time, I_12) data [kg-m^2].
         """
         return self._get_propellant_inertia_component(0, 1)
 
     @property
-    def propellant_I_13(self) -> "Function":
-        """Inertia tensor I_13 (I_xz) component of the propellant.
+    def propellant_I_13(self) -> rocketpy.Function:
+        """
+        Return inertia tensor `I_13` (`I_xz`) of the propellant over time.
 
         Returns:
-            Function object with (time, I_13) data [kg-m^2].
+            `rocketpy.Function` with (time, I_13) data [kg-m^2].
         """
         return self._get_propellant_inertia_component(0, 2)
 
     @property
-    def propellant_I_22(self) -> "Function":
-        """Inertia tensor I_22 (I_yy) component of the propellant.
+    def propellant_I_22(self) -> rocketpy.Function:
+        """
+        Return inertia tensor `I_22` (`I_yy`) of the propellant over time.
 
         Inertia relative to the e_2 axis (perpendicular to motor body axis), centered at
         the instantaneous propellant center of mass.
 
         Returns:
-            Function object with (time, I_22) data [kg-m^2].
+            `rocketpy.Function` with (time, I_22) data [kg-m^2].
         """
         return self._get_propellant_inertia_component(1, 1)
 
     @property
-    def propellant_I_23(self) -> "Function":
-        """Inertia tensor I_23 (I_yz) component of the propellant.
+    def propellant_I_23(self) -> rocketpy.Function:
+        """
+        Return inertia tensor `I_23` (`I_yz`) of the propellant over time.
 
         Returns:
-            Function object with (time, I_23) data [kg-m^2].
+            `rocketpy.Function` with (time, I_23) data [kg-m^2].
         """
         return self._get_propellant_inertia_component(1, 2)
 
     @property
-    def propellant_I_33(self) -> "Function":
-        """Inertia tensor I_33 (I_zz) component of the propellant.
+    def propellant_I_33(self) -> rocketpy.Function:
+        """
+        Return inertia tensor `I_33` (`I_zz`) of the propellant over time.
 
         Inertia relative to the e_3 axis (motor body axis), centered at the
         instantaneous propellant center of mass.
 
         Returns:
-            Function object with (time, I_33) data [kg-m^2].
+            `rocketpy.Function` with (time, I_33) data [kg-m^2].
         """
         return self._get_propellant_inertia_component(2, 2)

--- a/machwave/adapters/rocketpy/solid_motor.py
+++ b/machwave/adapters/rocketpy/solid_motor.py
@@ -3,6 +3,7 @@
 import typing
 
 from machwave.adapters.rocketpy.base import RocketPyMotorAdapter
+from machwave.models.grain.geometries import BatesSegment
 
 if typing.TYPE_CHECKING:
     from machwave.models.motors import SolidMotor
@@ -12,12 +13,13 @@ if typing.TYPE_CHECKING:
 
 
 class RocketPySolidMotorAdapter(RocketPyMotorAdapter["SolidSimulationResult"]):
-    """Adapter to use a Machwave SolidSimulationResult as a RocketPy SolidMotor."""
+    """Adapter to use a simulation result and motor as a RocketPy SolidMotor."""
 
     _rocketpy_motor_class = "SolidMotor"
 
     def _get_rocketpy_attributes(self) -> dict[str, typing.Any]:
-        """Extract motor and grain attributes compatible with RocketPy SolidMotor.
+        """
+        Extract motor and grain attributes compatible with RocketPy SolidMotor.
 
         Returns:
             Attributes for RocketPy SolidMotor initialization.
@@ -25,7 +27,6 @@ class RocketPySolidMotorAdapter(RocketPyMotorAdapter["SolidSimulationResult"]):
         Raises:
             ValueError: If grain configuration is incompatible with RocketPy.
         """
-        # Get base motor attributes
         base_attrs = super()._get_rocketpy_attributes()
 
         motor = typing.cast("SolidMotor", self.motor)
@@ -45,10 +46,18 @@ class RocketPySolidMotorAdapter(RocketPyMotorAdapter["SolidSimulationResult"]):
 
         first_segment = grain.segments[0]
 
+        # RocketPy's SolidMotor only supports a BATES geometry
+        if not isinstance(first_segment, BatesSegment):
+            raise ValueError(
+                "RocketPy SolidMotor only supports BATES grain geometry, got "
+                f"{type(first_segment).__name__}"
+            )
+
         grain_number = grain.segment_count
         grain_separation = grain.spacing
         grain_outer_radius = first_segment.outer_diameter / 2
         grain_initial_height = first_segment.length
+        grain_initial_inner_radius = first_segment.core_diameter / 2
         throat_radius = motor.thrust_chamber.nozzle.throat_diameter / 2
         grains_center_of_mass_position = motor.grain.get_center_of_gravity(
             web_distance=0.0
@@ -57,12 +66,7 @@ class RocketPySolidMotorAdapter(RocketPyMotorAdapter["SolidSimulationResult"]):
         # RocketPy handles real density internally
         grain_density = motor.propellant.ideal_density
 
-        if hasattr(first_segment, "core_diameter"):
-            grain_initial_inner_radius = first_segment.core_diameter / 2  # type: ignore[attr-defined]
-        else:  # Some geometries might not have core_diameter, use 0 as default
-            grain_initial_inner_radius = 0.0
-
-        # Combine base attributes with grain-specific parameters
+        # Combine base attributes with grain specific parameters
         solid_motor_attrs = {
             **base_attrs,
             "grain_number": grain_number,

--- a/machwave/common/decorators.py
+++ b/machwave/common/decorators.py
@@ -68,12 +68,11 @@ def check_bounds(lower: float = 0.0, upper: float = 1.0) -> typing.Callable:
 
 def warn_if_outside_range(lower: float, upper: float) -> typing.Callable:
     """
-    Emit a warning if the decorated function's return value is outside the specified
-    range.
+    Warn if the decorated function's return value is outside `[lower, upper]`.
 
     Args:
-        lower: The inclusive lower bound.
-        upper: The inclusive upper bound.
+        lower: Inclusive lower bound.
+        upper: Inclusive upper bound.
 
     Returns:
         The decorated function.

--- a/machwave/core/__init__.py
+++ b/machwave/core/__init__.py
@@ -1,5 +1,6 @@
 """
-The `machwave.core` module contains functions related to fluid dynamics, geometry,
-numerical methods and other core functionalities used across Machwave. These functions
-are almost immutable, since they are based on fundamental physics and mathematics.
+Core physics, numerical methods, and geometry utilities.
+
+Functions here are based on fundamental physics and mathematics and are
+considered nearly immutable across the codebase.
 """

--- a/machwave/core/compressible_flow/__init__.py
+++ b/machwave/core/compressible_flow/__init__.py
@@ -1,6 +1,4 @@
-"""
-Compressible flow theory and analysis.
-"""
+"""Compressible flow theory and analysis."""
 
 from .nozzle import (
     apply_thrust_coefficient_correction,

--- a/machwave/core/compressible_flow/isentropic.py
+++ b/machwave/core/compressible_flow/isentropic.py
@@ -4,7 +4,8 @@ import scipy.optimize
 
 
 def get_critical_pressure_ratio(k: float) -> float:
-    """Get critical pressure ratio for choked flow.
+    """
+    Get critical pressure ratio for choked flow.
 
     Args:
         k: Isentropic exponent.
@@ -16,7 +17,8 @@ def get_critical_pressure_ratio(k: float) -> float:
 
 
 def get_expansion_ratio_from_exit_mach(mach: float, k: float) -> float:
-    """Get expansion ratio from exit Mach number.
+    """
+    Get expansion ratio from exit Mach number.
 
     Args:
         mach: Mach number.
@@ -31,7 +33,8 @@ def get_expansion_ratio_from_exit_mach(mach: float, k: float) -> float:
 
 
 def get_exit_mach_from_expansion_ratio(k: float, expansion_ratio: float) -> float:
-    """Get exit Mach number from expansion ratio.
+    """
+    Get exit Mach number from expansion ratio.
 
     Args:
         k: Isentropic exponent.
@@ -64,7 +67,8 @@ def get_exit_pressure(
     expansion_ratio: float,
     chamber_pressure: float,
 ) -> float:
-    """Get exit pressure from isentropic relations.
+    """
+    Get exit pressure from isentropic relations.
 
     Args:
         k_exhaust: Isentropic exponent at exit.
@@ -85,7 +89,8 @@ def is_flow_choked(
     external_pressure: float,
     critical_pressure_ratio: float,
 ) -> bool:
-    """Check if flow is choked.
+    """
+    Check if flow is choked.
 
     Args:
         chamber_pressure: Chamber pressure [Pa].

--- a/machwave/core/compressible_flow/losses.py
+++ b/machwave/core/compressible_flow/losses.py
@@ -1,14 +1,14 @@
 """
-Losses and correction factors for rocket engines.
-All functions return a fraction, between 0 and 1.
+Losses and correction factors for rocket engine performance.
+
+All functions return a loss as a fraction in [0, 1].
 
 References:
     Coats, D. E., Levine, J. N., Nickerson, G. R., Tyson, T. J.,
     Cohen, N. S., Harry, D. P. III, & Price, C. F. (1975).
-    *A Computer Program for the Prediction of Solid Propellant
-    Rocket Motor Performance. Volume I* (Technical Report
-    AFRPL-TR-75-36, DTIC Accession AD-A015 140). Air Force
-    Rocket Propulsion Laboratory, Edwards Air Force Base, CA.
+    A Computer Program for the Prediction of Solid Propellant Rocket Motor
+    Performance. Volume I (Technical Report AFRPL-TR-75-36, DTIC Accession
+    AD-A015 140). Air Force Rocket Propulsion Laboratory, Edwards AFB, CA.
 """
 
 import numpy as np
@@ -17,11 +17,8 @@ from machwave.common import decorators
 
 KINETICS_LOSS_PRESSURE_THRESHOLD_PSI = 200  # psi
 
-"""
-AD-A015 140 cites typical ranges for the correction factors.
-Some of these ranges were adjusted based on the experience of the authors and the
-typical outcomes for validation cases. Ranges are expressed as fractions.
-"""
+# Typical ranges (fractions) for the correction factors per AD-A015 140,
+# tightened where experience and validation cases warranted it.
 
 TYPICAL_RANGES = {
     "divergent_loss": {"lower": 0.0075, "upper": 0.05},
@@ -35,14 +32,15 @@ TYPICAL_RANGES = {
 @decorators.warn_if_outside_range(**TYPICAL_RANGES["divergent_loss"])
 def get_nozzle_divergent_loss_fraction(divergent_angle: float) -> float:
     """
-    Calculates the divergent nozzle loss fraction given the half angle.
-    NOTE: only applicable for a conical convergent-divergent nozzle.
+    Return the divergent nozzle loss fraction given the half angle.
+
+    Only applicable for a conical convergent-divergent nozzle.
 
     Args:
-        divergent_angle: The half angle of the divergent nozzle [degrees].
+        divergent_angle: Half angle of the divergent nozzle [deg].
 
     Returns:
-        The divergent loss fraction in [0, 1].
+        Divergent loss fraction in [0, 1].
     """
     return 0.5 * (1 - np.cos(np.deg2rad(divergent_angle)))
 
@@ -53,25 +51,26 @@ def get_kinetics_loss_fraction(
     i_sp_th_frozen: float, i_sp_th_shifting: float, chamber_pressure_psi: float
 ) -> float:
     """
-    The kinetics loss accounts for the decrement in performance due to
-    incomplete heat transfer of latent heat to sensible heat caused by the finite time
-    required for the gas phase chemical reactions to occur.
+    Return the kinetics loss fraction.
 
-    Valid for liquid, solid, and hybrid propellants.
-    The expansion ratio of the i_sp_th_frozen and i_sp_th_shifting should be the same.
+    Kinetics loss accounts for the decrement in performance due to incomplete
+    heat transfer of latent to sensible heat caused by the finite time required
+    for the gas-phase chemical reactions to occur. Valid for liquid, solid, and
+    hybrid propellants; `i_sp_th_frozen` and `i_sp_th_shifting` must share the
+    same expansion ratio.
 
-    Pressure correction is applied for chamber pressures above 1.379 MPa (200 psi), in
-    order to dampen the effect of the kinetics loss.
+    A pressure correction dampens the kinetics loss above 1.379 MPa (200 psi).
 
-    The source AFRPL-TR-75-36 calculates it as a percentage, here it is converted to a
-    fraction [0, 1].
+    The source AFRPL-TR-75-36 expresses this as a percentage; here it is
+    returned as a fraction in [0, 1].
 
     Args:
-        i_sp_th_frozen: The specific impulse of the frozen flow [s].
-        i_sp_th_shifting: The specific impulse of the shifting flow [s].
-        chamber_pressure_psi: The chamber pressure [psi].
+        i_sp_th_frozen: Specific impulse of the frozen flow [s].
+        i_sp_th_shifting: Specific impulse of the shifting flow [s].
+        chamber_pressure_psi: Chamber pressure [psi].
+
     Returns:
-        The kinetics loss fraction in [0, 1].
+        Kinetics loss fraction in [0, 1].
     """
     i_sp_th_ratio = i_sp_th_frozen / i_sp_th_shifting
 
@@ -96,40 +95,35 @@ def get_boundary_layer_loss_fraction(
     c_2: float,
 ) -> float:
     """
+    Return the boundary layer loss fraction.
+
     Boundary layer loss accounts for the decrement in performance due to
-    the viscous and heat transfer effects in the nozzle walls. It is time dependent.
+    viscous and heat-transfer effects on the nozzle walls. It is time
+    dependent: the exponential transient is important in motors with short
+    burn durations (under 4 s). Dependence on expansion ratio represents the
+    effect of the amount of nozzle surface area. Valid for liquid, solid, and
+    hybrid propellants.
 
-    Valid for liquid, solid, and hybrid propellants.
+    Time constant `c_2` comes from analysis of the transient heating of a
+    BATES motor. Time constant `c_1` was obtained from a direct measurement
+    of the heat loss in a BATES motor, among other things. Typical values:
 
-    The time dependence is exponential due to the transient heat up, important in
-    motors with short burn durations (less than 4 seconds). Dependence on expansion
-    ratio represents the effect of a the amount of nozzle surface area.
+    - Ordinary nozzle: `c_1 = 0.003650`, `c_2 = 0.000937`.
+    - Solid steel nozzle with thick walls: `c_1 = 0.005060`, `c_2 = 0.0`.
 
-    Time constant C2 comes from analysis of a the transient heating of a BATES motor.
-
-    Time constant C1 was obtained from a direct measurement of the heat loss in a BATES
-    motor, among other things.
-
-    Ordinary nozzle:
-    C1 = 0.003650
-    C2 = 0.000937
-
-    Solid steel nozzle with relatively thick walls:
-    C1 = 0.005060
-    C2 = 0.000000
-
-    The source AFRPL-TR-75-36 calculates it as a percentage, here it is converted to a
-    fraction [0, 1].
+    The source AFRPL-TR-75-36 expresses this as a percentage; here it is
+    returned as a fraction in [0, 1].
 
     Args:
-        chamber_pressure_psi: The chamber pressure [psi].
-        throat_diameter_inch: The throat diameter [in].
-        expansion_ratio: The expansion ratio of the nozzle.
-        time: The time in seconds [s].
-        c_1: Coefficient for the boundary layer loss.
-        c_2: Coefficient for the boundary layer loss.
+        chamber_pressure_psi: Chamber pressure [psi].
+        throat_diameter_inch: Throat diameter [in].
+        expansion_ratio: Nozzle expansion ratio.
+        time: Time [s].
+        c_1: First boundary-layer loss coefficient.
+        c_2: Second boundary-layer loss coefficient.
+
     Returns:
-        The boundary layer loss fraction in [0, 1].
+        Boundary layer loss fraction in [0, 1].
     """
     term_1 = c_1 * (chamber_pressure_psi**0.8) / (throat_diameter_inch**0.2)
     term_2 = 1 + 2 * np.exp(
@@ -147,19 +141,19 @@ def _get_two_phase_phase_loss_particle_size(
     characteristic_length_inch: float,
 ) -> float:
     """
-    Helper function to calculate the two-phase flow loss due to particle size.
+    Return the two-phase flow average particle size [um].
 
-    Combines theories of particle growth by condensation in the chamber and collisions
-    in the nozzle.
+    Combines theories of particle growth by condensation in the chamber and
+    collisions in the nozzle.
 
     Args:
-        chamber_pressure_psi: The chamber pressure [psi].
-        mass_fraction_of_condensed_phase: The mass fraction of the condensed phase.
-        throat_diameter_inch: The throat diameter [in].
-        characteristic_length_inch: The characteristic length [in].
+        chamber_pressure_psi: Chamber pressure [psi].
+        mass_fraction_of_condensed_phase: Mass fraction of the condensed phase.
+        throat_diameter_inch: Throat diameter [in].
+        characteristic_length_inch: Characteristic length [in].
 
     Returns:
-        The two-phase flow average particle size in micrometers.
+        Two-phase flow average particle size [um].
     """
     return (
         0.454
@@ -180,22 +174,24 @@ def get_two_phase_flow_loss_fraction(
     characteristic_length_inch: float,
 ) -> float:
     """
-    Two-phase flow loss accounts for the decrement in performance due to
-    the presence of a condensed phase in the combustion products.
+    Return the two-phase flow loss fraction.
 
-    Valid for solid, and hybrid propellants.
+    Two-phase flow loss accounts for the decrement in performance due to the
+    presence of a condensed phase in the combustion products. Valid for solid
+    and hybrid propellants.
 
-    The source AFRPL-TR-75-36 calculates it as a percentage, here it is converted to a
-    fraction [0, 1].
+    The source AFRPL-TR-75-36 expresses this as a percentage; here it is
+    returned as a fraction in [0, 1].
 
     Args:
-        chamber_pressure_psi: The chamber pressure [psi].
-        mass_fraction_of_condensed_phase: The mass fraction of the condensed phase.
-        expansion_ratio: The expansion ratio of the nozzle.
-        throat_diameter_inch: The throat diameter [in].
-        characteristic_length_inch: The characteristic length [in].
+        chamber_pressure_psi: Chamber pressure [psi].
+        mass_fraction_of_condensed_phase: Mass fraction of the condensed phase.
+        expansion_ratio: Nozzle expansion ratio.
+        throat_diameter_inch: Throat diameter [in].
+        characteristic_length_inch: Characteristic length [in].
+
     Returns:
-        The two-phase flow loss fraction in [0, 1].
+        Two-phase flow loss fraction in [0, 1].
     """
     particle_size_um: float = _get_two_phase_phase_loss_particle_size(
         chamber_pressure_psi,
@@ -250,19 +246,20 @@ def get_overall_nozzle_efficiency(
     other_losses: float,
 ) -> float:
     """
-    Calculates the overall nozzle efficiency by combining the loss fractions.
+    Return the overall nozzle efficiency.
 
-    All inputs are loss fractions in [0, 1] (not percentages).
+    Combines individual loss fractions into a single efficiency. All inputs are
+    fractions in [0, 1] (not percentages).
 
     Args:
-        divergent_loss: The divergent nozzle loss fraction.
-        kinetics_loss: The kinetics loss fraction.
-        boundary_layer_loss: The boundary layer loss fraction.
-        two_phase_loss: The two-phase flow loss fraction.
-        other_losses: Additional losses, as a fraction in [0, 1].
+        divergent_loss: Divergent nozzle loss fraction.
+        kinetics_loss: Kinetics loss fraction.
+        boundary_layer_loss: Boundary layer loss fraction.
+        two_phase_loss: Two-phase flow loss fraction.
+        other_losses: Additional losses as a fraction in [0, 1].
 
     Returns:
-        The overall nozzle efficiency, as a fraction in [0, 1].
+        Overall nozzle efficiency as a fraction in [0, 1].
     """
     return 1.0 - (
         divergent_loss

--- a/machwave/core/compressible_flow/nozzle.py
+++ b/machwave/core/compressible_flow/nozzle.py
@@ -4,7 +4,8 @@ import numpy as np
 def get_optimal_expansion_ratio(
     k: float, chamber_pressure: float, atmospheric_pressure: float
 ) -> float:
-    """Get optimal expansion ratio for DeLaval nozzle.
+    """
+    Get optimal expansion ratio for DeLaval nozzle.
 
     Args:
         k: Isentropic exponent.
@@ -31,7 +32,8 @@ def get_ideal_thrust_coefficient(
     expansion_ratio: float,
     k_exhaust: float,
 ) -> float:
-    """Get ideal thrust coefficient for DeLaval nozzle.
+    """
+    Get ideal thrust coefficient for DeLaval nozzle.
 
     Args:
         chamber_pressure: Chamber pressure [Pa].
@@ -61,7 +63,8 @@ def apply_thrust_coefficient_correction(
     ideal_thrust_coefficient: float,
     nozzle_correction_factor: float,
 ) -> float:
-    """Apply nozzle efficiency correction to thrust coefficient.
+    """
+    Apply nozzle efficiency correction to thrust coefficient.
 
     Args:
         ideal_thrust_coefficient: Ideal thrust coefficient.
@@ -76,7 +79,8 @@ def apply_thrust_coefficient_correction(
 def get_thrust_from_thrust_coefficient(
     thrust_coefficient: float, chamber_pressure: float, nozzle_throat_area: float
 ) -> float:
-    """Get thrust from thrust coefficient.
+    """
+    Get thrust from thrust coefficient.
 
     Args:
         thrust_coefficient: Thrust coefficient.

--- a/machwave/core/conversions.py
+++ b/machwave/core/conversions.py
@@ -82,13 +82,13 @@ def convert_rankine_to_kelvin(temperature_rankine: float) -> float:
 
 def convert_lbft3_to_kgm3(density_lbft3: float) -> float:
     """
-    Converts density in lb/ft³ to kg/m³.
+    Convert density in lb/ft^3 to kg/m^3.
 
     Args:
-        density_lbft3: Density [lb/ft³].
+        density_lbft3: Density [lb/ft^3].
 
     Returns:
-        Density [kg/m³].
+        Density [kg/m^3].
     """
     return density_lbft3 * 16.01846337
 

--- a/machwave/core/incompressible_flow.py
+++ b/machwave/core/incompressible_flow.py
@@ -8,7 +8,8 @@ def get_mass_flow_orifice(
     pressure_upstream: float,
     pressure_downstream: float,
 ) -> float:
-    """Get mass flow rate through an orifice.
+    """
+    Get mass flow rate through an orifice.
 
     Args:
         discharge_coefficient: Discharge coefficient.

--- a/machwave/core/interpolation.py
+++ b/machwave/core/interpolation.py
@@ -12,7 +12,8 @@ class BoundedCubicSpline:
         x_points: Sequence[float],
         y_points: Sequence[float],
     ) -> None:
-        """Construct the spline from a table of knots.
+        """
+        Construct the spline from a table of knots.
 
         Args:
             x_points: Strictly increasing knot locations along the independent
@@ -47,7 +48,8 @@ class BoundedCubicSpline:
         return (self._domain_minimum, self._domain_maximum)
 
     def __call__(self, value: float) -> float:
-        """Return the interpolated value at `value`.
+        """
+        Return the interpolated value at `value`.
 
         Args:
             value: Independent-axis input at which to evaluate the spline.

--- a/machwave/core/mass_balance.py
+++ b/machwave/core/mass_balance.py
@@ -24,7 +24,7 @@ def compute_chamber_pressure_mass_balance(
         free_chamber_volume: Chamber free volume [m^3].
         throat_area: Nozzle throat area [m^2].
         k: Isentropic exponent of the mix.
-        R: Gas constant per molecular weight [J/(kg·K)].
+        R: Gas constant per molecular weight [J/(kg-K)].
         flame_temperature: Flame temperature [K].
         discharge_coefficient: Discharge coefficient.
 

--- a/machwave/core/mechanics.py
+++ b/machwave/core/mechanics.py
@@ -1,6 +1,4 @@
-"""
-Mechanics calculations.
-"""
+"""Mechanics calculations."""
 
 import numpy as np
 import numpy.typing as npt
@@ -12,7 +10,8 @@ def get_center_of_gravity(
     z_coords: npt.NDArray[np.float64],
     masses: npt.NDArray[np.float64] | None = None,
 ) -> npt.NDArray[np.float64]:
-    """Calculate center of gravity from point mass elements.
+    """
+    Calculate center of gravity from point mass elements.
 
     Computes the center of gravity (centroid) of a collection of point masses.
     The coordinate system is [z, x, y] where z is the axial direction.
@@ -56,7 +55,8 @@ def get_moment_of_inertia_tensor(
     z_coords: npt.NDArray[np.float64],
     element_mass: float,
 ) -> npt.NDArray[np.float64]:
-    """Calculate moment of inertia tensor from point mass elements.
+    """
+    Calculate moment of inertia tensor from point mass elements.
 
     Computes the 3x3 inertia tensor for a collection of point masses at given
     coordinates. All coordinates should be relative to the center of gravity. The

--- a/machwave/core/performance.py
+++ b/machwave/core/performance.py
@@ -1,6 +1,4 @@
-"""
-Performance metrics and calculations.
-"""
+"""Performance metrics and calculations."""
 
 import numpy as np
 import numpy.typing as npt
@@ -11,7 +9,8 @@ def get_total_impulse(
     thrust: npt.NDArray[np.float64],
     time: npt.NDArray[np.float64],
 ) -> float:
-    """Get total impulse by trapezoidal integration of the thrust curve.
+    """
+    Get total impulse by trapezoidal integration of the thrust curve.
 
     Args:
         thrust: Thrust samples [N].
@@ -24,7 +23,8 @@ def get_total_impulse(
 
 
 def get_specific_impulse(total_impulse: float, initial_propellant_mass: float) -> float:
-    """Get specific impulse.
+    """
+    Get specific impulse.
 
     Args:
         total_impulse: Total impulse [N-s].

--- a/machwave/core/solvers/__init__.py
+++ b/machwave/core/solvers/__init__.py
@@ -1,7 +1,4 @@
-"""
-Numerical methods for solving systems such as differential equations, optimization
-problems, and more.
-"""
+"""Numerical methods for differential equations, optimization, and similar."""
 
 from .rk4 import rk4th_ode_solver
 

--- a/machwave/core/solvers/rk4.py
+++ b/machwave/core/solvers/rk4.py
@@ -8,18 +8,17 @@ def rk4th_ode_solver(
     **kwargs: Any,
 ) -> tuple[float, ...]:
     """
-    Solves a system of ordinary differential equations using the 4th order Runge-Kutta
-    method.
+    Advance a system of ODEs by one step using the 4th-order Runge-Kutta method.
 
     Args:
-        variables: A dictionary containing the variables to be solved.
-        equation: A function that returns the derivatives of the variables.
-        d_t: The time step.
-        **kwargs: Additional keyword arguments to be passed to the equation function.
+        variables: Mapping of variable name to current value.
+        equation: Callable returning the derivatives of the variables.
+        d_t: Time step [s].
+        **kwargs: Additional keyword arguments forwarded to `equation`.
 
     Returns:
-        A tuple containing the new values of the variables. The length of the tuple is
-        equal to the number of variables + 1.
+        Tuple containing the new values of the variables followed by the
+        averaged auxiliary term; length equals `len(variables) + 1`.
     """
     k_1 = equation(**variables, **kwargs)
     k_2 = equation(

--- a/machwave/core/structural/bolted_joints.py
+++ b/machwave/core/structural/bolted_joints.py
@@ -1,7 +1,8 @@
 """
 Bolted joints stress and load calculations.
-This module provides functions to calculate shear, bearing, and tensile stresses and
-loads for bolted joints in plates and cylinders.
+
+Provides functions to calculate shear, bearing, and tensile stresses and loads
+for bolted joints in plates and cylinders.
 """
 
 import numpy as np
@@ -10,7 +11,8 @@ from ..geometric import get_circle_area
 
 
 def _bolt_cross_sectional_area(screw_diameter: float) -> float:
-    """Calculates the cross sectional area for a bolt or screw.
+    """
+    Calculates the cross sectional area for a bolt or screw.
 
     Args:
         screw_diameter: Effective diameter of the screw. An M4 screw has a diameter of
@@ -23,7 +25,8 @@ def _bolt_cross_sectional_area(screw_diameter: float) -> float:
 
 
 def _bearing_area_per_bolt(thickness: float, hole_diameter: float) -> float:
-    """Projected bearing area between bolt shank and plate.
+    """
+    Projected bearing area between bolt shank and plate.
 
     Args:
         thickness: Thickness of the plate.
@@ -36,7 +39,8 @@ def _bearing_area_per_bolt(thickness: float, hole_diameter: float) -> float:
 
 
 def _tearout_area_per_bolt(edge_distance: float, thickness: float) -> float:
-    """Gross shear area resisting tear-out toward a free edge.
+    """
+    Gross shear area resisting tear-out toward a free edge.
 
     Args:
         edge_distance: Distance from the center of the bolt hole to the edge of the
@@ -52,7 +56,8 @@ def _tearout_area_per_bolt(edge_distance: float, thickness: float) -> float:
 def _net_section_area(
     pitch_distance: float, thickness: float, hole_diameter: float
 ) -> float:
-    """Net tension area across the bolt line.
+    """
+    Net tension area across the bolt line.
 
     Args:
         pitch_distance: Distance between bolt centers.
@@ -66,7 +71,8 @@ def _net_section_area(
 
 
 def _arc_length(angle: float, diameter: float) -> float:
-    """Calculate the arc length on a cylinder wall corresponding to an angle.
+    """
+    Calculate the arc length on a cylinder wall corresponding to an angle.
 
     Args:
         angle: Angle in degrees.
@@ -85,7 +91,8 @@ def get_shear_stress_per_bolt(
     shank_diameter: float,
     n_shear_planes: int = 1,
 ) -> float:
-    """Transverse shear stress on a bolt.
+    """
+    Transverse shear stress on a bolt.
 
     Args:
         load: Applied transverse shear load per bolt.
@@ -104,7 +111,8 @@ def get_bearing_stress(
     plate_thickness: float,
     hole_diameter: float,
 ) -> float:
-    """Compressive (bearing) stress between bolt shank and plate.
+    """
+    Compressive (bearing) stress between bolt shank and plate.
 
     Args:
         load: Applied bearing load per bolt.
@@ -123,7 +131,8 @@ def get_tearout_shear_stress_plate(
     edge_distance: float,
     plate_thickness: float,
 ) -> float:
-    """Average shear stress along the tearout plane toward a free edge.
+    """
+    Average shear stress along the tearout plane toward a free edge.
 
     Args:
         load: Applied shear load causing tearout.
@@ -144,7 +153,8 @@ def get_net_section_tension_stress_plate(
     hole_diameter: float,
     n_bolts_in_row: int = 1,
 ) -> float:
-    """Tensile stress across the reduced net section of a bolted plate row.
+    """
+    Tensile stress across the reduced net section of a bolted plate row.
 
     Args:
         load: Applied axial load across the bolt row.
@@ -166,7 +176,8 @@ def get_tearout_shear_stress_cylinder(
     wall_thickness: float,
     outer_diameter: float,
 ) -> float:
-    """Average shear stress along the tearout plane toward crown/root of a cylinder.
+    """
+    Average shear stress along the tearout plane toward crown/root of a cylinder.
 
     Args:
         load: Applied shear load causing tearout.
@@ -189,7 +200,8 @@ def get_net_section_tension_stress_cylinder(
     outer_diameter: float,
     n_bolts_in_row: int = 1,
 ) -> float:
-    """Tensile stress across the reduced net section of a bolted row on a cylinder wall.
+    """
+    Tensile stress across the reduced net section of a bolted row on a cylinder wall.
 
     Args:
         load: Applied axial load across the bolt row.
@@ -218,7 +230,8 @@ def get_max_shear_load(
     allowable_shear_stress: float,
     n_shear_planes: int = 1,
 ) -> float:
-    """Return limiting transverse shear load on a bolt (single or double shear).
+    """
+    Return limiting transverse shear load on a bolt (single or double shear).
 
     Args:
         shank_diameter: Diameter of the bolt shank.
@@ -240,7 +253,8 @@ def get_max_bearing_load(
     hole_diameter: float,
     allowable_bearing_stress: float,
 ) -> float:
-    """Return limiting compressive/bearing load before hole elongation failure.
+    """
+    Return limiting compressive/bearing load before hole elongation failure.
 
     Args:
         plate_thickness: Thickness of the plate.
@@ -261,7 +275,8 @@ def get_max_tearout_load_plate(
     plate_thickness: float,
     allowable_shear_stress: float,
 ) -> float:
-    """Return limiting load causing shear tear-out toward an edge.
+    """
+    Return limiting load causing shear tear-out toward an edge.
 
     Args:
         edge_distance: Distance from the center of the bolt hole to the edge of the
@@ -284,7 +299,8 @@ def get_max_net_tension_load_plate(
     allowable_tensile_stress: float,
     n_bolts_in_row: int = 1,
 ) -> float:
-    """Return limiting axial load across a bolt row before net-section tension failure.
+    """
+    Return limiting axial load across a bolt row before net-section tension failure.
 
     Args:
         pitch_distance: Distance between bolt centers.
@@ -306,7 +322,8 @@ def get_max_tearout_load_cylinder(
     outer_diameter: float,
     allowable_shear_stress: float,
 ) -> float:
-    """Edge tear-out toward crown/root of a thin-walled cylinder.
+    """
+    Edge tear-out toward crown/root of a thin-walled cylinder.
 
     Arguments:
         edge_angle: Angle from the hole to the free edge.
@@ -331,7 +348,8 @@ def get_max_net_tension_load_cylinder(
     outer_diameter: float,
     n_bolts_in_row: int = 1,
 ) -> float:
-    """Net-section tension rupture across a bolt row on a cylinder wall.
+    """
+    Net-section tension rupture across a bolt row on a cylinder wall.
 
     Args:
         pitch_angle: Central angle between adjacent bolt centres along the same

--- a/machwave/core/structural/pressure_vessels.py
+++ b/machwave/core/structural/pressure_vessels.py
@@ -1,20 +1,15 @@
 """
-This module provides functions to calculate the burst pressure of pressure vessels,
-specifically closed-end thick-walled cylindrical vessels and flat plates, based on
-the Von Mises equivalent stress theory.
+Pressure vessel burst-pressure calculations.
 
+Provides functions for burst pressure of closed-end thick-walled cylindrical
+vessels and flat plates, based on the Von Mises equivalent stress theory.
 
 References:
-    Shigley, J.E., Mischke, C.R., & Budynas, R.G., "Mechanical Engineering
-    Design", 10th ed., McGraw-Hill, 2015.
+    Shigley, J.E., Mischke, C.R., & Budynas, R.G. (2015). Mechanical
+    Engineering Design (10th ed.). McGraw-Hill.
 """
 
 import numpy as np
-
-"""
-Individual stress calculations for a closed-end thick-walled cylindrical vessel
-under internal pressure.
-"""
 
 
 def _get_cylindrical_vessel_hoop_stress(
@@ -23,20 +18,19 @@ def _get_cylindrical_vessel_hoop_stress(
     outer_radius: float,
 ) -> float:
     """
-    Hoop (circumferential) stress at the inner wall for a closed-end
-    thick-walled cylindrical vessel under internal pressure.
+    Return the hoop stress at the inner wall of a thick-walled cylinder.
 
-    Acts tangentially around the circumference, “trying to split” the cylinder
-    along its length.
-
-    Formula from Shigley et al. (2015), Eq. (3-50).
+    Hoop (circumferential) stress acts tangentially around the circumference,
+    "trying to split" a closed-end cylinder along its length under internal
+    pressure. Formula from Shigley et al. (2015), Eq. (3-50).
 
     Args:
-        pressure (float): Internal pressure.
-        inner_radius (float): Inner radius of the cylinder.
-        outer_radius (float): Outer radius of the cylinder.
+        pressure: Internal pressure [Pa].
+        inner_radius: Inner radius of the cylinder [m].
+        outer_radius: Outer radius of the cylinder [m].
+
     Returns:
-        float: Hoop stress at the inner wall.
+        Hoop stress at the inner wall [Pa].
     """
     a = inner_radius
     b = outer_radius
@@ -49,19 +43,19 @@ def _get_cylindrical_vessel_radial_stress(
     outer_radius: float,
 ) -> float:
     """
-    Radial stress at the inner wall for a closed-end thick-walled cylindrical
-    vessel under internal pressure.
+    Return the radial stress at the inner wall of a thick-walled cylinder.
 
-    Acts along the radius, pushing inward or outward.
-
-    Formula from Shigley et al. (2015), Eq. (3-50).
+    Radial stress acts along the radius, pushing inward or outward for a
+    closed-end cylinder under internal pressure. Formula from Shigley et al.
+    (2015), Eq. (3-50).
 
     Args:
-        pressure (float): Internal pressure.
-        inner_radius (float): Inner radius of the cylinder.
-        outer_radius (float): Outer radius of the cylinder.
+        pressure: Internal pressure [Pa].
+        inner_radius: Inner radius of the cylinder [m].
+        outer_radius: Outer radius of the cylinder [m].
+
     Returns:
-        float: Radial stress at the inner wall.
+        Radial stress at the inner wall [Pa].
     """
     a = inner_radius
     b = outer_radius
@@ -74,26 +68,22 @@ def _get_cylindrical_vessel_logitudinal_stress(
     outer_radius: float,
 ) -> float:
     """
-    Longitudinal stress at the inner wall of a thick-walled closed-end cylinder
-    under internal pressure.
+    Return the longitudinal stress at the inner wall of a thick-walled cylinder.
 
-    Acts along the cylinder's axis, trying to pull the end caps off.
+    Longitudinal stress acts along the cylinder's axis, trying to pull the end
+    caps off, for a closed-end cylinder under internal pressure.
 
     Args:
-        pressure (float): Internal pressure.
-        inner_radius (float): Inner radius of the cylinder.
-        outer_radius (float): Outer radius of the cylinder.
+        pressure: Internal pressure [Pa].
+        inner_radius: Inner radius of the cylinder [m].
+        outer_radius: Outer radius of the cylinder [m].
+
     Returns:
-        float: Longitudinal stress at the inner wall.
+        Longitudinal stress at the inner wall [Pa].
     """
     a = inner_radius
     b = outer_radius
     return 2 * pressure * a**2 / (b**2 - a**2)
-
-
-"""
-Stress calculations:
-"""
 
 
 def get_cylindrical_vessel_von_mises_stress(
@@ -102,15 +92,18 @@ def get_cylindrical_vessel_von_mises_stress(
     outer_radius: float,
 ) -> float:
     """
-    Calculate the Von Mises equivalent stress for a closed-end thick-walled
-    cylindrical vessel under internal pressure.
+    Return the Von Mises equivalent stress for a thick-walled cylinder.
+
+    Applies to a closed-end thick-walled cylindrical vessel under internal
+    pressure.
 
     Args:
-        pressure (float): Internal pressure.
-        inner_radius (float): Inner radius of the cylinder.
-        outer_radius (float): Outer radius of the cylinder.
+        pressure: Internal pressure [Pa].
+        inner_radius: Inner radius of the cylinder [m].
+        outer_radius: Outer radius of the cylinder [m].
+
     Returns:
-        float: Von Mises equivalent stress (same units as pressure).
+        Von Mises equivalent stress [Pa].
     """
     sigma_t = _get_cylindrical_vessel_hoop_stress(pressure, inner_radius, outer_radius)
     sigma_r = _get_cylindrical_vessel_radial_stress(
@@ -130,18 +123,21 @@ def get_cylindrical_vessel_von_mises_stress(
 
 def get_flat_plate_stress(pressure: float, diameter: float, thickness: float) -> float:
     """
-    Membrane (tensile) stress in a flat, simply supported circular plate
-    loaded by uniform internal pressure.
+    Return the membrane (tensile) stress in a uniformly loaded flat plate.
 
-    This is conservative for real end caps, which often include edge
-    bending restraint or doming.
+    Applies to a simply supported circular plate loaded by uniform internal
+    pressure. Conservative for real end caps, which often include edge bending
+    restraint or doming.
+
+    Args:
+        pressure: Internal pressure [Pa].
+        diameter: Plate diameter [m].
+        thickness: Plate thickness [m].
+
+    Returns:
+        Membrane stress [Pa].
     """
     return pressure * diameter / (2.0 * thickness)
-
-
-"""
-Burst pressure calculations:
-"""
 
 
 def get_cylindrical_vessel_burst_pressure(
@@ -150,18 +146,20 @@ def get_cylindrical_vessel_burst_pressure(
     material_yield_strength: float,
 ) -> float:
     """
-    Calculate the internal burst pressure at which the Von Mises equivalent
-    stress reaches the material's yield strength.
+    Return the burst pressure for a thick-walled cylindrical vessel.
+
+    Defined as the internal pressure at which the Von Mises equivalent stress
+    reaches the material's yield strength.
 
     Args:
-        inner_radius (float): Inner radius of the vessel.
-        outer_radius (float): Outer radius of the vessel.
-        material_yield_strength (float): Yield strength of the material.
+        inner_radius: Inner radius of the vessel [m].
+        outer_radius: Outer radius of the vessel [m].
+        material_yield_strength: Material yield strength [Pa].
 
     Returns:
-        float: Burst pressure (same units as yield strength).
+        Burst pressure [Pa].
     """
-    # Von Mises stress per unit internal pressure
+    # Von Mises stress per unit internal pressure.
     equiv_per_unit = get_cylindrical_vessel_von_mises_stress(
         1.0, inner_radius, outer_radius
     )
@@ -175,15 +173,17 @@ def get_flat_plate_burst_pressure(
     material_yield_strength: float,
 ) -> float:
     """
-    Calculate the internal burst pressure at which the Von Mises equivalent
-    stress reaches the material's yield strength.
+    Return the burst pressure for a flat plate.
+
+    Defined as the internal pressure at which the membrane stress reaches the
+    material's yield strength.
 
     Args:
-        diameter (float): Diameter of the plate.
-        thickness (float): Thickness of the plate.
-        material_yield_strength (float): Yield strength of the material.
+        diameter: Plate diameter [m].
+        thickness: Plate thickness [m].
+        material_yield_strength: Material yield strength [Pa].
 
     Returns:
-        float: Burst pressure (same units as yield strength).
+        Burst pressure [Pa].
     """
     return 2 * material_yield_strength * thickness / diameter

--- a/machwave/io/eng.py
+++ b/machwave/io/eng.py
@@ -13,7 +13,8 @@ def generate_eng_file_content(
     name: str,
     eng_res: int = 25,
 ) -> str:
-    """Generate .eng file content for rocket simulation software.
+    """
+    Generate .eng file content for rocket simulation software.
 
     Args:
         time: Time array [s].

--- a/machwave/models/feed_systems/base.py
+++ b/machwave/models/feed_systems/base.py
@@ -17,7 +17,8 @@ class FeedSystem(ABC):
     """
 
     def __init__(self, fuel_tank: Tank, oxidizer_tank: Tank):
-        """Initialize the FeedSystem with associated tank objects.
+        """
+        Initialize the FeedSystem with associated tank objects.
 
         Args:
             fuel_tank: Instance representing the fuel tank.
@@ -38,7 +39,8 @@ class FeedSystem(ABC):
         discharge_coefficient: float | None = None,
         injector_area: float | None = None,
     ) -> float:
-        """Compute and return the current oxidizer mass flow rate [kg/s].
+        """
+        Compute and return the current oxidizer mass flow rate [kg/s].
 
         Args:
             chamber_pressure: Chamber pressure [Pa].
@@ -58,7 +60,8 @@ class FeedSystem(ABC):
         discharge_coefficient: float | None = None,
         injector_area: float | None = None,
     ) -> float:
-        """Compute and return the current fuel mass flow rate [kg/s].
+        """
+        Compute and return the current fuel mass flow rate [kg/s].
 
         Args:
             chamber_pressure: Chamber pressure [Pa].

--- a/machwave/models/feed_systems/components/gas_generator.py
+++ b/machwave/models/feed_systems/components/gas_generator.py
@@ -3,7 +3,8 @@ import dataclasses
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GasGeneratorSpec:
-    """Gas generator driving a turbopump turbine.
+    """
+    Gas generator driving a turbopump turbine.
 
     Attributes:
         name: Identifier used in logs and reports.

--- a/machwave/models/feed_systems/components/pump.py
+++ b/machwave/models/feed_systems/components/pump.py
@@ -3,7 +3,8 @@ import dataclasses
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class PumpSpec:
-    """Propellant pump used by turbopump cycles.
+    """
+    Propellant pump used by turbopump cycles.
 
     Attributes:
         name: Identifier used in logs and reports.

--- a/machwave/models/feed_systems/components/regenerative_jacket.py
+++ b/machwave/models/feed_systems/components/regenerative_jacket.py
@@ -3,7 +3,8 @@ import dataclasses
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class RegenerativeJacketSpec:
-    """Regenerative cooling component around the chamber and nozzle.
+    """
+    Regenerative cooling component around the chamber and nozzle.
 
     Attributes:
         name: Identifier used in logs and reports.

--- a/machwave/models/feed_systems/components/turbine.py
+++ b/machwave/models/feed_systems/components/turbine.py
@@ -3,7 +3,8 @@ import dataclasses
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class TurbineSpec:
-    """Turbine used by turbopump cycles.
+    """
+    Turbine used by turbopump cycles.
 
     Attributes:
         name: Identifier used in logs and reports.

--- a/machwave/models/feed_systems/cycles/__init__.py
+++ b/machwave/models/feed_systems/cycles/__init__.py
@@ -1,4 +1,5 @@
-"""Concrete feed-system cycle implementations.
+"""
+Concrete feed-system cycle implementations.
 
 Each module in this package implements one cycle topology (pressure-fed,
 electric-pump, gas-generator, expander, staged combustion, ...). Cycles consume

--- a/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
+++ b/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
@@ -92,12 +92,14 @@ class StackedTankPressureFedFeedSystem(FeedSystem):
         injector_area: float | None = None,
     ) -> float:
         """
-        Compute the current fuel mass flow rate via get_mass_flow_orifice().
-        The pressure upstream will be the same as the oxidizer tank pressure, since this is a model for a stacked tank.
+        Compute the current fuel mass flow rate via the orifice model.
+
+        The upstream pressure is the oxidizer tank pressure, since this models
+        a stacked tank.
 
         Args:
             chamber_pressure: Chamber pressure [Pa].
-            discharge_coefficient: Discharge coefficient for the injector (dimensionless).
+            discharge_coefficient: Discharge coefficient for the injector.
             injector_area: Effective flow area for the fuel injector [m^2].
 
         Returns:
@@ -125,9 +127,7 @@ class StackedTankPressureFedFeedSystem(FeedSystem):
         )
 
     def get_oxidizer_tank_pressure(self) -> float:
-        """
-        Returns the tank pressure [Pa].
-        """
+        """Returns the tank pressure [Pa]."""
         return self.oxidizer_tank.get_pressure()
 
     def get_fuel_tank_pressure(self) -> float:

--- a/machwave/models/feed_systems/tanks/base.py
+++ b/machwave/models/feed_systems/tanks/base.py
@@ -22,7 +22,8 @@ class Tank:
         temperature: float,
         initial_fluid_mass: float,
     ) -> None:
-        """Initialize a two-phase tank model.
+        """
+        Initialize a two-phase tank model.
 
         Args:
             fluid_name: Name of the fluid in the CoolProp database
@@ -52,7 +53,8 @@ class Tank:
         temperature: float,
         initial_fluid_mass: float,
     ) -> None:
-        """Raise ``ValueError`` if the tank fill is denser than liquid.
+        """
+        Raise ``ValueError`` if the tank fill is denser than liquid.
 
         The implied bulk density ``initial_fluid_mass / volume`` cannot exceed
         the saturated-liquid density at ``temperature`` — anything denser
@@ -70,7 +72,8 @@ class Tank:
             )
 
     def get_pressure(self) -> float:
-        """Return the current tank pressure [Pa] using two-phase logic.
+        """
+        Return the current tank pressure [Pa] using two-phase logic.
 
         1) Compute the saturation pressure at the given temperature.
         2) If fluid_mass > mass_if_all_vapor(p_sat), the tank is partially
@@ -98,7 +101,8 @@ class Tank:
             )
 
     def get_density(self, pressure: float | None = None) -> float:
-        """Return fluid density [kg/m^3] at tank pressure and temperature.
+        """
+        Return fluid density [kg/m^3] at tank pressure and temperature.
 
         Uses CoolProp. If pressure is provided, it is used as the tank
         pressure override (e.g., a piston-pressurized stacked-tank system).
@@ -147,7 +151,8 @@ class Tank:
             self.fluid_mass = 0.0
 
     def _mass_if_all_vapor(self, p_vapor: float) -> float:
-        """Return mass if tank were entirely vapor at given pressure.
+        """
+        Return mass if tank were entirely vapor at given pressure.
 
         Uses ideal gas law at pressure p_vapor [Pa] and
         temperature self.temperature.
@@ -167,8 +172,9 @@ class Tank:
         self, mass: float, volume: float, temperature: float
     ) -> float:
         """
-        Computes the pressure [Pa] if all the fluid is in the vapor phase,
-        using the ideal gas law: P = (mass / M) * R * T / volume.
+        Return the ideal-gas pressure [Pa] if all the fluid is vapor.
+
+        Uses `P = (mass / M) * R * T / volume`.
         """
         molar_mass = CP.PropsSI("M", self.fluid_name)  # kg/mol
         R_universal = scipy.constants.R  # J/(mol*K)

--- a/machwave/models/grain/base.py
+++ b/machwave/models/grain/base.py
@@ -8,6 +8,8 @@ import numpy as np
 
 
 class GrainGeometryError(Exception):
+    """Raised when a grain geometry is invalid."""
+
     def __init__(self, message: str) -> None:
         self.message = message
 
@@ -16,7 +18,8 @@ class GrainGeometryError(Exception):
 
 @dataclass(frozen=True, slots=True)
 class InhibitedSurfaces:
-    """Describes which surfaces of a grain segment are inhibited.
+    """
+    Describes which surfaces of a grain segment are inhibited.
 
     Attributes:
         outer_surface: If True, the outer cylindrical surface is inhibited.
@@ -31,6 +34,7 @@ class InhibitedSurfaces:
     lower_end: bool = False
 
     def __post_init__(self) -> None:
+        """Reject configurations where every surface is inhibited."""
         if (
             self.outer_surface
             and self.inner_surface
@@ -43,9 +47,7 @@ class InhibitedSurfaces:
 
 
 class GrainSegment(ABC):
-    """
-    Represents a grain segment.
-    """
+    """Represents a grain segment."""
 
     def __init__(
         self,
@@ -67,78 +69,79 @@ class GrainSegment(ABC):
 
     @abstractmethod
     def get_web_thickness(self) -> float:
-        """
-        Calculates the total web thickness of the segment.
-
-        :return: The total web thickness of the segment
-        :rtype: float
-        """
+        """Return the total web thickness of the segment [m]."""
         pass
 
     @abstractmethod
     def get_length(self, web_distance: float) -> float:
+        """Return the segment length at a given web distance [m]."""
         pass
 
     @abstractmethod
     def get_port_area(self, web_distance: float, *args: Any, **kwargs: Any) -> float:
         """
-        Calculates the port area as a function of the web distance traveled.
+        Return the port area as a function of the web distance traveled.
 
         This method assumes a 2D or simplified model where the port area can
         be represented by a single scalar value at a given web distance.
 
         Args:
-            web_distance: Distance traveled into the grain web.
+            web_distance: Distance traveled into the grain web [m].
             *args: Additional positional arguments.
             **kwargs: Additional keyword arguments.
 
         Returns:
-            A float representing the port area.
+            Port area [m^2].
         """
         pass
 
     @abstractmethod
     def get_burn_area(self, web_distance: float) -> float:
         """
-        Calculates burn area in function of the web distance traveled.
+        Return the burn area at a given web distance.
 
-        :param float web_distance: Web distance traveled
-        :return: Burn area in function of the web distance traveled
-        :rtype: float
+        Args:
+            web_distance: Web distance traveled [m].
+
+        Returns:
+            Burn area [m^2].
         """
         pass
 
     @abstractmethod
     def get_volume(self, web_distance: float) -> float:
         """
-        Calculates volume in function of the web distance traveled.
+        Return the segment volume at a given web distance.
 
-        :param float web_distance: Web distance traveled
-        :return: Segment volume in function of the instant web thickness
-        :rtype: float
+        Args:
+            web_distance: Web distance traveled [m].
+
+        Returns:
+            Segment volume [m^3].
         """
         pass
 
     @abstractmethod
     def get_center_of_gravity(self, *args, **kwargs) -> np.typing.NDArray[np.float64]:
         """
-        Calculates the center of gravity of the segment.
+        Return the center of gravity of the segment.
 
         The coordinate system origin is at the port, closest to the nozzle,
         with positive x-direction pointing toward the bulkhead.
 
-        :return: The center of gravity of the segment [x, y, z] in meters
-        :rtype: np.typing.NDArray[np.float64]
+        Returns:
+            Center of gravity of the segment [x, y, z] [m].
         """
         pass
 
     @abstractmethod
     def get_moment_of_inertia(self, *args, **kwargs) -> np.typing.NDArray[np.float64]:
         """
-        Calculates the moment of inertia tensor of the segment at its center of gravity.
+        Return the moment of inertia tensor at the segment's center of gravity.
 
         Returns:
-            A 3x3 array representing the inertia tensor [kg-m^2] with components:
+            A 3x3 inertia tensor [kg-m^2] with components:
+
                 [[Ixx, Ixy, Ixz],
                  [Iyx, Iyy, Iyz],
                  [Izx, Izy, Izz]]
@@ -147,12 +150,14 @@ class GrainSegment(ABC):
 
     def get_mass(self, web_distance: float, ideal_density: float) -> float:
         """
-        Calculates the mass of the segment at a given web distance.
+        Return the mass of the segment at a given web distance.
 
-        :param float web_distance: Web distance traveled [m]
-        :param float ideal_density: Ideal propellant density [kg/m^3]
-        :return: Mass of the segment at the given web distance [kg]
-        :rtype: float
+        Args:
+            web_distance: Web distance traveled [m].
+            ideal_density: Ideal propellant density [kg/m^3].
+
+        Returns:
+            Mass of the segment [kg].
         """
         if ideal_density <= 0:
             raise ValueError(f"ideal_density must be > 0 (got {ideal_density})")
@@ -161,7 +166,8 @@ class GrainSegment(ABC):
 
     def validate(self) -> None:
         """
-        Validates grain geometry.
+        Validate grain geometry.
+
         For every attribute that a child class adds, it must be validated here.
         """
         if not isinstance(self.inhibited_surfaces, InhibitedSurfaces):
@@ -182,15 +188,9 @@ class GrainSegment(ABC):
 
 class GrainSegment2D(GrainSegment, ABC):
     """
-    Class that represents a 2D grain segment.
+    A 2D grain segment with uniform cross section along its length.
 
-    A 2D grain segment is a segment that has the same cross sectional geometry
-    throughout its length.
-
-    Some examples of 2D grain geometries:
-    - BATES
-    - Tubular
-    - Pseudo-finocyl
+    Examples of 2D grain geometries: BATES, tubular, pseudo-finocyl.
     """
 
     def __init__(
@@ -210,42 +210,45 @@ class GrainSegment2D(GrainSegment, ABC):
     @abstractmethod
     def get_core_area(self, web_distance: float) -> float:
         """
-        Calculates the core area in function of the web distance traveled.
+        Return the core area at a given web distance.
 
-        Example:
-        In a simple tubular geometry, the core area would be equal to the
-        instant length of the segment times the instant core area.
+        In a simple tubular geometry, the core area equals the instant length
+        of the segment times the instant inner circumference. Not to be confused
+        with port area.
 
-        Not to be confused with port area!
+        Args:
+            web_distance: Web distance traveled [m].
 
-        :param float web_distance: Web distance traveled
-        :return: Core area in function of the web distance traveled
-        :rtype: float
+        Returns:
+            Core area [m^2].
         """
         pass
 
     @abstractmethod
     def get_face_area(self, web_distance: float) -> float:
         """
-        Calculates the face area in function of the web distance traveled.
+        Return the face area at a given web distance.
 
-        Example:
-        In a simple tubular geometry, the face area would be equal to the
-        outer diameter area minus the instantaneous core diameter area.
+        In a simple tubular geometry, the face area equals the outer diameter
+        area minus the instantaneous core diameter area.
 
-        :param float web_distance: Web distance traveled
-        :return: Face area in function of the web distance traveled
-        :rtype: float
+        Args:
+            web_distance: Web distance traveled [m].
+
+        Returns:
+            Face area [m^2].
         """
         pass
 
     def get_length(self, web_distance: float) -> float:
+        """Return the segment length at a given web distance [m]."""
         exposed_ends = (not self.inhibited_surfaces.upper_end) + (
             not self.inhibited_surfaces.lower_end
         )
         return self.length - web_distance * exposed_ends
 
     def get_burn_area(self, web_distance: float) -> float:
+        """Return the segment burn area at a given web distance [m^2]."""
         if web_distance > self.get_web_thickness():
             return 0
 
@@ -262,6 +265,7 @@ class GrainSegment2D(GrainSegment, ABC):
         return core_area + total_face_area
 
     def get_volume(self, web_distance: float) -> float:
+        """Return the segment volume at a given web distance [m^3]."""
         if self.get_web_thickness() >= web_distance:
             return self.get_length(web_distance=web_distance) * self.get_face_area(
                 web_distance=web_distance
@@ -272,11 +276,9 @@ class GrainSegment2D(GrainSegment, ABC):
 
 class GrainSegment3D(GrainSegment, ABC):
     """
-    Class that represents a 3D grain segment.
+    A 3D grain segment with cross section varying along its length.
 
-    Some examples of 3D grain geometries:
-    - Conical
-    - Finocyl
+    Examples of 3D grain geometries: conical, finocyl.
     """
 
     def __init__(
@@ -296,24 +298,19 @@ class GrainSegment3D(GrainSegment, ABC):
     @abstractmethod
     def get_port_area(self, web_distance: float, z: float) -> float:
         """
-        Calculates the port area as a function of the web distance traveled
-        and a specified height (z).
-
-        NOTE: This method is not implemented.
+        Return the port area at a given web distance and axial height.
 
         Args:
-            web_distance: The distance traveled into the grain web.
-            z: The axial position (height) along the grain.
+            web_distance: Distance traveled into the grain web [m].
+            z: Axial position (height) along the grain [m].
 
         Returns:
-            The port area at the given web distance and height.
+            Port area at the given web distance and height [m^2].
         """
         pass
 
     def get_length(self, web_distance: float) -> float:
-        """
-        NOTE: Modify later.
-        """
+        """Return the segment length at a given web distance [m]."""
         exposed_ends = (not self.inhibited_surfaces.upper_end) + (
             not self.inhibited_surfaces.lower_end
         )
@@ -321,32 +318,36 @@ class GrainSegment3D(GrainSegment, ABC):
 
 
 class Grain:
+    """Assembly of one or more grain segments."""
+
     def __init__(self, spacing: float = 0.0) -> None:
         """
         Initialize a grain assembly.
 
         Args:
-            spacing: Distance between segments in meters. Default is 0.0
-                (no spacing).
+            spacing: Distance between segments [m]. Default is 0.0 (no spacing).
         """
         self.segments: list[GrainSegment] = []
         self.spacing = spacing
 
     def add_segment(self, new_segment: GrainSegment) -> None:
         """
-        Adds a new segment to the grain.
+        Add a new segment to the grain.
 
-        :param GrainSegment new_segment: The new segment to be added
-        :rtype: None
-        :raises Exceptiom: If the new_segment is not valid
+        Args:
+            new_segment: The new segment to be added.
+
+        Raises:
+            TypeError: If `new_segment` is not a `GrainSegment` instance.
         """
         if isinstance(new_segment, GrainSegment):
             self.segments.append(new_segment)
         else:
-            raise Exception("Argument is not a GrainSegment class instance")
+            raise TypeError("Argument is not a GrainSegment class instance")
 
     def get_effective_density_ratio(self, *, web_distance: float) -> float:
-        r"""Return an effective (burn-area weighted) density ratio.
+        r"""
+        Return an effective (burn-area weighted) density ratio.
 
         Used for gas generation terms where $\dot{m} \propto A_b r \rho_p$.
         """
@@ -364,7 +365,7 @@ class Grain:
         return float(np.sum(burn_areas * density_ratios) / total_burn_area)
 
     def get_real_density(self, *, web_distance: float, ideal_density: float) -> float:
-        """Return grain *effective real* propellant density [kg/m^3]."""
+        """Return grain effective real propellant density [kg/m^3]."""
         if ideal_density <= 0:
             raise ValueError(f"ideal_density must be > 0 (got {ideal_density})")
         return ideal_density * self.get_effective_density_ratio(
@@ -389,14 +390,12 @@ class Grain:
     @property
     def total_length(self) -> float:
         """
-        Calculates total length of the grain.
+        Return the total length of the grain [m].
 
-        Example:
-        - 1 segment of 0.5 m length -> total length = 0.5 m
-        - 2 segments of 0.5 m length with 0.1 m spacing -> total length = 1.1 m
-        - 3 segments of 0.5 m length with 0.1 m spacing -> total length = 1.7 m
-
-        :rtype: float
+        Examples:
+            - 1 segment of 0.5 m length -> total length = 0.5 m.
+            - 2 segments of 0.5 m length with 0.1 m spacing -> total length = 1.1 m.
+            - 3 segments of 0.5 m length with 0.1 m spacing -> total length = 1.7 m.
         """
         total_segment_length = np.sum([grain.length for grain in self.segments])
         if len(self.segments) > 1:  # add spacing between segments
@@ -405,18 +404,14 @@ class Grain:
 
     @property
     def segment_count(self) -> int:
-        """
-        Returns the number of segments in the grain.
-
-        :rtype: int
-        """
+        """Return the number of segments in the grain."""
         return len(self.segments)
 
     def get_center_of_gravity(
         self, web_distance: float
     ) -> np.typing.NDArray[np.float64]:
         """
-        Calculates the center of gravity of the grain.
+        Return the center of gravity of the grain.
 
         Takes the mass-weighted average of all segment centers of gravity,
         accounting for varying density ratios and spacing between segments.
@@ -425,9 +420,9 @@ class Grain:
             web_distance: Web distance traveled [m].
 
         Returns:
-            A 1D array of shape (3,) representing the [x, y, z] coordinates
-            of the center of gravity [m]. Origin is at the port of the grain
-            (closest to nozzle), with positive x pointing toward bulkhead.
+            A 1D array of shape (3,) with the [x, y, z] coordinates of the
+            center of gravity [m]. Origin is at the port of the grain (closest
+            to nozzle), with positive x pointing toward bulkhead.
 
         Raises:
             ValueError: If no segments are found in the grain.
@@ -469,8 +464,10 @@ class Grain:
         self, ideal_density: float, web_distance: float = 0.0
     ) -> np.typing.NDArray[np.float64]:
         """
-        Combines the inertia tensors of all grain segments using the parallel axis
-        theorem, accounting for varying density ratios and spacing between segments.
+        Combine the inertia tensors of all grain segments.
+
+        Uses the parallel axis theorem, accounting for varying density ratios
+        and spacing between segments.
 
         Args:
             ideal_density: Propellant ideal density [kg/m^3].
@@ -478,14 +475,14 @@ class Grain:
 
         Returns:
             A 3x3 inertia tensor [kg-m^2] at the grain's center of gravity:
+
                 [[Ixx, Ixy, Ixz],
                  [Ixy, Iyy, Iyz],
                  [Ixz, Iyz, Izz]]
 
-            Coordinate system: Origin at grain's center of gravity, with:
-            - x-axis: axial direction (toward bulkhead)
-            - y-axis: radial direction
-            - z-axis: radial direction
+            Coordinate system: origin at grain's center of gravity, with x-axis
+            in the axial direction (toward bulkhead) and y-/z-axes in the
+            radial plane.
 
         Raises:
             ValueError: If no segments are found in the grain.
@@ -529,11 +526,13 @@ class Grain:
 
     def get_burn_area(self, web_distance: float) -> float:
         """
-        Calculates the BATES burn area given the web distance.
+        Return the grain burn area at a given web distance.
 
-        :param float web_distance: Instant web thickness value
-        :return float: Instant burn area, in m^2 and in function of web
-        :rtype: float
+        Args:
+            web_distance: Web distance traveled [m].
+
+        Returns:
+            Total burn area summed across all segments [m^2].
         """
         return np.sum(
             [segment.get_burn_area(web_distance) for segment in self.segments]
@@ -541,11 +540,13 @@ class Grain:
 
     def get_propellant_volume(self, web_distance: float) -> float:
         """
-        Calculates the BATES grain volume given the web distance.
+        Return the grain propellant volume at a given web distance.
 
-        :param float web_distance: Instant web thickness value
-        :return: Instant propellant volume, in m^3 and in function of web
-        :rtype: float
+        Args:
+            web_distance: Web distance traveled [m].
+
+        Returns:
+            Total propellant volume summed across all segments [m^3].
         """
         return np.sum([segment.get_volume(web_distance) for segment in self.segments])
 
@@ -556,8 +557,16 @@ class Grain:
         web_distance: np.ndarray,
     ) -> np.ndarray:
         """
-        Returns a numpy multidimensional array with the mass flux for each
-        grain.
+        Return mass flux per segment over time.
+
+        Args:
+            burn_rate: Burn rate samples [m/s].
+            ideal_density: Propellant ideal density [kg/m^3].
+            web_distance: Web distance samples [m].
+
+        Returns:
+            Mass flux array of shape `(segment_count, len(web_distance))`
+            [kg/(s-m^2)].
         """
         segment_mass_flux = np.zeros((self.segment_count, np.size(web_distance)))
 
@@ -582,8 +591,10 @@ class Grain:
         return segment_mass_flux
 
     def get_segment_mismatches(self) -> list[str]:
-        """Return per-attribute descriptions of where segments diverge. Uses
-        first segment as a reference.
+        """
+        Return per-attribute descriptions of where segments diverge.
+
+        Uses the first segment as reference.
 
         Returns:
             One description per divergent (segment, attribute) pair.

--- a/machwave/models/grain/base.py
+++ b/machwave/models/grain/base.py
@@ -130,7 +130,7 @@ class GrainSegment(ABC):
         with positive x-direction pointing toward the bulkhead.
 
         Returns:
-            Center of gravity of the segment [x, y, z] [m].
+            Center of gravity of the segment as `(x, y, z)` [m].
         """
         pass
 

--- a/machwave/models/grain/fmm/_2d.py
+++ b/machwave/models/grain/fmm/_2d.py
@@ -47,8 +47,9 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
 
     def get_maps(self) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         """
-        Return a tuple of two 2D arrays (map_x, map_y).
-        Each is of shape (map_dim, map_dim), ranging from -1 to 1.
+        Return the coordinate maps `(map_x, map_y)`.
+
+        Each array has shape `(map_dim, map_dim)` and ranges from -1 to 1.
         """
         if self.maps is None:
             map_x, map_y = np.meshgrid(
@@ -59,9 +60,7 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
         return self.maps
 
     def get_mask(self) -> NDArray[np.bool_]:
-        """
-        Return a boolean mask indicating which points lie outside the unit circle.
-        """
+        """Return a boolean mask indicating which points lie outside the unit circle."""
         if self.mask is None:
             map_x, map_y = self.get_maps()
             self.mask = (map_x**2 + map_y**2) > 1
@@ -80,25 +79,20 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
 
     def get_contours(self, web_distance: float) -> list[NDArray[np.float64]]:
         """
-        Return a list of contour arrays for the given web distance.
-        Each contour is typically an (N,2) array of (row, col) points.
+        Return contour arrays for the given web distance.
+
+        Each contour is typically an `(N, 2)` array of `(row, col)` points.
         """
         map_dist = self.normalize(web_distance)
         return get_contours(self.get_regression_map(), map_dist)
 
     def get_port_area(self, web_distance: float) -> float:
-        """
-        Return the grain's port area (open cross-sectional area) at the given web distance.
-        Could be a scalar or array, depending on how the computations are done.
-        """
+        """Return the open cross-sectional port area [m^2]."""
         face_area = self.get_face_area(web_distance)
         return get_circle_area(self.outer_diameter) - face_area
 
     def get_face_area_interp_func(self) -> Callable[[float], float]:
-        """
-        Build and return an interpolation function that, given a normalized
-        web distance, returns the face area in square meters.
-        """
+        """Return an interpolator mapping normalized web distance to face area [m^2]."""
         if self.face_area_interp_func is None:
             regression_map = self.get_regression_map()
             valid = np.logical_not(self.get_mask())
@@ -137,15 +131,12 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
         return self.face_area_interp_func
 
     def get_face_area(self, web_distance: float) -> float:
-        """
-        Return the face area at the given web distance.
-        """
+        """Return the face area at the given web distance."""
         map_distance = self.normalize(web_distance)
         return float(self.get_face_area_interp_func()(map_distance))
 
     def get_burn_area_interp_func(self) -> Callable[[float], float]:
         """Return a cached interpolator for burn area [m^2] vs normalized web."""
-
         if self.burn_area_interp_func is None:
             regression_map = self.get_regression_map()
             valid = np.logical_not(self.get_mask())
@@ -219,9 +210,7 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
         return max(0.0, value)
 
     def get_core_perimeter(self, web_distance: float) -> float:
-        """
-        Return the perimeter of the open core at the given web distance.
-        """
+        """Return the perimeter of the open core at the given web distance."""
         contours = self.get_contours(web_distance)
         return float(
             sum(
@@ -232,13 +221,15 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
 
     def get_core_area(self, web_distance: float) -> float:
         """
-        Calculate the core (internal) area at the given web distance by
-        multiplying perimeter by grain segment length (a 2D approximation).
+        Return the core (internal) area [m^2] at the given web distance.
+
+        Computed as `perimeter * length` (2D approximation).
         """
         return self.get_core_perimeter(web_distance) * self.get_length(web_distance)
 
     def _validate_web_distance(self, web_distance: float) -> None:
-        """Validate that web distance does not exceed web thickness.
+        """
+        Validate that web distance does not exceed web thickness.
 
         Raises:
             GrainGeometryError: If web distance exceeds web thickness.
@@ -251,7 +242,8 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
     def _get_active_material_indices(
         self, web_distance: float
     ) -> tuple[NDArray[np.int_], NDArray[np.int_]]:
-        """Get indices of active material at given web distance.
+        """
+        Get indices of active material at given web distance.
 
         Args:
             web_distance: Web distance traveled [m].
@@ -276,7 +268,8 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
     def _indices_to_normalized_coords(
         self, y_indices: NDArray[np.int_], x_indices: NDArray[np.int_]
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        """Convert indices to normalized coordinates centered at origin.
+        """
+        Convert indices to normalized coordinates centered at origin.
 
         Args:
             y_indices: Y-axis indices from face map.
@@ -292,14 +285,13 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
 
     def get_center_of_gravity(self, web_distance: float) -> NDArray[np.float64]:
         """
-        Calculates the center of gravity of a 2D FMM grain segment at a web
-        distance.
+        Return the center of gravity of a 2D FMM grain segment.
 
         Args:
             web_distance: Web distance traveled [m].
 
         Returns:
-            Center of gravity [x, y, z] in meters from the port of the segment.
+            Center of gravity [x, y, z] [m], measured from the segment port.
         """
         self._validate_web_distance(web_distance)
         y_indices, x_indices = self._get_active_material_indices(web_distance)
@@ -326,7 +318,7 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
 
         Args:
             web_distance: Web distance traveled [m].
-            ideal_density: Propellant ideal density [kg/m³].
+            ideal_density: Propellant ideal density [kg/m^3].
 
         Returns:
             A 3x3 inertia tensor [kg-m^2].
@@ -360,7 +352,7 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
         moi = get_moment_of_inertia_tensor(x_rel, y_rel, z_rel, element_mass)
 
         # For 2D grain (uniform along axial direction), add axial contribution
-        # For a uniform rod of length L with mass M: I_axial = M*L²/12 (about CoG)
+        # For a uniform rod of length L with mass M: I_axial = M*L^2/12 (about CoG)
         I_axial = total_mass * current_length**2 / 12
 
         # Add axial contribution to radial axes (indices 1 and 2 in [z,x,y] system)

--- a/machwave/models/grain/fmm/_2d.py
+++ b/machwave/models/grain/fmm/_2d.py
@@ -291,7 +291,7 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
             web_distance: Web distance traveled [m].
 
         Returns:
-            Center of gravity [x, y, z] [m], measured from the segment port.
+            Center of gravity as `(x, y, z)` [m], measured from the segment port.
         """
         self._validate_web_distance(web_distance)
         y_indices, x_indices = self._get_active_material_indices(web_distance)

--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -59,7 +59,7 @@ class FMMGrainSegment3D(FMMGrainSegment, GrainSegment3D, ABC):
                 geometry setup).
 
         Returns:
-            A float representing the port area at the specified z slice, in m².
+            A float representing the port area at the specified z slice, in m^2.
         """
         map_dist = self.normalize(web_distance)
         valid = np.logical_not(self.get_mask())
@@ -168,7 +168,6 @@ class FMMGrainSegment3D(FMMGrainSegment, GrainSegment3D, ABC):
 
     def get_burn_area_interp_func(self) -> Callable[[float], float]:
         """Return a cached interpolator for burn area [m^2] vs normalized web."""
-
         if self.burn_area_interp_func is None:
             regression_map = self.get_regression_map()
             valid = np.logical_not(self.get_mask())
@@ -223,7 +222,8 @@ class FMMGrainSegment3D(FMMGrainSegment, GrainSegment3D, ABC):
         return active_elements * volume_per_element
 
     def _validate_web_distance(self, web_distance: float) -> None:
-        """Validate that web distance does not exceed web thickness.
+        """
+        Validate that web distance does not exceed web thickness.
 
         Raises:
             GrainGeometryError: If web distance exceeds web thickness.
@@ -237,7 +237,8 @@ class FMMGrainSegment3D(FMMGrainSegment, GrainSegment3D, ABC):
     def _get_active_material_indices(
         self, web_distance: float
     ) -> tuple[NDArray[np.int_], NDArray[np.int_], NDArray[np.int_]]:
-        """Get indices of active material at given web distance.
+        """
+        Get indices of active material at given web distance.
 
         Args:
             web_distance: Web distance traveled [m].
@@ -265,7 +266,8 @@ class FMMGrainSegment3D(FMMGrainSegment, GrainSegment3D, ABC):
         y_indices: NDArray[np.int_],
         x_indices: NDArray[np.int_],
     ) -> tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]:
-        """Convert indices to normalized coordinates centered at origin.
+        """
+        Convert indices to normalized coordinates centered at origin.
 
         Args:
             z_indices: Z-axis (axial) indices from face map.
@@ -283,8 +285,7 @@ class FMMGrainSegment3D(FMMGrainSegment, GrainSegment3D, ABC):
 
     def get_center_of_gravity(self, web_distance: float) -> NDArray[np.float64]:
         """
-        Calculates the center of gravity of a 3D FMM grain segment at a web
-        distance.
+        Return the center of gravity of a 3D FMM grain segment.
 
         Args:
             web_distance: Web distance traveled [m].

--- a/machwave/models/grain/fmm/__init__.py
+++ b/machwave/models/grain/fmm/__init__.py
@@ -1,9 +1,10 @@
 """
-This module contains classes that model grain geometries using the Fast Marching
-Method (FMM). Both 2D and 3D geometries are supported, along with STL files.
+Fast Marching Method (FMM) grain geometry models.
+
+Supports both 2D and 3D geometries, as well as STL meshes.
 
 References:
-https://math.berkeley.edu/~sethian/2006/Explanations/fast_marching_explain.html
+    https://math.berkeley.edu/~sethian/2006/Explanations/fast_marching_explain.html
 """
 
 from machwave.models.grain.fmm._2d import FMMGrainSegment2D

--- a/machwave/models/grain/fmm/base.py
+++ b/machwave/models/grain/fmm/base.py
@@ -30,6 +30,16 @@ class FMMGrainSegment(GrainSegment, ABC):
         inhibited_surfaces: InhibitedSurfaces | None = None,
         density_ratio: float = 1.0,
     ) -> None:
+        """
+        Initialize an FMM grain segment.
+
+        Args:
+            map_dim: Pixel resolution of the cross-section map.
+            length: Segment length [m].
+            outer_diameter: Outer diameter [m].
+            inhibited_surfaces: Surfaces inhibited from burning.
+            density_ratio: Ratio of real to ideal propellant density.
+        """
         self.map_dim = map_dim
 
         # "Cache" variables:
@@ -48,36 +58,33 @@ class FMMGrainSegment(GrainSegment, ABC):
 
     @abstractmethod
     def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
-        """
-        Method needs to be implemented for each and every geometry.
-        """
+        """Method needs to be implemented for each and every geometry."""
         pass
 
     @abstractmethod
     def get_maps(self) -> tuple:
         """
+        Return the coordinate maps for the grain.
+
         Returns:
-            - 2D: (map_x, map_y)
-            - 3D: (map_x, map_y, map_z)
+            `(map_x, map_y)` for 2D; `(map_x, map_y, map_z)` for 3D.
         """
         pass
 
     @abstractmethod
     def get_mask(self) -> np.ndarray:
-        """
-        Implementation varies depending if the geometry is 2D or 3D.
-        """
+        """Implementation varies depending if the geometry is 2D or 3D."""
         pass
 
     def validate(self) -> None:
         """
-        Validates the internal geometry of the grain.
+        Validate the internal geometry of the grain.
 
-        This method ensures the grain map dimension meets the minimum
-        required size. If validation fails, a GrainGeometryError is raised.
+        Ensures the grain map dimension meets the minimum required size.
 
         Raises:
-            GrainGeometryError: If the grain map dimension is below the valid threshold.
+            GrainGeometryError: If the grain map dimension is below the valid
+                threshold.
         """
         super().validate()
         if not self.map_dim >= MINIMUM_MAP_DIMENSION:
@@ -88,48 +95,35 @@ class FMMGrainSegment(GrainSegment, ABC):
 
     def normalize(self, value: int | float) -> float:
         """
-        Converts a raw dimensional value into a normalized scale based on the
-        object's outer diameter.
+        Convert a dimensional value to a fraction of the half-diameter.
 
         Args:
-            value: The dimensional value (e.g., length) to normalize.
+            value: Dimensional value (e.g., length) to normalize [m].
 
         Returns:
-            A float representing the dimension as a fraction of the object's
-            half-diameter.
+            Value expressed as a fraction of the half-diameter.
         """
         return value / (0.5 * self.outer_diameter)
 
     def denormalize(
         self, value: int | float | NDArray[np.float64]
     ) -> float | NDArray[np.float64]:
-        """
-        Converts a normalized input value into an actual dimension based on the
-        object's outer diameter.
-
-        Args:
-            value: A numeric value representing a normalized quantity.
-
-        Returns:
-            The denormalized value as a float, calculated by scaling `value` with
-            the object's outer diameter.
-        """
+        """Convert a normalized input back into a dimensional value [m]."""
         return (value / 2) * (self.outer_diameter)
 
     def map_to_area(
         self, value: float | NDArray[np.float64]
     ) -> float | NDArray[np.float64]:
         """
-        Convert a pixel-area value into square meters.
+        Convert a pixel-area value to [m^2].
 
-        The conversion is based on the ratio of this object's outer diameter
-        (squared) to the total pixel map dimension (squared).
+        Scales by `outer_diameter^2 / map_dim^2`.
 
         Args:
-            value: The area in pixel units.
+            value: Area in pixel units.
 
         Returns:
-            The corresponding area in square meters.
+            Area [m^2].
         """
         return (self.outer_diameter**2) * (value / (self.map_dim**2))
 
@@ -137,25 +131,20 @@ class FMMGrainSegment(GrainSegment, ABC):
         self, value: float | NDArray[np.float64]
     ) -> float | NDArray[np.float64]:
         """
-        Convert a pixel-distance value into meters.
+        Convert a pixel-distance value to [m].
 
-        The conversion is based on the ratio of this object's outer diameter
-        to its total map dimension.
+        Scales by `outer_diameter / map_dim`.
 
         Args:
-            value: The distance in pixel units.
+            value: Distance in pixel units.
 
         Returns:
-            The corresponding distance in meters.
+            Distance [m].
         """
         return self.outer_diameter * (value / self.map_dim)
 
     def get_empty_face_map(self) -> np.ndarray:
-        """
-        Return a new face map consisting entirely of ones.
-
-        The shape of the array matches the first element in the object's stored maps.
-        """
+        """Return a face map of all ones, shaped like the first stored map."""
         return np.ones_like(self.get_maps()[0])
 
     def _apply_inhibition(
@@ -163,18 +152,18 @@ class FMMGrainSegment(GrainSegment, ABC):
         face_map: NDArray[np.int_],
         outside: NDArray[np.bool_],
     ) -> tuple[NDArray[np.int_], NDArray[np.bool_]]:
-        """Apply surface-inhibition adjustments to the face map and mask.
+        """
+        Apply surface-inhibition adjustments to the face map and mask.
 
-        This base implementation handles outer surface inhibition.
-        2D and 3D subclasses add their own logic to apply other inhibited surfaces as
-        needed.
+        Base implementation handles outer-surface inhibition. 2D and 3D
+        subclasses add their own logic for other inhibited surfaces.
 
         Args:
             face_map: Mutable copy of the initial face map.
             outside: Mutable copy of the circular boundary mask.
 
         Returns:
-            The face_map and outside mask with inhibition applied.
+            Tuple `(face_map, outside)` with inhibition applied.
         """
         if not self.inhibited_surfaces.outer_surface:
             inside = ~outside  # Invert the mask
@@ -188,9 +177,8 @@ class FMMGrainSegment(GrainSegment, ABC):
         """
         Return a masked representation of the face map.
 
-        The mask is circular and normalized to the map dimensions. If a mask
-        has not been created yet, it is generated by combining the initial face
-        map with the circular mask.
+        The mask is circular and normalized to the map dimensions. Generated on
+        first access by combining the initial face map with the circular mask.
         """
         if self.masked_face is None:
             face_map = self.get_initial_face_map().copy()
@@ -202,18 +190,15 @@ class FMMGrainSegment(GrainSegment, ABC):
         return self.masked_face
 
     def get_cell_size(self) -> float:
-        """
-        Return the size of each grid cell in normalized coordinates.
-
-        The value is derived by taking 1 divided by the map dimension.
-        """
+        """Return the cell size in normalized coordinates (`1 / map_dim`)."""
         return 1 / self.map_dim
 
     @property
     def has_cross_section_regression(self) -> bool:
-        """Whether the cross-section has any burning surface.
+        """
+        Return whether the cross-section has any burning surface.
 
-        Inspects the masked face map for zero-valued (burning) cells.
+        Inspects the masked face map for zero-valued (burning) cells. Returns
         False when no burning front exists for the FMM to propagate from.
         """
         masked_face = self.get_masked_face()
@@ -222,14 +207,12 @@ class FMMGrainSegment(GrainSegment, ABC):
 
     def get_regression_map(self):
         """
-        Calculate and return the distance map for grain regression.
+        Return the distance map for grain regression.
 
-        This uses the fast marching method (scikit-fmm) on the masked face.
-        Each value represents the distance from the initial face along the
-        cross-section of the grain.
-
-        When the cross-section has no burning surface (end burner), a
-        static map is returned.
+        Uses the fast marching method (scikit-fmm) on the masked face. Each
+        value represents the distance from the initial face along the
+        cross-section of the grain. When the cross-section has no burning
+        surface (end burner), a static map is returned instead.
         """
         if self.regression_map is None:
             masked_face = self.get_masked_face()
@@ -248,11 +231,10 @@ class FMMGrainSegment(GrainSegment, ABC):
 
     def get_web_thickness(self) -> float:
         """
-        Return the maximum thickness of the grain web in real units.
+        Return the maximum web thickness of the grain [m].
 
-        The web thickness is the largest distance from the center of the
-        grain segment, derived from the distance map and converted to a
-        real-world measurement.
+        Derived from the distance map as the largest normalized distance,
+        converted back into real units.
         """
         if self.web_thickness is None:
             self.web_thickness = float(
@@ -265,13 +247,13 @@ class FMMGrainSegment(GrainSegment, ABC):
         self, web_distance: float, *args: Any, **kwargs: Any
     ) -> list[NDArray[np.float64]]:
         """
-        Return the contours of the regression map after a specified web distance.
+        Return the contours of the regression map for a given web distance.
 
-        This method must be implemented by a subclass to compute the contour
-        data based on the given web distance and any additional parameters.
+        Must be implemented by a subclass to compute the contour data based on
+        the given web distance and any additional parameters.
 
         Args:
-            web_distance: The depth of regression into the grain web.
+            web_distance: Depth of regression into the grain web [m].
             *args: Additional positional arguments.
             **kwargs: Additional keyword arguments.
 

--- a/machwave/models/grain/fmm/contours.py
+++ b/machwave/models/grain/fmm/contours.py
@@ -23,8 +23,10 @@ def get_contours(
 
 def get_length(contour: np.ndarray, map_size: int, tolerance: float = 3.0) -> float:
     """
-    Returns the total length of all segments in a contour that aren't within
-    'tolerance' of the edge of a circle with diameter 'map_size'.
+    Return the total length of contour segments away from the disc edge.
+
+    Segments within `tolerance` of the edge of a circle of diameter `map_size`
+    are excluded.
 
     Args:
         contour: The contour array.

--- a/machwave/models/grain/fmm/stl.py
+++ b/machwave/models/grain/fmm/stl.py
@@ -9,10 +9,7 @@ from machwave.models.grain.fmm import FMMGrainSegment3D
 
 
 class FMMSTLGrainSegment(FMMGrainSegment3D, ABC):
-    """
-    Fast Marching Method (FMM) implementation for a grain segment obtained
-    from an STL file.
-    """
+    """FMM grain segment loaded from an STL mesh."""
 
     def __init__(
         self,
@@ -22,6 +19,16 @@ class FMMSTLGrainSegment(FMMGrainSegment3D, ABC):
         inhibited_surfaces: InhibitedSurfaces | None = None,
         map_dim: int = 50,
     ) -> None:
+        """
+        Initialize an STL-backed FMM grain segment.
+
+        Args:
+            file_path: Path to a watertight STL mesh of the grain.
+            outer_diameter: Outer diameter [m].
+            length: Segment length [m].
+            inhibited_surfaces: Surfaces inhibited from burning.
+            map_dim: Pixel resolution of the cross-section map.
+        """
         self.file_path = file_path
         self.outer_diameter = outer_diameter
         self.length = length
@@ -37,6 +44,7 @@ class FMMSTLGrainSegment(FMMGrainSegment3D, ABC):
         )
 
     def validate(self) -> None:
+        """Validate STL grain segment geometry."""
         if not self.map_dim >= 20:
             raise GrainGeometryError(
                 f"Map dimension must be at least 20 for STL grains, got {self.map_dim}"
@@ -44,18 +52,19 @@ class FMMSTLGrainSegment(FMMGrainSegment3D, ABC):
 
     def get_voxel_size(self) -> float:
         """
-        NOTE: Only returns correct voxel size if map_dim is an odd number.
+        Return the voxel edge size [m].
 
-        :return: the voxel edge size.
-        :rtype: float
+        Note:
+            Only returns correct voxel size if `map_dim` is an odd number.
         """
         return self.outer_diameter / int(self.map_dim - 1)
 
     def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
         """
-        Generate a map by voxelizing an STL file. Uses trimesh library.
+        Generate the initial face map by voxelizing an STL file.
 
-        NOTE: Still needs to convert boolean matrix to masked array.
+        Uses the `trimesh` library. Still needs to convert the boolean matrix
+        to a masked array.
         """
         mesh = trimesh.load_mesh(self.file_path)
         assert isinstance(mesh, trimesh.Trimesh), "Expected a single Trimesh"

--- a/machwave/models/grain/geometries/bates.py
+++ b/machwave/models/grain/geometries/bates.py
@@ -107,7 +107,7 @@ class BatesSegment(GrainSegment2D):
                 symmetry; included for API consistency.
 
         Returns:
-            Center of gravity [x, y, z] [m], measured from the aft end (port,
+            Center of gravity as `(x, y, z)` [m], measured from the aft end (port,
             closest to nozzle). Always returns [length/2, 0, 0] for symmetric
             BATES grains.
         """

--- a/machwave/models/grain/geometries/bates.py
+++ b/machwave/models/grain/geometries/bates.py
@@ -9,6 +9,8 @@ from machwave.models.grain.base import InhibitedSurfaces
 
 
 class BatesSegment(GrainSegment2D):
+    """BATES grain segment: cylindrical with circular central port."""
+
     INHIBITED_SURFACES = InhibitedSurfaces(
         outer_surface=True,
         inner_surface=False,
@@ -23,6 +25,15 @@ class BatesSegment(GrainSegment2D):
         length: float,
         density_ratio: float = 1.0,
     ) -> None:
+        """
+        Initialize a BATES grain segment.
+
+        Args:
+            outer_diameter: Outer diameter [m].
+            core_diameter: Core (port) diameter [m].
+            length: Segment length [m].
+            density_ratio: Ratio of real to ideal propellant density.
+        """
         self.core_diameter = core_diameter
 
         super().__init__(
@@ -33,6 +44,7 @@ class BatesSegment(GrainSegment2D):
         )
 
     def validate(self) -> None:
+        """Validate BATES segment geometry."""
         super().validate()
 
         if not self.outer_diameter > self.core_diameter:
@@ -46,35 +58,37 @@ class BatesSegment(GrainSegment2D):
             )
 
     def get_core_diameter(self, web_distance: float) -> float:
+        """Return the core diameter at a given web distance [m]."""
         return self.core_diameter + 2 * web_distance
 
     def get_port_area(self, web_distance: float) -> float:
+        """Return the port area at a given web distance [m^2]."""
         return get_circle_area(diameter=self.get_core_diameter(web_distance))
 
     def get_core_area(self, web_distance: float) -> float:
+        """Return the core (inner cylindrical) surface area [m^2]."""
         length = self.get_length(web_distance=web_distance)
         core_diameter = self.core_diameter + 2 * web_distance
         return get_cylinder_surface_area(length, core_diameter)
 
     def get_face_area(self, web_distance: float) -> float:
+        """Return the annular face area at a given web distance [m^2]."""
         core_diameter = self.get_core_diameter(web_distance)
         return np.pi * (((self.outer_diameter**2) - (core_diameter) ** 2) / 4)
 
     def get_web_thickness(self) -> float:
         """
-        More details on the web thickness of BATES grains can be found in:
-        https://www.nakka-rocketry.net/design1.html
+        Return the BATES web thickness [m].
+
+        See: https://www.nakka-rocketry.net/design1.html.
         """
         return 0.5 * (self.outer_diameter - self.core_diameter)
 
     def get_optimal_length(self) -> float:
         """
-        Returns the optimal length for BATES segment.
-        More details on the calculation:
-        https://www.nakka-rocketry.net/th_grain.html
+        Return the optimal length for neutral burn of a BATES segment [mm].
 
-        :return: Optimal length for neutral burn of BATES segment
-        :rtype: float
+        See: https://www.nakka-rocketry.net/th_grain.html.
         """
         return 1e3 * 0.5 * (3 * self.outer_diameter + self.core_diameter)
 
@@ -82,20 +96,20 @@ class BatesSegment(GrainSegment2D):
         self, web_distance: float = 0.0
     ) -> np.typing.NDArray[np.float64]:
         """
-        Calculate the center of gravity of the BATES grain segment.
+        Return the center of gravity of a BATES segment.
 
         BATES is a symmetrical 2D geometry that burns radially. Due to its
         cylindrical symmetry, the center of gravity remains constant at the
         geometric center regardless of web distance burned.
 
         Args:
-            web_distance: Web distance traveled (unused for BATES due to symmetry),
-                         in meters. Included for API consistency.
+            web_distance: Web distance traveled [m]. Unused for BATES due to
+                symmetry; included for API consistency.
 
         Returns:
-            Center of gravity in 3D space [x, y, z], in meters, measured from
-            the aft end (port, closest to nozzle). Always returns [length/2, 0, 0]
-            for symmetric BATES grains.
+            Center of gravity [x, y, z] [m], measured from the aft end (port,
+            closest to nozzle). Always returns [length/2, 0, 0] for symmetric
+            BATES grains.
         """
         # For symmetric BATES grains, CoG doesn't change with burn
         # The grain burns radially inward, maintaining axial symmetry
@@ -106,8 +120,10 @@ class BatesSegment(GrainSegment2D):
         self, ideal_density: float, web_distance: float = 0.0
     ) -> np.typing.NDArray[np.float64]:
         """
-        Calculate the moment of inertia tensor of the BATES grain segment (hollow
-        cylinder) at its center of gravity.
+        Return the moment of inertia tensor of the BATES segment.
+
+        Treats the segment as a hollow cylinder and evaluates the tensor at
+        its center of gravity.
 
         Args:
             ideal_density: Propellant ideal density [kg/m^3].

--- a/machwave/models/grain/geometries/conical.py
+++ b/machwave/models/grain/geometries/conical.py
@@ -6,6 +6,8 @@ from machwave.models.grain.fmm import FMMGrainSegment3D
 
 
 class ConicalGrainSegment(FMMGrainSegment3D):
+    """Grain segment with a conical port tapering between two diameters."""
+
     def __init__(
         self,
         length: float,
@@ -15,6 +17,17 @@ class ConicalGrainSegment(FMMGrainSegment3D):
         inhibited_surfaces: InhibitedSurfaces | None = None,
         density_ratio: float = 1.0,
     ) -> None:
+        """
+        Initialize a conical grain segment.
+
+        Args:
+            length: Segment length [m].
+            outer_diameter: Outer diameter [m].
+            upper_core_diameter: Core diameter at the upper (bulkhead) end [m].
+            lower_core_diameter: Core diameter at the lower (nozzle) end [m].
+            inhibited_surfaces: Surfaces inhibited from burning.
+            density_ratio: Ratio of real to ideal propellant density.
+        """
         self.upper_core_diameter = upper_core_diameter
         self.lower_core_diameter = lower_core_diameter
 
@@ -26,6 +39,7 @@ class ConicalGrainSegment(FMMGrainSegment3D):
         )
 
     def validate(self) -> None:
+        """Validate conical segment geometry."""
         super().validate()
 
         if not self.upper_core_diameter > 0:
@@ -48,6 +62,7 @@ class ConicalGrainSegment(FMMGrainSegment3D):
             )
 
     def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
+        """Return the initial face map for the conical port."""
         map_x, map_y, map_z = self.get_maps()
         core_map = self.get_empty_face_map()
 

--- a/machwave/models/grain/geometries/d_grain.py
+++ b/machwave/models/grain/geometries/d_grain.py
@@ -6,6 +6,8 @@ from machwave.models.grain.fmm import FMMGrainSegment2D
 
 
 class DGrainSegment(FMMGrainSegment2D):
+    """D-shaped grain segment with a single offset planar slot."""
+
     def __init__(
         self,
         length: float,
@@ -14,6 +16,16 @@ class DGrainSegment(FMMGrainSegment2D):
         inhibited_surfaces: InhibitedSurfaces | None = None,
         density_ratio: float = 1.0,
     ) -> None:
+        """
+        Initialize a D-grain segment.
+
+        Args:
+            length: Segment length [m].
+            outer_diameter: Outer diameter [m].
+            slot_offset: Distance from the grain center to the slot face [m].
+            inhibited_surfaces: Surfaces inhibited from burning.
+            density_ratio: Ratio of real to ideal propellant density.
+        """
         self.slot_offset = slot_offset
 
         super().__init__(
@@ -24,6 +36,7 @@ class DGrainSegment(FMMGrainSegment2D):
         )
 
     def validate(self) -> None:
+        """Validate D-grain segment geometry."""
         super().validate()
 
         if not self.slot_offset >= 0:
@@ -38,6 +51,7 @@ class DGrainSegment(FMMGrainSegment2D):
             )
 
     def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
+        """Return the initial face map for the D-grain port."""
         slot_offset_normalized = self.normalize(self.slot_offset)
         map_x = self.get_maps()[0]
         core_map = self.get_empty_face_map()

--- a/machwave/models/grain/geometries/multi_port.py
+++ b/machwave/models/grain/geometries/multi_port.py
@@ -6,6 +6,8 @@ from machwave.models.grain.fmm import FMMGrainSegment2D
 
 
 class MultiPortGrainSegment(FMMGrainSegment2D):
+    """Grain segment with multiple circular ports arranged radially."""
+
     def __init__(
         self,
         length: float,
@@ -16,6 +18,18 @@ class MultiPortGrainSegment(FMMGrainSegment2D):
         inhibited_surfaces: InhibitedSurfaces | None = None,
         density_ratio: float = 1.0,
     ) -> None:
+        """
+        Initialize a multi-port grain segment.
+
+        Args:
+            length: Segment length [m].
+            outer_diameter: Outer diameter [m].
+            port_diameter: Diameter of each port [m].
+            port_radial_count: Number of ports per concentric ring.
+            port_level_count: Number of concentric rings of ports.
+            inhibited_surfaces: Surfaces inhibited from burning.
+            density_ratio: Ratio of real to ideal propellant density.
+        """
         self.port_diameter = port_diameter
         self.port_radial_count = int(port_radial_count)
         self.port_level_count = int(port_level_count)
@@ -28,6 +42,7 @@ class MultiPortGrainSegment(FMMGrainSegment2D):
         )
 
     def validate(self) -> None:
+        """Validate multi-port segment geometry."""
         super().validate()
 
         if not self.port_diameter > 0:
@@ -51,9 +66,7 @@ class MultiPortGrainSegment(FMMGrainSegment2D):
             )
 
     def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
-        """
-        NOTE: Still needs to correctly implement wagon wheel ports.
-        """
+        """NOTE: Still needs to correctly implement wagon wheel ports."""
         map_x, map_y = self.get_maps()
         core_map = self.get_empty_face_map()
 

--- a/machwave/models/grain/geometries/rod_and_tube.py
+++ b/machwave/models/grain/geometries/rod_and_tube.py
@@ -6,6 +6,8 @@ from machwave.models.grain.fmm import FMMGrainSegment2D
 
 
 class RodAndTubeGrainSegment(FMMGrainSegment2D):
+    """Rod-and-tube grain segment: central rod inside a concentric tube."""
+
     def __init__(
         self,
         length: float,
@@ -15,6 +17,17 @@ class RodAndTubeGrainSegment(FMMGrainSegment2D):
         inhibited_surfaces: InhibitedSurfaces | None = None,
         density_ratio: float = 1.0,
     ) -> None:
+        """
+        Initialize a rod-and-tube grain segment.
+
+        Args:
+            length: Segment length [m].
+            outer_diameter: Outer (tube outer) diameter [m].
+            rod_outer_diameter: Central rod outer diameter [m].
+            tube_inner_diameter: Tube inner diameter [m].
+            inhibited_surfaces: Surfaces inhibited from burning.
+            density_ratio: Ratio of real to ideal propellant density.
+        """
         self.rod_outer_diameter = rod_outer_diameter
         self.tube_inner_diameter = tube_inner_diameter
 
@@ -26,6 +39,7 @@ class RodAndTubeGrainSegment(FMMGrainSegment2D):
         )
 
     def validate(self) -> None:
+        """Validate rod-and-tube segment geometry."""
         super().validate()
 
         if not self.rod_outer_diameter > 0:
@@ -44,9 +58,7 @@ class RodAndTubeGrainSegment(FMMGrainSegment2D):
             )
 
     def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
-        """
-        NOTE: Still needs to correctly implement wagon wheel ports.
-        """
+        """NOTE: Still needs to correctly implement wagon wheel ports."""
         map_x, map_y = self.get_maps()
         core_map = self.get_empty_face_map()
 

--- a/machwave/models/grain/geometries/star.py
+++ b/machwave/models/grain/geometries/star.py
@@ -6,6 +6,8 @@ from machwave.models.grain.fmm import FMMGrainSegment2D
 
 
 class StarGrainSegment(FMMGrainSegment2D):
+    """Star grain segment with a radial point pattern as the port."""
+
     def __init__(
         self,
         length: float,
@@ -16,6 +18,18 @@ class StarGrainSegment(FMMGrainSegment2D):
         inhibited_surfaces: InhibitedSurfaces | None = None,
         density_ratio: float = 1.0,
     ) -> None:
+        """
+        Initialize a star grain segment.
+
+        Args:
+            length: Segment length [m].
+            outer_diameter: Outer diameter [m].
+            number_of_points: Number of star points (must be < 12).
+            point_length: Radial length of each point [m].
+            point_width: Width of each point at the base [m].
+            inhibited_surfaces: Surfaces inhibited from burning.
+            density_ratio: Ratio of real to ideal propellant density.
+        """
         self.number_of_points = int(number_of_points)
         self.point_length = point_length
         self.point_width = point_width
@@ -28,6 +42,7 @@ class StarGrainSegment(FMMGrainSegment2D):
         )
 
     def validate(self) -> None:
+        """Validate star segment geometry."""
         super().validate()
 
         if not self.number_of_points > 0:
@@ -53,10 +68,10 @@ class StarGrainSegment(FMMGrainSegment2D):
 
     def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
         """
-        This method returns the initial face map for a star grain segment.
+        Return the initial face map for a star grain segment.
 
         References:
-        openMotor, https://github.com/reilleya/openMotor
+            openMotor, https://github.com/reilleya/openMotor
         """
         map_x, map_y = self.get_maps()
         core_map = self.get_empty_face_map()

--- a/machwave/models/grain/geometries/wagon_wheel.py
+++ b/machwave/models/grain/geometries/wagon_wheel.py
@@ -6,6 +6,8 @@ from machwave.models.grain.fmm import FMMGrainSegment2D
 
 
 class WagonWheelGrainSegment(FMMGrainSegment2D):
+    """Wagon-wheel grain segment with a central core and radial spoke ports."""
+
     def __init__(
         self,
         length: float,
@@ -18,6 +20,20 @@ class WagonWheelGrainSegment(FMMGrainSegment2D):
         inhibited_surfaces: InhibitedSurfaces | None = None,
         density_ratio: float = 1.0,
     ) -> None:
+        """
+        Initialize a wagon-wheel grain segment.
+
+        Args:
+            length: Segment length [m].
+            outer_diameter: Outer diameter [m].
+            core_diameter: Central core diameter [m].
+            number_of_ports: Number of radial spoke ports (must be even).
+            port_inner_diameter: Inner radial extent of each spoke port [m].
+            port_outer_diameter: Outer radial extent of each spoke port [m].
+            port_angular_width: Angular width of each spoke port [deg].
+            inhibited_surfaces: Surfaces inhibited from burning.
+            density_ratio: Ratio of real to ideal propellant density.
+        """
         self.core_diameter = core_diameter
         self.number_of_ports = int(number_of_ports)
         self.port_inner_diameter = port_inner_diameter
@@ -32,6 +48,7 @@ class WagonWheelGrainSegment(FMMGrainSegment2D):
         )
 
     def validate(self) -> None:
+        """Validate wagon-wheel segment geometry."""
         super().validate()
 
         if not self.number_of_ports > 0:
@@ -72,9 +89,7 @@ class WagonWheelGrainSegment(FMMGrainSegment2D):
             )
 
     def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
-        """
-        NOTE: Still needs to correctly implement wagon wheel ports.
-        """
+        """NOTE: Still needs to correctly implement wagon wheel ports."""
         map_x, map_y = self.get_maps()
         core_map = self.get_empty_face_map()
 

--- a/machwave/models/motors/base.py
+++ b/machwave/models/motors/base.py
@@ -14,10 +14,7 @@ T = TypeVar("T", bound=ThrustChamber)
 
 
 class Motor(Generic[P, T], ABC):
-    """
-    Abstract rocket motor/engine class. Can be used to model any chemical
-    rocket propulsion system, such as Solid, Hybrid and Liquid.
-    """
+    """Abstract rocket motor/engine for solid, hybrid, or liquid systems."""
 
     def __init__(
         self,
@@ -25,72 +22,57 @@ class Motor(Generic[P, T], ABC):
         thrust_chamber: T,
     ) -> None:
         """
-        Instantiates object attributes common to any motor/engine (Solid,
-        Hybrid or Liquid).
+        Initialize attributes common to any motor or engine.
 
         Args:
-            propellant: Object representing the propellant used in the motor.
-            thrust_chamber: Object representing the thrust chamber of the motor.
+            propellant: Propellant used in the motor.
+            thrust_chamber: Thrust chamber of the motor.
         """
         self.propellant = propellant
         self.thrust_chamber = thrust_chamber
 
     @abstractmethod
     def get_launch_mass(self) -> float:
-        """
-        Calculates the total mass of the motor before launch.
-
-        Returns:
-            Total mass of the motor before launch, in kg
-        """
+        """Return the total mass of the motor before launch [kg]."""
         pass
 
     @abstractmethod
     def get_dry_mass(self) -> float:
-        """
-        Calculates the dry mass of the rocket at any time.
-
-        Returns:
-            Dry mass of the rocket, in kg
-        """
+        """Return the dry mass of the motor [kg]."""
         pass
 
     @abstractmethod
     def get_center_of_gravity(self, *args, **kwargs) -> np.typing.NDArray[np.float64]:
         """
-        Calculate the center of gravity of the propulsion system.
+        Return the center of gravity of the propulsion system.
 
         The coordinate system origin corresponds to the combustion chamber axis
         at the nozzle exit plane, with positive x pointing toward the bulkhead.
 
         Returns:
-            A 1D array of shape (3,) representing the [x, y, z] coordinates of
-            the center of gravity, in meters.
+            1D array of shape `(3,)` containing the `[x, y, z]` coordinates of
+            the center of gravity [m].
         """
         pass
 
     @property
     @abstractmethod
     def initial_propellant_mass(self) -> float:
-        """
-        Returns:
-            Initial propellant mass, in kg
-        """
+        """Return the initial propellant mass [kg]."""
         pass
 
     def get_thrust(self, cf: float, chamber_pressure: float) -> float:
         """
-        Calculates the thrust based on instantaneous thrust coefficient and
-        chamber pressure.
+        Return the instantaneous thrust [N].
 
-        Utilized nozzle throat area from the structure and nozzle classes.
+        Uses the nozzle throat area from the thrust chamber.
 
         Args:
-            cf: Instantaneous thrust coefficient, adimensional
-            chamber_pressure: Instantaneous chamber pressure, in Pa
+            cf: Instantaneous thrust coefficient (dimensionless).
+            chamber_pressure: Instantaneous chamber pressure [Pa].
 
         Returns:
-            Instantaneous thrust, in Newtons
+            Instantaneous thrust [N].
         """
         return get_thrust_from_thrust_coefficient(
             cf,

--- a/machwave/models/motors/liquid.py
+++ b/machwave/models/motors/liquid.py
@@ -8,6 +8,8 @@ from .base import Motor
 
 
 class LiquidEngine(Motor[BiliquidPropellant, LiquidEngineThrustChamber]):
+    """Liquid rocket engine with bi-liquid propellant and a feed system."""
+
     def __init__(
         self,
         propellant: BiliquidPropellant,
@@ -21,12 +23,16 @@ class LiquidEngine(Motor[BiliquidPropellant, LiquidEngineThrustChamber]):
 
         Args:
             propellant: Bi-liquid propellant properties (oxidizer + fuel).
-            thrust_chamber: Thrust chamber assembly (nozzle + combustion chamber + injector).
-            feed_system: Propellant feed system (tanks, lines, pumps/pressurization).
-            oxidizer_tank_cog: Axial position of the oxidizer tank center (where propellant CoG is),
-                measured from the nozzle exit, in meters. If None, uses a default estimate.
-            fuel_tank_cog: Axial position of the fuel tank center (where propellant CoG is),
-                measured from the nozzle exit, in meters. If None, uses a default estimate.
+            thrust_chamber: Thrust chamber assembly (nozzle, combustion chamber,
+                injector).
+            feed_system: Propellant feed system (tanks, lines, pumps or
+                pressurization).
+            oxidizer_tank_cog: Axial position of the oxidizer propellant center
+                of gravity, measured from the nozzle exit [m]. If None, uses a
+                default estimate.
+            fuel_tank_cog: Axial position of the fuel propellant center of
+                gravity, measured from the nozzle exit [m]. If None, uses a
+                default estimate.
         """
         super().__init__(propellant, thrust_chamber)
         self.feed_system = feed_system
@@ -35,40 +41,37 @@ class LiquidEngine(Motor[BiliquidPropellant, LiquidEngineThrustChamber]):
 
     @property
     def initial_propellant_mass(self) -> float:
-        """
-        Returns the initial propellant mass in kg.
-        """
+        """Return the initial propellant mass [kg]."""
         return self.feed_system.get_propellant_mass()
 
     def get_launch_mass(self) -> float:
+        """Return the launch mass (dry mass + initial propellant) [kg]."""
         return self.thrust_chamber.dry_mass + self.initial_propellant_mass
 
     def get_dry_mass(self) -> float:
+        """Return the dry mass [kg]."""
         return self.thrust_chamber.dry_mass
 
     def get_center_of_gravity(
         self, propellant_fraction: float = 0.0
     ) -> np.typing.NDArray[np.float64]:
         """
-        Calculate the center of gravity of the liquid engine including structural
-        dry mass, oxidizer, and fuel.
+        Return the engine center of gravity.
 
-        The calculation uses a mass-weighted average of:
-        1. Structural dry mass (thrust chamber, tanks structure, feed lines, etc.)
-        2. Oxidizer mass (from oxidizer tank)
-        3. Fuel mass (from fuel tank)
+        Combines structural dry mass, oxidizer, and fuel via a mass-weighted
+        average. Origin is at the nozzle exit on the chamber axis with
+        positive x pointing forward (toward bulkhead).
 
         Args:
-            propellant_fraction: Fraction of propellant consumed (0.0 = full, 1.0 = empty).
+            propellant_fraction: Fraction of propellant consumed (0.0 = full,
+                1.0 = empty).
 
         Returns:
-            Center of gravity in 3D space [x, y, z], in meters.
-            Origin is at the nozzle exit on the chamber axis.
-            Positive x-direction points forward (toward bulkhead/away from nozzle exit).
+            Center of gravity [x, y, z] [m].
 
         Raises:
-            ValueError: If thrust_chamber.center_of_gravity_coordinate, oxidizer_tank_cog,
-                or fuel_tank_cog is not defined.
+            ValueError: If `thrust_chamber.center_of_gravity_coordinate`,
+                `oxidizer_tank_cog`, or `fuel_tank_cog` is not defined.
         """
         initial_ox_mass = self.feed_system.oxidizer_tank.initial_fluid_mass
         initial_fuel_mass = self.feed_system.fuel_tank.initial_fluid_mass

--- a/machwave/models/motors/liquid.py
+++ b/machwave/models/motors/liquid.py
@@ -67,7 +67,7 @@ class LiquidEngine(Motor[BiliquidPropellant, LiquidEngineThrustChamber]):
                 1.0 = empty).
 
         Returns:
-            Center of gravity [x, y, z] [m].
+            Center of gravity as `(x, y, z)` [m].
 
         Raises:
             ValueError: If `thrust_chamber.center_of_gravity_coordinate`,

--- a/machwave/models/motors/solid.py
+++ b/machwave/models/motors/solid.py
@@ -12,6 +12,8 @@ class SolidMotor(
         propellants.SolidPropellant, thrust_chamber.SolidMotorThrustChamber
     ]
 ):
+    """Solid rocket motor with a propellant grain and thrust chamber."""
+
     def __init__(
         self,
         grain: grain.Grain,
@@ -33,13 +35,13 @@ class SolidMotor(
 
     def get_free_chamber_volume(self, propellant_volume: float) -> float:
         """
-        Calculates the chamber volume without any propellant.
+        Return the chamber volume without any propellant.
 
         Args:
-            propellant_volume: Propellant volume, in m^3
+            propellant_volume: Propellant volume [m^3].
 
         Returns:
-            Free chamber volume, in m^3
+            Free chamber volume [m^3].
         """
         return (
             self.thrust_chamber.combustion_chamber.internal_volume - propellant_volume
@@ -47,41 +49,38 @@ class SolidMotor(
 
     @property
     def initial_propellant_mass(self) -> float:
-        """
-        Returns:
-            Initial propellant mass, in kg
-        """
+        """Return the initial propellant mass [kg]."""
         return self.grain.get_propellant_mass(
             web_distance=0, ideal_density=self.propellant.ideal_density
         )
 
     def get_launch_mass(self) -> float:
+        """Return the launch mass (dry mass + initial propellant) [kg]."""
         return self.thrust_chamber.dry_mass + self.initial_propellant_mass
 
     def get_dry_mass(self) -> float:
+        """Return the dry mass [kg]."""
         return self.thrust_chamber.dry_mass
 
     def get_center_of_gravity(
         self, web_distance: float = 0.0
     ) -> np.typing.NDArray[np.float64]:
         """
-        Calculates the center of gravity of the solid motor including
-        propellant grain (wet mass) and dry mass.
+        Return the solid motor center of gravity.
 
-        The calculation uses a mass-weighted average of:
-        1. Propellant grain CoG;
-        2. Thrust chamber dry mass CoG, considered constant.
+        Combines the propellant grain (wet mass) and the thrust chamber dry
+        mass via a mass-weighted average. Dry mass center of gravity is
+        considered constant.
 
         Args:
-            web_distance: Web distance traveled [m].
-                Defaults to ignition state.
+            web_distance: Web distance traveled [m]. Defaults to ignition state.
 
         Returns:
-            Center of gravity in 3D space (x, y, z) [m].
+            Center of gravity [x, y, z] [m].
 
         Raises:
-            ValueError: If thrust chamber dry mass CoG is not defined or if
-                total mass is less than or equal to zero.
+            ValueError: If the thrust chamber dry mass center of gravity is not
+                defined or if the total mass is not strictly positive.
         """
         grain_cog_port = self.grain.get_center_of_gravity(web_distance=web_distance)
         propellant_mass = self.grain.get_propellant_mass(

--- a/machwave/models/motors/solid.py
+++ b/machwave/models/motors/solid.py
@@ -76,7 +76,7 @@ class SolidMotor(
             web_distance: Web distance traveled [m]. Defaults to ignition state.
 
         Returns:
-            Center of gravity [x, y, z] [m].
+            Center of gravity as `(x, y, z)` [m].
 
         Raises:
             ValueError: If the thrust chamber dry mass center of gravity is not

--- a/machwave/models/propellants/categories/__init__.py
+++ b/machwave/models/propellants/categories/__init__.py
@@ -1,14 +1,12 @@
 """Propellant categories or mixture types."""
 
-from .base import MixtureType, Propellant, PropellantValidationError
+from .base import MixtureType, Propellant
 from .biliquid import BiliquidPropellant
-from .solid import BurnRateOutOfBoundsError, SolidPropellant
+from .solid import SolidPropellant
 
 __all__ = [
     "BiliquidPropellant",
-    "BurnRateOutOfBoundsError",
     "MixtureType",
     "Propellant",
-    "PropellantValidationError",
     "SolidPropellant",
 ]

--- a/machwave/models/propellants/categories/base.py
+++ b/machwave/models/propellants/categories/base.py
@@ -15,6 +15,8 @@ class PropellantValidationError(Exception):
 
     def __init__(self, message: str):
         """
+        Initialize with a description of the validation error.
+
         Args:
             message: Description of the validation error.
         """
@@ -39,7 +41,8 @@ class Propellant(abc.ABC):
         components: list[PropellantComponent] | None = None,
         combustion_efficiency: float = 0.95,
     ):
-        """Initialize propellant.
+        """
+        Initialize propellant.
 
         Args:
             name: Propellant name.
@@ -57,7 +60,8 @@ class Propellant(abc.ABC):
 
     @abc.abstractmethod
     def _validate_components(self):
-        """Validate components meet propellant type requirements.
+        """
+        Validate components meet propellant type requirements.
 
         Raises:
             PropellantValidationError: If validation fails.
@@ -66,7 +70,8 @@ class Propellant(abc.ABC):
 
     @abc.abstractmethod
     def _get_thermochemical_service(self) -> cea_service.RocketCEAService:
-        """Create thermochemical service for this propellant.
+        """
+        Create thermochemical service for this propellant.
 
         Implemented for every subclass of propellant category, based on how the CEA
         object is constructed (from components, from properties, others).
@@ -85,7 +90,8 @@ class Propellant(abc.ABC):
         expansion_ratio: float = 8.0,
         mixture_ratio: float | None = None,
     ) -> ThermochemicalProperties:
-        """Evaluate thermochemical properties at given conditions.
+        """
+        Evaluate thermochemical properties at given conditions.
 
         Args:
             chamber_pressure: Chamber pressure [Pa].

--- a/machwave/models/propellants/categories/biliquid.py
+++ b/machwave/models/propellants/categories/biliquid.py
@@ -20,7 +20,8 @@ class BiliquidPropellant(Propellant):
         properties: ThermochemicalProperties | None = None,
         oxidizer_to_fuel_ratio: float | None = None,
     ):
-        """Initialize biliquid propellant.
+        """
+        Initialize biliquid propellant.
 
         Args:
             name: Propellant name.
@@ -43,7 +44,8 @@ class BiliquidPropellant(Propellant):
         self.fuel_tank_density: float = 0.0
 
     def _validate_components(self):
-        """Validate biliquid has exactly 2 components: oxidizer and fuel.
+        """
+        Validate biliquid has exactly 2 components: oxidizer and fuel.
 
         Raises:
             PropellantValidationError: If validation fails.
@@ -75,7 +77,8 @@ class BiliquidPropellant(Propellant):
         )
 
     def _get_thermochemical_service(self):
-        """Create RocketCEA service for biliquid propellant.
+        """
+        Create RocketCEA service for biliquid propellant.
 
         Returns:
             RocketCEAService instance.

--- a/machwave/models/propellants/categories/solid.py
+++ b/machwave/models/propellants/categories/solid.py
@@ -18,6 +18,8 @@ class BurnRateOutOfBoundsError(Exception):
 
     def __init__(self, chamber_pressure: float):
         """
+        Build the error from the offending chamber pressure.
+
         Args:
             chamber_pressure: Chamber pressure that is out of bounds [Pa].
         """
@@ -41,16 +43,18 @@ class SolidPropellant(Propellant):
         properties: ThermochemicalProperties | None = None,
         burn_rate_map: list[dict[str, float | int]] | None = None,
     ):
-        """Initialize solid propellant. If components are not provided,
-        properties must be defined and vice-versa.
+        """
+        Initialize a solid propellant.
+
+        Either `components` or `properties` must be provided.
 
         Args:
             name: Propellant name.
             components: Chemical components (optional).
             mass_fractions: Mass fractions for each component (optional).
-            combustion_efficiency: Efficiency factor (0-1).
+            combustion_efficiency: Efficiency factor in [0, 1].
             properties: Pre-defined thermochemical properties (optional).
-            burn_rate_map: St. Robert's law coefficients by pressure range.
+            burn_rate_map: Saint Robert's law coefficients by pressure range.
         """
         super().__init__(
             name=name,
@@ -67,7 +71,8 @@ class SolidPropellant(Propellant):
         return self._properties
 
     def _validate_components(self):
-        """Validate solid propellant has oxidizer and fuel.
+        """
+        Validate that the solid propellant has both an oxidizer and a fuel.
 
         Raises:
             PropellantValidationError: If validation fails.
@@ -116,7 +121,8 @@ class SolidPropellant(Propellant):
             )
 
     def _get_thermochemical_service(self):
-        """Create RocketCEA service from components.
+        """
+        Create a RocketCEA service from this propellant's components.
 
         Returns:
             RocketCEAService instance.
@@ -144,17 +150,17 @@ class SolidPropellant(Propellant):
         expansion_ratio: float = 8.0,
         mixture_ratio: float | None = None,
     ) -> ThermochemicalProperties:
-        """Evaluate thermochemical properties.
+        """
+        Evaluate thermochemical properties.
 
-        If properties are pre-defined, returns them directly.
-        Otherwise, evaluates using the thermochemical service via parent
-        class.
+        If properties are pre-defined, returns them directly. Otherwise,
+        evaluates using the thermochemical service via the parent class.
 
         Args:
             chamber_pressure: Chamber pressure [Pa].
             expansion_ratio: Nozzle area expansion ratio (Ae/At).
-            mixture_ratio: Per-call mixture ratio override (unused for solid
-                formulations; accepted for parent-class compatibility).
+            mixture_ratio: Per-call mixture ratio override. Unused for solid
+                formulations; accepted for parent-class compatibility.
 
         Returns:
             Pre-defined or calculated properties.
@@ -168,9 +174,10 @@ class SolidPropellant(Propellant):
 
     @property
     def ideal_density(self) -> float:
-        """Calculate ideal propellant density [kg/m^3] for solid mixtures.
+        """
+        Return the ideal propellant density [kg/m^3] for solid mixtures.
 
-        Uses harmonic mean based on solid mixture mass fractions.
+        Uses a harmonic mean based on solid mixture mass fractions.
         """
         self._validate_components()
         reciprocal_sum = sum(
@@ -179,10 +186,12 @@ class SolidPropellant(Propellant):
         return 1.0 / reciprocal_sum
 
     def get_burn_rate(self, chamber_pressure: float) -> float:
-        """Calculate instantaneous burn rate for solid propellants.
+        """
+        Return the instantaneous burn rate of the solid propellant.
 
-        Uses St. Robert's law: r = a * P^n, where r is burn rate [m/s],
-        P is chamber pressure [MPa], and a, n are empirical coefficients.
+        Uses Saint Robert's law `r = a * P^n`, where `r` is burn rate [m/s],
+        `P` is chamber pressure [MPa], and `a`, `n` are empirical coefficients
+        drawn from `burn_rate_map`.
 
         Args:
             chamber_pressure: Chamber pressure [Pa].
@@ -191,8 +200,8 @@ class SolidPropellant(Propellant):
             Burn rate [m/s].
 
         Raises:
-            BurnRateOutOfBoundsError: If pressure is outside valid range.
-            ValueError: If burn_rate model is not defined.
+            BurnRateOutOfBoundsError: If pressure is outside the valid range.
+            PropellantValidationError: If the burn rate model is not defined.
         """
         if not self.burn_rate_map:
             raise PropellantValidationError(

--- a/machwave/models/propellants/components.py
+++ b/machwave/models/propellants/components.py
@@ -1,6 +1,7 @@
 """
-This module contains classes representing the chemical components of a propellant
-formulation, including their roles and properties.
+Chemical components of a propellant formulation.
+
+Provides classes representing the role and properties of each component.
 """
 
 import dataclasses
@@ -22,12 +23,13 @@ class ComponentRole(enum.StrEnum):
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class PropellantComponent:
-    """Chemical component of a propellant formulation.
+    """
+    Chemical component of a propellant formulation.
 
     Attributes:
         name: Component name (i.e., "KNO3", "LOX", "HTPB").
         role: Component role (oxidizer, fuel, additive).
-        density: Component density [kg/m³].
+        density: Component density [kg/m^3].
         chemical_formula: Element symbols to atom counts (i.e., {"H": 2, "O": 1}).
         enthalpy: Standard enthalpy of formation [J/mol].
         initial_temperature: Initial component temperature before combustion [K].
@@ -41,7 +43,8 @@ class PropellantComponent:
     initial_temperature: float = 298.15
 
     def to_cea_dict(self, *, weight_percent: float) -> dict:
-        """Convert component to CEA-compatible dictionary format.
+        """
+        Convert component to CEA-compatible dictionary format.
 
         Args:
             weight_percent: Component weight percent in the mixture [%].

--- a/machwave/models/propellants/formulations/base.py
+++ b/machwave/models/propellants/formulations/base.py
@@ -9,7 +9,8 @@ from .. import properties as propellant_properties
 
 
 def _parse_mixture_type(data: dict) -> propellant_categories.MixtureType:
-    """Parse and validate mixture_type from JSON data.
+    """
+    Parse and validate mixture_type from JSON data.
 
     Args:
         data: JSON data dictionary.
@@ -34,7 +35,8 @@ def _parse_mixture_type(data: dict) -> propellant_categories.MixtureType:
 
 
 def _parse_component(comp_data: dict) -> propellant_components.PropellantComponent:
-    """Parse single component from JSON data.
+    """
+    Parse single component from JSON data.
 
     Args:
         comp_data: Component dictionary from JSON.
@@ -68,19 +70,20 @@ def _parse_component(comp_data: dict) -> propellant_components.PropellantCompone
 def _parse_components(
     data: dict, *, mixture_type: propellant_categories.MixtureType
 ) -> tuple[list[propellant_components.PropellantComponent], list[float] | None]:
-    """Parse all components from JSON data.
+    """
+    Parse all components from JSON data.
 
     Args:
         data: JSON data dictionary.
+        mixture_type: Propellant mixture type.
 
     Returns:
-        (components, mass_fractions)
-
-        - For SOLID: mass_fractions is a list[float] aligned with components.
-        - For BILIQUID: mass_fractions is None (O/F defines mixture).
+        Tuple `(components, mass_fractions)`. For `SOLID`, `mass_fractions`
+        is a list aligned with `components`. For `BILIQUID`, `mass_fractions`
+        is None (O/F ratio defines the mixture).
 
     Raises:
-        ValueError: If component data invalid.
+        ValueError: If component data is invalid.
     """
     components_data = data.get("components", [])
     components = [_parse_component(comp_data) for comp_data in components_data]
@@ -97,7 +100,8 @@ def _parse_components(
 def _parse_properties(
     data: dict,
 ) -> propellant_properties.ThermochemicalProperties | None:
-    """Parse thermochemical properties from JSON data.
+    """
+    Parse thermochemical properties from JSON data.
 
     Args:
         data: JSON data dictionary.
@@ -132,19 +136,21 @@ def _create_propellant(
     mass_fractions: list[float] | None,
     properties: propellant_properties.ThermochemicalProperties | None,
 ) -> propellant_categories.SolidPropellant | propellant_categories.BiliquidPropellant:
-    """Create propellant instance based on mixture type.
+    """
+    Create propellant instance based on mixture type.
 
     Args:
         mixture_type: Type of propellant mixture.
         data: JSON data dictionary.
         components: Parsed components.
+        mass_fractions: Parsed mass fractions for solid mixtures, or None.
         properties: Parsed properties or None.
 
     Returns:
-        SolidPropellant or BiliquidPropellant instance.
+        `SolidPropellant` or `BiliquidPropellant` instance.
 
     Raises:
-        ValueError: If mixture_type unsupported.
+        ValueError: If `mixture_type` is unsupported.
     """
     if mixture_type == propellant_categories.MixtureType.SOLID:
         return propellant_categories.SolidPropellant(
@@ -170,7 +176,8 @@ def _create_propellant(
 def get_propellant_from_json(
     filepath: str | Path,
 ) -> propellant_categories.SolidPropellant | propellant_categories.BiliquidPropellant:
-    """Load propellant formulation from JSON file.
+    """
+    Load propellant formulation from JSON file.
 
     Args:
         filepath: Path to JSON file.

--- a/machwave/models/propellants/properties.py
+++ b/machwave/models/propellants/properties.py
@@ -23,8 +23,8 @@ VALIDATION_BOUNDS: dict[str, tuple[float, float]] = {
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class ThermochemicalProperties:
-    """Thermochemical properties for the combustion products of chemical rocket
-    propellants.
+    """
+    Thermochemical properties of chemical-rocket combustion products.
 
     Attributes:
         k_chamber: Isentropic exponent in chamber.
@@ -82,7 +82,8 @@ class ThermochemicalProperties:
 
     @functools.cached_property
     def is_two_phase_flow(self) -> bool:
-        """Check if combustion products have condensed phase species.
+        """
+        Check if combustion products have condensed phase species.
 
         Returns:
             True if qsi_chamber > 0 or qsi_exhaust > 0.

--- a/machwave/models/thrust_chamber/base.py
+++ b/machwave/models/thrust_chamber/base.py
@@ -10,10 +10,7 @@ from machwave.models.thrust_chamber.nozzle import Nozzle
 
 
 class ThrustChamber(abc.ABC):
-    """
-    Represents the thrust chamber assembly of a liquid rocket engine.
-    ThrustChamber acts as a coordinating layer that ties these elements together.
-    """
+    """Thrust chamber assembly that ties nozzle, chamber, and injectors together."""
 
     def __init__(
         self,
@@ -23,19 +20,16 @@ class ThrustChamber(abc.ABC):
         center_of_gravity_coordinate: tuple[float, float, float] | None = None,
     ):
         """
-        Initialize the ThrustChamber.
+        Initialize a thrust chamber.
 
         Args:
-            nozzle:
-                An instance of a Nozzle class.
-            combustion_chamber:
-                An instance of a CombustionChamber class.
-            dry_mass:
-                The dry mass of the thrust chamber assembly in kg.
-            center_of_gravity_coordinate:
-                3D position (x, y, z) of the dry mass (hardware) center of gravity,
-                measured from the nozzle exit, in meters. Positive x values point toward
-                the bulkhead. If None, will be estimated from chamber geometry.
+            nozzle: Nozzle instance.
+            combustion_chamber: Combustion chamber instance.
+            dry_mass: Dry mass of the thrust chamber assembly [kg].
+            center_of_gravity_coordinate: Dry-mass center of gravity position
+                `(x, y, z)` [m], measured from the nozzle exit. Positive x
+                points toward the bulkhead. If None, estimated from chamber
+                geometry.
         """
         self.nozzle = nozzle
         self.combustion_chamber = combustion_chamber
@@ -48,6 +42,8 @@ class ThrustChamber(abc.ABC):
 
 
 class SolidMotorThrustChamber(ThrustChamber):
+    """Thrust chamber assembly specialized for solid rocket motors."""
+
     def __init__(
         self,
         nozzle: Nozzle,
@@ -57,21 +53,18 @@ class SolidMotorThrustChamber(ThrustChamber):
         center_of_gravity_coordinate: tuple[float, float, float] | None = None,
     ):
         """
-        Initialize the SolidMotorThrustChamber.
+        Initialize a solid motor thrust chamber.
 
         Args:
-            nozzle:
-                An instance of a Nozzle class.
-            combustion_chamber:
-                An instance of a CombustionChamber class.
-            dry_mass:
-                The dry mass of the thrust chamber assembly in kg.
-            nozzle_exit_to_grain_port_distance:
-                Axial distance from nozzle exit plane to the grain port [m].
-            center_of_gravity_coordinate:
-                3D position (x, y, z) of the dry mass (hardware) center of gravity,
-                measured from the nozzle exit, in meters. Positive x values point toward
-                the bulkhead. If None, will be estimated from chamber geometry.
+            nozzle: Nozzle instance.
+            combustion_chamber: Combustion chamber instance.
+            dry_mass: Dry mass of the thrust chamber assembly [kg].
+            nozzle_exit_to_grain_port_distance: Axial distance from the nozzle
+                exit plane to the grain port [m].
+            center_of_gravity_coordinate: Dry-mass center of gravity position
+                `(x, y, z)` [m], measured from the nozzle exit. Positive x
+                points toward the bulkhead. If None, estimated from chamber
+                geometry.
         """
         super().__init__(
             nozzle, combustion_chamber, dry_mass, center_of_gravity_coordinate
@@ -80,10 +73,7 @@ class SolidMotorThrustChamber(ThrustChamber):
 
 
 class LiquidEngineThrustChamber(ThrustChamber):
-    """
-    Represents the thrust chamber assembly of a liquid rocket engine.
-    This class is a specialization of the ThrustChamber class for liquid rocket engines.
-    """
+    """Thrust chamber assembly specialized for liquid rocket engines."""
 
     def __init__(
         self,
@@ -94,21 +84,17 @@ class LiquidEngineThrustChamber(ThrustChamber):
         center_of_gravity_coordinate: tuple[float, float, float] | None = None,
     ):
         """
-        Initialize the LiquidEngineThrustChamber.
+        Initialize a liquid engine thrust chamber.
 
         Args:
-            nozzle:
-                An instance of a Nozzle class.
-            injector:
-                An instance of an Injector class.
-            combustion_chamber:
-                An instance of a CombustionChamber class.
-            dry_mass:
-                The dry mass of the thrust chamber assembly in kg.
-            center_of_gravity_coordinate:
-                3D position (x, y, z) of the dry mass (hardware) center of gravity,
-                measured from the nozzle exit, in meters. Positive x values point toward
-                the bulkhead. If None, will be estimated from chamber geometry.
+            nozzle: Nozzle instance.
+            injector: Bipropellant injector instance.
+            combustion_chamber: Combustion chamber instance.
+            dry_mass: Dry mass of the thrust chamber assembly [kg].
+            center_of_gravity_coordinate: Dry-mass center of gravity position
+                `(x, y, z)` [m], measured from the nozzle exit. Positive x
+                points toward the bulkhead. If None, estimated from chamber
+                geometry.
         """
         super().__init__(
             nozzle, combustion_chamber, dry_mass, center_of_gravity_coordinate

--- a/machwave/models/thrust_chamber/combustion_chamber.py
+++ b/machwave/models/thrust_chamber/combustion_chamber.py
@@ -11,7 +11,8 @@ class CombustionChamber:
         internal_length: float,
         thermal_liner_thickness: float = 0.0,
     ) -> None:
-        """Create a new CombustionChamber instance.
+        """
+        Create a new CombustionChamber instance.
 
         Args:
             casing_inner_diameter: Internal diameter [m].

--- a/machwave/models/thrust_chamber/injector.py
+++ b/machwave/models/thrust_chamber/injector.py
@@ -1,7 +1,5 @@
 class BipropellantInjector:
-    """
-    A simple injector class for a liquid rocket engine.
-    """
+    """A simple injector class for a liquid rocket engine."""
 
     def __init__(
         self,

--- a/machwave/models/thrust_chamber/nozzle.py
+++ b/machwave/models/thrust_chamber/nozzle.py
@@ -4,6 +4,8 @@ from machwave.core.geometric import get_circle_area
 
 
 class Nozzle:
+    """Converging-diverging nozzle geometry and loss coefficients."""
+
     def __init__(
         self,
         inlet_diameter,
@@ -15,24 +17,42 @@ class Nozzle:
         c_2: float = 0.0,
         discharge_coefficient: float = 1.0,
     ) -> None:
+        """
+        Initialize a nozzle.
+
+        Args:
+            inlet_diameter: Inlet diameter [m].
+            throat_diameter: Throat diameter [m].
+            divergent_angle: Divergent half-angle [deg].
+            convergent_angle: Convergent half-angle [deg].
+            expansion_ratio: Area ratio of exit to throat.
+            c_1: Boundary-layer loss coefficient (see notes below).
+            c_2: Boundary-layer loss coefficient (see notes below).
+            discharge_coefficient: Throat discharge coefficient.
+
+        Notes:
+            Boundary-layer loss correction coefficients (ref. a015140) are used
+            in the boundary-layer percentage loss calculation to account for
+            viscous and heat-transfer effects on the nozzle walls. Typical
+            values:
+
+            - Ordinary nozzle: `c_1 = 0.003650`, `c_2 = 0.000937`.
+            - Thick-walled solid steel nozzle: `c_1 = 0.005060`, `c_2 = 0.0`.
+        """
         self.inlet_diameter = inlet_diameter
         self.throat_diameter = throat_diameter
         self.divergent_angle = divergent_angle
         self.convergent_angle = convergent_angle
         self.expansion_ratio = expansion_ratio
-
-        # Boundary layer loss correction coefficients (ref. a015140).
-        # Used in the boundary layer percentage loss calculation to account
-        # for viscous and heat transfer effects in the nozzle walls.
-        # Ordinary nozzle:                 c_1 = 0.003650, c_2 = 0.000937
-        # Thick-walled solid steel nozzle: c_1 = 0.005060, c_2 = 0.000000
         self.c_1 = c_1
         self.c_2 = c_2
         self.discharge_coefficient = discharge_coefficient
 
     @property
     def outlet_diameter(self):
+        """Return the nozzle exit diameter [m]."""
         return self.throat_diameter * np.sqrt(self.expansion_ratio)
 
     def get_throat_area(self):
+        """Return the nozzle throat area [m^2]."""
         return get_circle_area(self.throat_diameter)

--- a/machwave/models/thrust_chamber/nozzle.py
+++ b/machwave/models/thrust_chamber/nozzle.py
@@ -8,11 +8,11 @@ class Nozzle:
 
     def __init__(
         self,
-        inlet_diameter,
-        throat_diameter,
-        divergent_angle,
-        convergent_angle,
-        expansion_ratio,
+        inlet_diameter: float,
+        throat_diameter: float,
+        divergent_angle: float,
+        convergent_angle: float,
+        expansion_ratio: float,
         c_1: float = 0.00506,
         c_2: float = 0.0,
         discharge_coefficient: float = 1.0,
@@ -49,10 +49,10 @@ class Nozzle:
         self.discharge_coefficient = discharge_coefficient
 
     @property
-    def outlet_diameter(self):
+    def outlet_diameter(self) -> float:
         """Return the nozzle exit diameter [m]."""
         return self.throat_diameter * np.sqrt(self.expansion_ratio)
 
-    def get_throat_area(self):
+    def get_throat_area(self) -> float:
         """Return the nozzle throat area [m^2]."""
         return get_circle_area(self.throat_diameter)

--- a/machwave/montecarlo/base.py
+++ b/machwave/montecarlo/base.py
@@ -16,10 +16,13 @@ SEARCH_TREE_DEPTH_LIMIT = 20
 
 @dataclass(init=False, slots=True)
 class MonteCarloParameter(float):
+    """Float value annotated with a distribution and spread for sampling."""
+
     _spread: float | tuple[float, float]
     _distribution: str
 
     def __new__(cls, value: float, *, spread=0.0, distribution="normal"):
+        """Construct a parameter with a center value, spread, and distribution."""
         obj = float.__new__(cls, value)
         obj._spread = spread
         obj._distribution = distribution
@@ -27,14 +30,17 @@ class MonteCarloParameter(float):
 
     @property
     def random_generator(self) -> random.RandomGenerator:
+        """Return a generator that samples from this parameter's distribution."""
         return random.get_random_generator(
             self._distribution, float(self), self._spread
         )
 
     def get_random_value(self) -> float:
+        """Sample a single random value from this parameter's distribution."""
         return self.random_generator.get_value()
 
     def __repr__(self) -> str:
+        """Return a debugging representation of the parameter."""
         return (
             f"MonteCarloParameter({float(self):.6g}, spread={self._spread}, "
             f"dist='{self._distribution}')"
@@ -43,10 +49,10 @@ class MonteCarloParameter(float):
 
 class MonteCarloSimulation:
     """
-    The MonteCarloSimulation class:
-    - Stores data for a Monte Carlo simulation
-    - Executes the simulation
-    - Delegates plotting to `plot_service.py`
+    Monte Carlo driver that runs scenarios and stores their results.
+
+    Stores parameters and simulation type, executes the configured number of
+    scenarios, and delegates plotting to `plot_service.py`.
     """
 
     def __init__(
@@ -56,11 +62,11 @@ class MonteCarloSimulation:
         simulation: type[InternalBallisticsSimulation],
     ) -> None:
         """
-        Initializes a MonteCarloSimulation object.
+        Initialize a Monte Carlo driver.
 
         Args:
-            parameters: list with the input parameters for a simulation class.
-            number_of_scenarios: Number of scenarios to be simulated.
+            parameters: Input parameters for a simulation class.
+            number_of_scenarios: Number of scenarios to simulate.
             simulation: Simulation class reference.
         """
         self.parameters = parameters
@@ -73,9 +79,7 @@ class MonteCarloSimulation:
         self._object_store = dict()  # for nested parameter processing
 
     def generate_scenario(self) -> list[typing.Any]:
-        """
-        Generates a Monte Carlo scenario in the form of a list of parameters.
-        """
+        """Generates a Monte Carlo scenario in the form of a list of parameters."""
         new_scenario = []
         parameters_copy = deepcopy(self.parameters)
 
@@ -92,12 +96,13 @@ class MonteCarloSimulation:
 
     def _process_nested_parameters(self, parameter: typing.Any) -> None:
         """
-        Recursively processes an object's attributes to replace
-        MonteCarloParameter instances with randomized values and store objects
-        using UUIDs.
+        Replace nested `MonteCarloParameter` instances with randomized values.
+
+        Recursively walks the object's attributes; replacements are performed
+        in place and intermediate objects are tracked using UUIDs.
 
         Args:
-            parameter: The object whose attributes will be processed.
+            parameter: Object whose attributes will be processed.
         """
         parameter_uuid = uuid.uuid4()
         self._object_store[parameter_uuid] = parameter
@@ -128,33 +133,39 @@ class MonteCarloSimulation:
             search_tree = new_search_tree
 
     def run(self) -> None:
-        """
-        Executes `number_of_scenarios` runs of the underlying Simulation.
-        """
+        """Executes `number_of_scenarios` runs of the underlying Simulation."""
         self.results = []
         for _ in range(self.number_of_scenarios):
             scenario = self.generate_scenario()
             self.results.append(self.simulation(*scenario).run())
 
     def retrieve_values_from_result(self, property_name: str) -> np.ndarray:
-        """Retrieve a scalar property across every Monte Carlo result.
+        """
+        Retrieve a scalar property across every Monte Carlo result.
 
         Args:
-            property_name: Attribute name on the ``SimulationResult``.
+            property_name: Attribute name on the `SimulationResult`.
 
         Returns:
-            Array of length ``number_of_scenarios``.
+            Array of length `number_of_scenarios`.
         """
         return np.array(
             [getattr(sim_result, property_name) for sim_result in self.results]
         )
 
     def get_property_stats(self, property_name: str) -> dict[str, float]:
-        """Descriptive statistics for a scalar property across all results.
+        """
+        Return descriptive statistics for a scalar property across results.
 
         Metrics returned: mean, median, variance, std_dev, mode, skew (Fisher,
         unbiased), kurtosis (excess, unbiased), p5 (5th percentile), p95 (95th
         percentile).
+
+        Args:
+            property_name: Attribute name on the `SimulationResult`.
+
+        Returns:
+            Mapping of metric name to value.
         """
         values = np.asarray(self.retrieve_values_from_result(property_name))
 
@@ -186,6 +197,7 @@ class MonteCarloSimulation:
         x_axes_title: str = "x",
         **plotly_kwargs,
     ) -> None:
+        """Plot a histogram of a scalar property across all results."""
         plot_service.plot_histogram(
             self.results, property_name, x_axes_title, **plotly_kwargs
         )
@@ -198,6 +210,7 @@ class MonteCarloSimulation:
         kde_points: int = 200,
         **plotly_kwargs,
     ) -> None:
+        """Plot a histogram of a scalar property with a KDE overlay."""
         plot_service.plot_histogram_with_kde(
             self.results,
             property_name,
@@ -213,6 +226,7 @@ class MonteCarloSimulation:
         x_axes_title: str = "x",
         **plotly_kwargs,
     ) -> None:
+        """Plot the empirical CDF of a scalar property across all results."""
         plot_service.plot_cdf(
             self.results, property_name, x_axes_title, **plotly_kwargs
         )
@@ -225,6 +239,7 @@ class MonteCarloSimulation:
         title: str | None = None,
         **plotly_kwargs,
     ) -> None:
+        """Plot min and max envelopes of a time series across all results."""
         plot_service.plot_time_series_extremes(
             self.results,
             time_property,

--- a/machwave/montecarlo/random.py
+++ b/machwave/montecarlo/random.py
@@ -8,7 +8,8 @@ import numpy as np
 
 @dataclass(slots=True, frozen=True)
 class RandomGenerator(ABC):
-    """Abstract class for a random number generator.
+    """
+    Abstract class for a random number generator.
 
     Attributes:
         value: Nominal or mean value of the parameter.
@@ -23,9 +24,7 @@ class RandomGenerator(ABC):
     spread: float | tuple[float, float] = 0.0
 
     def __post_init__(self) -> None:
-        """
-        Ensures non-negative spread values and valid inputs.
-        """
+        """Ensures non-negative spread values and valid inputs."""
         if isinstance(self.spread, tuple):
             if len(self.spread) != 2 or self.spread[0] < 0 or self.spread[1] < 0:
                 raise ValueError("Spread must be a tuple of two non-negative values.")
@@ -73,13 +72,11 @@ class NormalRandomGenerator(RandomGenerator):
 
     def get_value(self) -> float:
         """
-        In numpy.random, "scale" determines the standard deviation of the
-        normal distribution. In this case, the spread is defined as 3 times
-        the standard deviation, so that ~99.7% of the generated values are
-        within spread.
+        Return a sample from the normal distribution.
 
-        Returns:
-            Random value based on a normal probability distribution.
+        In `numpy.random`, `scale` is the standard deviation. Here the spread
+        is defined as 3 times the standard deviation, so ~99.7% of generated
+        values lie within `value +/- spread`.
         """
         return np.random.normal(
             loc=self.value,
@@ -126,7 +123,8 @@ _GENERATOR_REGISTRY: dict[str, FactoryFn] = {
 
 
 def register_random_generator(name: str, ctor: FactoryFn) -> None:
-    """Add a new random generator to the registry at runtime.
+    """
+    Add a new random generator to the registry at runtime.
 
     Args:
         name: Name of the generator (case-insensitive).
@@ -146,7 +144,8 @@ def get_random_generator(
     *args,
     **kwargs,
 ) -> RandomGenerator:
-    """Return a random number generator based on probability distribution.
+    """
+    Return a random number generator based on probability distribution.
 
     Args:
         probability_distribution: Name of the probability distribution

--- a/machwave/services/cea.py
+++ b/machwave/services/cea.py
@@ -1,7 +1,4 @@
-"""This module defines a service for thermochemical calculations, RocketCEAService.
-It uses that uses the rocketcea package to perform Chemical Equilibrium calculations
-for solid propellants, based on the widely accepted NASA's CEA code.
-"""
+"""Thermochemical service wrapper around `rocketcea` (NASA CEA)."""
 
 import re
 from uuid import uuid4
@@ -21,15 +18,17 @@ from machwave.core.conversions import (
 
 
 def normalize_custom_propellant_name(name: str) -> str:
-    """Normalize a *custom* propellant name for RocketCEA registration.
+    """
+    Normalize a custom propellant name for RocketCEA registration.
 
-    RocketCEA internally sanitizes propellant identifiers; if we register a
-    propellant with a name containing characters like '-' or '(', the lookup can
-    fail later if RocketCEA normalizes it differently.
+    RocketCEA internally sanitizes propellant identifiers; registering a name
+    containing characters like `-` or `(` can cause lookups to fail later if
+    RocketCEA normalizes it differently.
 
     Notes:
-        This should be used for custom propellant registration (propName), not for
-        built-in oxidizer/fuel names (oxName/fuelName), which can be case-sensitive.
+        Use this for custom propellant registration (`propName`), not for
+        built-in oxidizer/fuel names (`oxName`/`fuelName`), which can be
+        case-sensitive.
     """
     normalized = name.strip().upper()
     normalized = re.sub(r"\s+", "_", normalized)
@@ -72,27 +71,27 @@ def create_cea_service(
     fuel_card_string: str | None = None,
     oxidizer_to_fuel_ratio: float | None = None,
 ) -> "RocketCEAService":
-    """Factory function to create RocketCEAService with propellant registration.
+    """
+    Create a `RocketCEAService` and register propellants if needed.
 
-    This function handles all the complexity of registering custom
-    propellants/oxidizers/fuels with RocketCEA and returns a simple service wrapper.
+    Handles registering custom propellants, oxidizers, and fuels with RocketCEA
+    and returns a thin service wrapper. Supported configurations:
 
-    Configuration modes:
-    1. Solid/monopropellant: propellant_name (+ optional card_string)
-    2. Biliquid: oxidizer_name + fuel_name (+ optional card strings)
-    3. Custom biliquid: Custom oxidizer/fuel via card strings
+    1. Solid or monopropellant: `propellant_name` (plus optional `card_string`).
+    2. Biliquid: `oxidizer_name` and `fuel_name` (plus optional card strings).
+    3. Custom biliquid: custom oxidizer/fuel via card strings.
 
     Args:
-        propellant_name: Name of solid/monoliquid propellant.
-        card_string: CEA card string for custom solid/monopropellant.
-        oxidizer_name: Oxidizer name for biliquid propellant.
-        oxidizer_card_string: CEA card string for custom oxidizer.
-        fuel_name: Fuel name for biliquid propellant.
-        fuel_card_string: CEA card string for custom fuel.
-        oxidizer_to_fuel_ratio: O/F ratio for biliquid propellant.
+        propellant_name: Solid or monoliquid propellant name.
+        card_string: CEA card string for a custom solid/monopropellant.
+        oxidizer_name: Oxidizer name for a biliquid propellant.
+        oxidizer_card_string: CEA card string for a custom oxidizer.
+        fuel_name: Fuel name for a biliquid propellant.
+        fuel_card_string: CEA card string for a custom fuel.
+        oxidizer_to_fuel_ratio: O/F ratio for a biliquid propellant.
 
     Returns:
-        Configured RocketCEAService instance.
+        Configured `RocketCEAService` instance.
 
     Raises:
         ValueError: If configuration is invalid or registration/creation fails.
@@ -157,18 +156,20 @@ def create_cea_service(
 
 
 class RocketCEAService:
-    """Thin wrapper around RocketCEA CEA_Obj for thermochemical queries.
+    """
+    Thin wrapper around RocketCEA `CEA_Obj` for thermochemical queries.
 
-    This class provides a clean interface for fetching thermochemical properties.
-    Use create_cea_service() factory function to instantiate with custom propellants.
+    Use `create_cea_service()` to instantiate with custom propellants.
     """
 
     def __init__(self, cea_obj: CEA_Obj, oxidizer_to_fuel_ratio: float | None = None):
-        """Initialize service with CEA object.
+        """
+        Initialize the service from a configured `CEA_Obj`.
 
         Args:
-            cea_obj: RocketCEA CEA_Obj instance.
-            oxidizer_to_fuel_ratio: O/F ratio for biliquid propellants (optional).
+            cea_obj: RocketCEA `CEA_Obj` instance.
+            oxidizer_to_fuel_ratio: O/F ratio for biliquid propellants
+                (optional).
         """
         self.cea_obj = cea_obj
         self.oxidizer_to_fuel_ratio = oxidizer_to_fuel_ratio
@@ -326,7 +327,7 @@ class RocketCEAService:
         return qsi_chamber, qsi_exhaust
 
     def get_tank_densities(self) -> tuple[float, float]:
-        """Get tank densities [kg/m³]: (oxidizer, fuel)."""
+        """Get tank densities [kg/m^3]: (oxidizer, fuel)."""
         densities_lb_per_ft3 = self.cea_obj.get_Densities()
         return (
             convert_lbft3_to_kgm3(densities_lb_per_ft3[0]),

--- a/machwave/services/plots/ballistics.py
+++ b/machwave/services/plots/ballistics.py
@@ -6,7 +6,8 @@ import plotly.subplots
 def ballistics_plots(
     t: np.ndarray, a: np.ndarray, v: np.ndarray, y: np.ndarray
 ) -> go.Figure:
-    """Create interactive plots for height, velocity, and acceleration.
+    """
+    Create interactive plots for height, velocity, and acceleration.
 
     Args:
         t: Time array.
@@ -44,7 +45,7 @@ def ballistics_plots(
     fig.update_xaxes(title_text="Time (s)", row=3, col=1)
     fig.update_yaxes(title_text="Height (m)", row=1, col=1)
     fig.update_yaxes(title_text="Velocity (m/s)", row=2, col=1)
-    fig.update_yaxes(title_text="Acceleration (m/s²)", row=3, col=1)
+    fig.update_yaxes(title_text="Acceleration (m/s^2)", row=3, col=1)
 
     fig.update_layout(title="Ballistics Plots", height=900)
 

--- a/machwave/services/plots/fmm/face_map.py
+++ b/machwave/services/plots/fmm/face_map.py
@@ -8,7 +8,8 @@ from machwave.common.arrays import replace_array_values
 def _create_plot_2d_frame(
     face_map: np.ndarray,
 ) -> tuple[go.Heatmap, go.Contour, go.Contour]:
-    """Create a 2D frame with a heatmap and contour lines of a segment face.
+    """
+    Create a 2D frame with a heatmap and contour lines of a segment face.
 
     Args:
         face_map: 2D NumPy array representing the face map.
@@ -66,7 +67,8 @@ def _create_plot_2d_frame(
 def plot_2d_face_map(
     face_map: np.ndarray,
 ) -> go.Figure:
-    """Plot a 2D face map with a heatmap and contour lines.
+    """
+    Plot a 2D face map with a heatmap and contour lines.
 
     Args:
         face_map: 2D NumPy array representing the face map.
@@ -225,7 +227,8 @@ def plot_3d_face_map_animated(
     face_maps: np.ndarray,
     web_distances: np.typing.NDArray[np.float64],
 ) -> go.Figure:
-    """Plot an animated 3D face map with longitudinal and axial views.
+    """
+    Plot an animated 3D face map with longitudinal and axial views.
 
     Displays two side-by-side subplots animated over web distance:
 

--- a/machwave/services/plots/internal_ballistics.py
+++ b/machwave/services/plots/internal_ballistics.py
@@ -6,7 +6,8 @@ import plotly.subplots
 def thrust_pressure_plot(
     time: np.ndarray, thrust: np.ndarray, chamber_pressure: np.ndarray
 ) -> go.Figure:
-    """Generate an interactive plot with thrust and chamber pressure.
+    """
+    Generate an interactive plot with thrust and chamber pressure.
 
     Args:
         time: Time array.
@@ -56,7 +57,8 @@ def thrust_pressure_plot(
 
 
 def mass_flux_plot(time: np.ndarray, mass_flux: np.ndarray) -> go.Figure:
-    """Generate an interactive plot for mass flux across multiple segments.
+    """
+    Generate an interactive plot for mass flux across multiple segments.
 
     Args:
         time: Time array.
@@ -90,9 +92,10 @@ def plot_bipropellant_tank_profiles(
     fuel_tank_mass: np.ndarray,
 ) -> go.Figure:
     """
-    Generates an interactive double chart:
-      - Left subplot: oxidizer & fuel tank pressures (in MPa) vs time
-      - Right subplot: oxidizer & fuel tank masses (in kg) vs time
+    Generate an interactive two-panel chart of tank pressures and masses.
+
+    Left subplot: oxidizer and fuel tank pressures [MPa] versus time. Right
+    subplot: oxidizer and fuel tank masses [kg] versus time.
 
     Args:
         time: Time array [s].

--- a/machwave/services/plots/montecarlo.py
+++ b/machwave/services/plots/montecarlo.py
@@ -11,7 +11,8 @@ def plot_histogram(
     x_axes_title: str = "x",
     **plotly_kwargs,
 ) -> None:
-    """Histogram of a scalar property across all Monte Carlo results.
+    """
+    Histogram of a scalar property across all Monte Carlo results.
 
     Args:
         results: List of ``SimulationResult`` objects.
@@ -35,7 +36,8 @@ def plot_histogram_with_kde(
     kde_points: int = 200,
     **plotly_kwargs,
 ) -> None:
-    """Histogram plus KDE curve for a scalar property across all results.
+    """
+    Histogram plus KDE curve for a scalar property across all results.
 
     Args:
         results: List of ``SimulationResult`` objects.
@@ -81,7 +83,8 @@ def plot_cdf(
     percentiles: Sequence[int] = (5, 25, 50, 75, 95),
     **plotly_kwargs,
 ) -> None:
-    """Empirical CDF of a scalar property across all results.
+    """
+    Empirical CDF of a scalar property across all results.
 
     Args:
         results: List of ``SimulationResult`` objects.
@@ -146,16 +149,16 @@ def plot_time_series_extremes(
     title: str | None = None,
     **plotly_kwargs,
 ) -> None:
-    """Plot the lowest-mean, highest-mean, and median-mean scenarios for a
-    time-series property across all Monte Carlo results.
+    """
+    Plot lowest-mean, highest-mean, and median-mean scenarios over time.
 
     Each curve is aligned against the longest time array, padding shorter
     series with NaN so they stop where their data ends.
 
     Args:
-        results: List of ``SimulationResult`` objects.
-        time_property: Name of the time-array attribute (e.g. ``"time"``).
-        series_property: Name of the y(t) array attribute (e.g. ``"thrust"``).
+        results: List of `SimulationResult` objects.
+        time_property: Name of the time-array attribute (e.g. `"time"`).
+        series_property: Name of the y(t) array attribute (e.g. `"thrust"`).
         x_axes_title: Label for the x-axis.
         title: Plot title. If None, a default title is generated.
         **plotly_kwargs: Extra kwargs passed to go.Scatter.

--- a/machwave/simulation/base.py
+++ b/machwave/simulation/base.py
@@ -9,7 +9,8 @@ from machwave.simulation.states import MotorState
 
 @dataclass
 class InternalBallisticsSimulationParams:
-    """Parameters for an internal ballistics simulation.
+    """
+    Parameters for an internal ballistics simulation.
 
     Attributes:
         d_t: Time step.
@@ -26,7 +27,8 @@ class InternalBallisticsSimulationParams:
 
 
 class InternalBallisticsSimulation:
-    """Internal ballistics simulation class.
+    """
+    Internal ballistics simulation class.
 
     Attributes:
         motor: Motor object.
@@ -38,10 +40,18 @@ class InternalBallisticsSimulation:
         motor: Motor,
         params: InternalBallisticsSimulationParams,
     ) -> None:
+        """
+        Initialize an internal ballistics simulation.
+
+        Args:
+            motor: Motor model to simulate.
+            params: Simulation parameters.
+        """
         self.motor: Motor = motor
         self.params: InternalBallisticsSimulationParams = params
 
     def _build_motor_state(self) -> MotorState:
+        """Build the motor state matching the configured motor type."""
         if isinstance(self.motor, SolidMotor):
             return SolidMotorState(
                 motor=self.motor,
@@ -59,6 +69,7 @@ class InternalBallisticsSimulation:
         raise ValueError("Unsupported motor type.")
 
     def run(self) -> SimulationResult:
+        """Run the simulation to thrust termination and return its result."""
         motor_state = self._build_motor_state()
 
         d_t = self.params.d_t

--- a/machwave/simulation/liquid/results.py
+++ b/machwave/simulation/liquid/results.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, kw_only=True)
 class LiquidSimulationResult(SimulationResult["LiquidEngineState"]):
+    """Simulation result for a liquid engine run."""
+
     oxidizer_mass: SimulationResultArray
     fuel_mass: SimulationResultArray
     nozzle_correction_factor: SimulationResultArray
@@ -57,7 +59,7 @@ class LiquidSimulationResult(SimulationResult["LiquidEngineState"]):
         print(f"  Mean: {np.mean(self.thrust):.4f}", file=file)
 
         print("\nIMPULSE AND I_SP", file=file)
-        print(f"  Total impulse: {self.total_impulse:.4f} N·s", file=file)
+        print(f"  Total impulse: {self.total_impulse:.4f} N-s", file=file)
         print(f"  Specific impulse: {self.specific_impulse:.4f} s", file=file)
 
         print("\nPROPELLANT REMAINING (kg)", file=file)

--- a/machwave/simulation/liquid/states.py
+++ b/machwave/simulation/liquid/states.py
@@ -24,6 +24,16 @@ class LiquidEngineState(simulation_states.MotorState):
         external_pressure: float,
         other_losses: float,
     ) -> None:
+        """
+        Initialize a liquid engine state.
+
+        Args:
+            motor: Liquid engine to track.
+            igniter_pressure: Initial chamber pressure from the igniter [Pa].
+            external_pressure: Ambient pressure [Pa].
+            other_losses: Fractional losses not covered by specific
+                mechanisms, in [0, 1].
+        """
         super().__init__(
             motor=motor,
             igniter_pressure=igniter_pressure,
@@ -47,6 +57,7 @@ class LiquidEngineState(simulation_states.MotorState):
         ]
 
     def get_m_dot_in(self) -> float:
+        """Return the total inlet mass flow (fuel + oxidizer) [kg/s]."""
         return self._m_dot_fuel + self._m_dot_ox
 
     def run_timestep(
@@ -54,7 +65,8 @@ class LiquidEngineState(simulation_states.MotorState):
         d_t: float,
         external_pressure: float,
     ) -> None:
-        """Advance simulation by time step d_t under external pressure.
+        """
+        Advance simulation by time step d_t under external pressure.
 
         Args:
             d_t: Time step.

--- a/machwave/simulation/results.py
+++ b/machwave/simulation/results.py
@@ -37,6 +37,7 @@ class SimulationResult(ABC, Generic[StateT]):
 
     @classmethod
     def from_state(cls, state: StateT) -> "SimulationResult":
+        """Build a `SimulationResult` from a finished motor state."""
         return cls(
             **cls._collect_base_fields(state),
             **cls._collect_extra_fields(state),
@@ -83,6 +84,7 @@ class SimulationResult(ABC, Generic[StateT]):
         """Print the subclass-specific portion of the report."""
 
     def summary(self) -> dict[str, float]:
+        """Return a mapping of headline scalar metrics for this result."""
         return {
             "burn_time": self.burn_time,
             "thrust_time": self.thrust_time,
@@ -97,5 +99,5 @@ class SimulationResult(ABC, Generic[StateT]):
         }
 
     def _extra_summary(self) -> dict[str, float]:
-        """Return subclass-specific scalar metrics to merge into ``summary()``."""
+        """Return subclass-specific scalar metrics to merge into `summary()`."""
         return {}

--- a/machwave/simulation/solid/results.py
+++ b/machwave/simulation/solid/results.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, kw_only=True)
 class SolidSimulationResult(SimulationResult["SolidMotorState"]):
+    """Simulation result for a solid motor run."""
+
     free_chamber_volume: SimulationResultArray
     web: SimulationResultArray
     burn_area: SimulationResultArray
@@ -84,9 +86,11 @@ class SolidSimulationResult(SimulationResult["SolidMotorState"]):
     def _get_klemmung(
         burn_area: SimulationResultArray, throat_area: float
     ) -> SimulationResultArray:
-        """Klemmung (Kn) over non-zero burn-area samples.
+        """
+        Return Klemmung (Kn) over non-zero burn-area samples.
 
-        Returns Kn values where burn area is positive; length is <= len(burn_area).
+        Returns Kn values where burn area is positive; length is at most
+        `len(burn_area)`.
         """
         return burn_area[burn_area > 0] / throat_area
 
@@ -94,10 +98,13 @@ class SolidSimulationResult(SimulationResult["SolidMotorState"]):
     def _classify_burn_profile(
         klemmung: SimulationResultArray, deviancy: float = 0.02
     ) -> str:
-        """Classify a burn profile as "regressive", "progressive", or "neutral".
+        """
+        Classify a burn profile as "regressive", "progressive", or "neutral".
 
-        `deviancy` is the fractional threshold around 1.0 for the initial-to-final
-        ratio that delimits the neutral band.
+        Args:
+            klemmung: Klemmung samples.
+            deviancy: Fractional threshold around 1.0 for the initial-to-final
+                ratio that delimits the neutral band.
         """
         ratio = float(klemmung[0] / klemmung[-1])
         if ratio > 1 + deviancy:

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -26,6 +26,16 @@ class SolidMotorState(simulation_states.MotorState):
         external_pressure: float,
         other_losses: float,
     ) -> None:
+        """
+        Initialize a solid motor state.
+
+        Args:
+            motor: Solid motor to track.
+            igniter_pressure: Initial chamber pressure from the igniter [Pa].
+            external_pressure: Ambient pressure [Pa].
+            other_losses: Fractional losses not covered by specific
+                mechanisms, in [0, 1].
+        """
         super().__init__(
             motor=motor,
             igniter_pressure=igniter_pressure,
@@ -65,6 +75,7 @@ class SolidMotorState(simulation_states.MotorState):
         self.overall_efficiency: simulation_states.SimulationStateArray = [0.0]
 
     def get_m_dot_in(self) -> float:
+        """Return the propellant mass generation rate from the grain [kg/s]."""
         propellant_density = self.motor.grain.get_real_density(
             web_distance=self.web[-1],
             ideal_density=self.motor.propellant.ideal_density,
@@ -76,7 +87,8 @@ class SolidMotorState(simulation_states.MotorState):
         d_t: float,
         external_pressure: float,
     ) -> None:
-        """Iterate the motor operation by calculating operational parameters.
+        """
+        Iterate the motor operation by calculating operational parameters.
 
         Args:
             d_t: Time increment [s].

--- a/machwave/simulation/states.py
+++ b/machwave/simulation/states.py
@@ -23,6 +23,16 @@ class MotorState(ABC):
         external_pressure: float,
         other_losses: float,
     ) -> None:
+        """
+        Initialize a motor state.
+
+        Args:
+            motor: Motor to track.
+            igniter_pressure: Initial chamber pressure from the igniter [Pa].
+            external_pressure: Ambient pressure [Pa].
+            other_losses: Fractional losses not covered by specific
+                mechanisms, in [0, 1].
+        """
         self.motor = motor
         self.other_losses = other_losses
 
@@ -56,16 +66,29 @@ class MotorState(ABC):
 
     @property
     def initial_propellant_mass(self) -> float:
+        """Return the initial propellant mass [kg]."""
         return self.motor.initial_propellant_mass
 
     @property
     def thrust_time(self) -> float:
+        """
+        Return the thrust time [s].
+
+        Raises:
+            ValueError: If the simulation has not yet completed.
+        """
         if self._thrust_time is None:
             raise ValueError("Thrust time has not been set, run the simulation.")
         return self._thrust_time
 
     @property
     def burn_time(self) -> float:
+        """
+        Return the burn time [s].
+
+        Raises:
+            ValueError: If the simulation has not yet completed.
+        """
         if self._burn_time is None:
             raise ValueError("Burn time has not been set, run the simulation.")
         return self._burn_time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,27 @@ Homepage = "https://github.com/felipebogaertsm/machwave"
 
 [tool.ruff]
 line-length = 88
+
+[tool.ruff.lint]
+select = ["D"]
+extend-select = ["D213", "D407"]
+# Skipped intentionally:
+#   D100, D104: module/package docstrings not required.
+#   D102, D105, D107: trivial methods, magic methods, and __init__ are not
+#     required to be documented (getters, simple delegations, etc.). When the
+#     behavior is non-obvious, document it; otherwise let the name speak.
+#   D203, D212: incompatible with Google convention.
+ignore = ["D100", "D102", "D104", "D105", "D107", "D203", "D212"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.pycodestyle]
+max-doc-length = 88
+
+[tool.ruff.lint.per-file-ignores]
+# Tests, examples, scripts, and docs are exempt from docstring requirements.
+"tests/**" = ["D"]
+"examples/**" = ["D"]
+"scripts/**" = ["D"]
+"docs/**" = ["D"]

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,6 +1,8 @@
-"""Each factory exposes ``build(**overrides)``; composite factories delegate
+"""
+Each factory exposes ``build(**overrides)``; composite factories delegate
 sub-component construction to lower-level factories so overrides apply at any
-layer."""
+layer.
+"""
 
 from tests.factories.feed_systems import (
     StackedTankPressureFedFeedSystemFactory,

--- a/tests/factories/propellants.py
+++ b/tests/factories/propellants.py
@@ -1,6 +1,8 @@
-"""ThermochemicalProperties uses polyfactory's DataclassFactory (the model is a
+"""
+ThermochemicalProperties uses polyfactory's DataclassFactory (the model is a
 frozen, kw_only dataclass with strict validation bounds); the rest are plain
-builders so chemical formulas stay deterministic rather than randomized."""
+builders so chemical formulas stay deterministic rather than randomized.
+"""
 
 from __future__ import annotations
 

--- a/tests/test_adapters/test_rocketpy_solid_motor.py
+++ b/tests/test_adapters/test_rocketpy_solid_motor.py
@@ -1,0 +1,81 @@
+"""Tests for the RocketPy SolidMotor adapter."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from machwave.adapters.rocketpy import RocketPySolidMotorAdapter
+from machwave.models import grain as grain_models
+
+from tests.factories import (
+    ConicalGrainSegmentFactory,
+    DGrainSegmentFactory,
+    MultiPortGrainSegmentFactory,
+    RodAndTubeGrainSegmentFactory,
+    SolidMotorFactory,
+    StarGrainSegmentFactory,
+    WagonWheelGrainSegmentFactory,
+)
+
+
+def _stub_simulation_result() -> SimpleNamespace:
+    """Return a stand-in result with the fields read by the base adapter."""
+    time = np.array([0.0, 1.0])
+    thrust = np.array([100.0, 100.0])
+    return SimpleNamespace(
+        time=time,
+        thrust=thrust,
+        thrust_time=1.0,
+        exit_pressure=np.array([1e5, 1e5]),
+    )
+
+
+def _build_adapter_without_init(motor) -> RocketPySolidMotorAdapter:
+    """Bypass __init__ so the test isolates the geometry validation."""
+    adapter = RocketPySolidMotorAdapter.__new__(RocketPySolidMotorAdapter)
+    adapter.motor = motor
+    adapter.simulation_result = _stub_simulation_result()
+    return adapter
+
+
+@pytest.mark.parametrize(
+    "segment_factory",
+    [
+        StarGrainSegmentFactory,
+        WagonWheelGrainSegmentFactory,
+        ConicalGrainSegmentFactory,
+        DGrainSegmentFactory,
+        MultiPortGrainSegmentFactory,
+        RodAndTubeGrainSegmentFactory,
+    ],
+)
+def test_non_bates_geometry_raises_value_error(segment_factory) -> None:
+    grain = grain_models.Grain()
+    grain.add_segment(segment_factory.build())
+    motor = SolidMotorFactory.build(grain=grain)
+    adapter = _build_adapter_without_init(motor)
+
+    with pytest.raises(ValueError, match="only supports BATES grain geometry"):
+        adapter._get_rocketpy_attributes()
+
+
+def test_bates_geometry_produces_expected_keys() -> None:
+    motor = SolidMotorFactory.build()
+    adapter = _build_adapter_without_init(motor)
+
+    attrs = adapter._get_rocketpy_attributes()
+
+    assert attrs["grain_number"] == motor.grain.segment_count
+    assert attrs["grain_outer_radius"] == pytest.approx(
+        motor.grain.segments[0].outer_diameter / 2
+    )
+    assert attrs["grain_initial_inner_radius"] == pytest.approx(
+        motor.grain.segments[0].core_diameter / 2
+    )
+    assert attrs["grain_initial_height"] == pytest.approx(
+        motor.grain.segments[0].length
+    )
+    assert attrs["throat_radius"] == pytest.approx(
+        motor.thrust_chamber.nozzle.throat_diameter / 2
+    )

--- a/tests/test_core/test_compressible_flow/test_losses.py
+++ b/tests/test_core/test_compressible_flow/test_losses.py
@@ -134,22 +134,22 @@ def test_get_two_phase_phase_loss_particle_size(
         (150.0, 0.12, 9.0, 0.8, 20.0, 5.0, 0.077083257633896425),
         # 1 in <= throat < 2 in
         (200.0, 0.12, 10.0, 1.5, 20.0, 6.0, 0.05081089868159106),
-        # throat >= 2 in, particle < 4 µm
+        # throat >= 2 in, particle < 4 um
         (250.0, 0.12, 12.0, 3.0, 20.0, 3.0, 0.016621488765966366),
-        # throat >= 2 in, 4 µm <= particle <= 8 µm
+        # throat >= 2 in, 4 um <= particle <= 8 um
         (250.0, 0.12, 12.0, 3.0, 20.0, 6.0, 0.034185173799418895),
-        # throat >= 2 in, particle > 8 µm
+        # throat >= 2 in, particle > 8 um
         (250.0, 0.12, 12.0, 3.0, 20.0, 9.0, 0.037947076355546048),
         # - xi < 0.09 branch
         # throat < 1 in
         (150.0, 0.05, 9.0, 0.8, 20.0, 5.0, 0.03708669962078615),
         # 1 in <= throat < 2 in
         (200.0, 0.05, 10.0, 1.5, 20.0, 6.0, 0.024446405026319503),
-        # throat >= 2 in, particle < 4 µm
+        # throat >= 2 in, particle < 4 um
         (250.0, 0.05, 12.0, 3.0, 20.0, 3.0, 0.007967177893556986),
-        # throat >= 2 in, 4 µm <= particle <= 8 µm
+        # throat >= 2 in, 4 um <= particle <= 8 um
         (250.0, 0.05, 12.0, 3.0, 20.0, 6.0, 0.01644734941282387),
-        # throat >= 2 in, particle > 8 µm
+        # throat >= 2 in, particle > 8 um
         (250.0, 0.05, 12.0, 3.0, 20.0, 9.0, 0.01820912334005975),
     ],
 )
@@ -212,9 +212,7 @@ def test_get_overall_nozzle_efficiency_valid(
 
 
 def test_get_overall_nozzle_efficiency_out_of_bounds():
-    """
-    When the sum of loss fractions exceeds 1, the @check_bounds decorator should raise.
-    """
+    """When the sum of loss fractions exceeds 1, the @check_bounds decorator should raise."""
     with pytest.raises((ValueError, AssertionError)):
         # Sum = 1.10, outside allowed range.
         losses.get_overall_nozzle_efficiency(

--- a/tests/test_core/test_incompressible_flow.py
+++ b/tests/test_core/test_incompressible_flow.py
@@ -32,9 +32,7 @@ def test_get_mass_flow_orifice(
 
 
 def test_get_mass_flow_orifice_raises_value_error():
-    """
-    ValueError is raised when downstream pressure exceeds upstream pressure.
-    """
+    """ValueError is raised when downstream pressure exceeds upstream pressure."""
     with pytest.raises(
         ValueError, match="Pressure downstream cannot be greater than upstream"
     ):

--- a/tests/test_io/test_eng.py
+++ b/tests/test_io/test_eng.py
@@ -51,9 +51,7 @@ from machwave.io.eng import generate_eng_file_content
 
 @pytest.fixture
 def payload_data():
-    """
-    Fixture to set up common test data used in all test cases.
-    """
+    """Fixture to set up common test data used in all test cases."""
     return {
         "time": np.linspace(0, 5, 100),  # Simulated time data
         "thrust": np.linspace(0, 500, 100),  # Simulated thrust data
@@ -69,9 +67,7 @@ def payload_data():
 
 
 def test_eng_header_format(payload_data):
-    """
-    Test if the header in the .eng file is formatted correctly.
-    """
+    """Test if the header in the .eng file is formatted correctly."""
     content = generate_eng_file_content(
         time=payload_data["time"],
         thrust=payload_data["thrust"],
@@ -102,9 +98,7 @@ def test_eng_header_format(payload_data):
 
 
 def test_eng_data_format(payload_data):
-    """
-    Test if the time and thrust data in the .eng file are formatted correctly.
-    """
+    """Test if the time and thrust data in the .eng file are formatted correctly."""
     content = generate_eng_file_content(
         time=payload_data["time"],
         thrust=payload_data["thrust"],
@@ -174,9 +168,7 @@ def test_eng_data_values(payload_data):
 
 
 def test_eng_file_ends_with_semicolon(payload_data):
-    """
-    Test if the .eng file ends with a semicolon.
-    """
+    """Test if the .eng file ends with a semicolon."""
     content = generate_eng_file_content(
         time=payload_data["time"],
         thrust=payload_data["thrust"],

--- a/tests/test_models/test_propulsion/test_feed_systems/test_tanks.py
+++ b/tests/test_models/test_propulsion/test_feed_systems/test_tanks.py
@@ -167,9 +167,7 @@ def test_two_phase_density_constant_while_two_phase(fluid_name, temperature):
 
 
 def test_remove_negative_mass():
-    """
-    Removing negative mass should raise ValueError.
-    """
+    """Removing negative mass should raise ValueError."""
     tank = Tank("Water", 0.01, 300.0, 1.0)
     with pytest.raises(ValueError):
         tank.remove_propellant(-0.5)

--- a/tests/test_models/test_propulsion/test_grain/test_cog/test_bates_cog.py
+++ b/tests/test_models/test_propulsion/test_grain/test_cog/test_bates_cog.py
@@ -9,7 +9,6 @@ class TestBatesGrainCenterOfGravity:
 
     def test_single_segment_cog_position(self):
         """Test CoG with a single BATES segment of length 1.0m."""
-
         grain = Grain(spacing=0.1)  # Spacing doesn't matter with 1 segment
 
         segment = BatesSegment(
@@ -27,10 +26,7 @@ class TestBatesGrainCenterOfGravity:
         np.testing.assert_array_almost_equal(cog, expected_cog)
 
     def test_two_segments_equal_length_with_spacing(self):
-        """
-        Test CoG with 2 BATES segments of length 1.0m each with 0.1m spacing.
-        """
-
+        """Test CoG with 2 BATES segments of length 1.0m each with 0.1m spacing."""
         grain = Grain(spacing=0.1)
 
         segment_1 = BatesSegment(
@@ -56,9 +52,7 @@ class TestBatesGrainCenterOfGravity:
         np.testing.assert_array_almost_equal(cog, expected_cog)
 
     def test_three_segments_equal_length_with_spacing(self):
-        """
-        Test CoG with 3 BATES segments of length 1.0m each with 0.2m spacing.
-        """
+        """Test CoG with 3 BATES segments of length 1.0m each with 0.2m spacing."""
         grain = Grain(spacing=0.2)
 
         segment1 = BatesSegment(
@@ -92,9 +86,7 @@ class TestBatesGrainCenterOfGravity:
         np.testing.assert_array_almost_equal(cog, expected_cog)
 
     def test_three_segments_variable_length_with_spacing(self):
-        """
-        Test CoG with 3 BATES segments of different lengths with 0.2m spacing.
-        """
+        """Test CoG with 3 BATES segments of different lengths with 0.2m spacing."""
         grain = Grain(spacing=0.2)
 
         # L1 = 1.0m

--- a/tests/test_models/test_propulsion/test_grain/test_inhibition/test_fmm_inhibition.py
+++ b/tests/test_models/test_propulsion/test_grain/test_inhibition/test_fmm_inhibition.py
@@ -52,7 +52,8 @@ def _boundary_ring_cells(masked_face) -> int:
 
 
 def _end_burning_cells(masked_face_3d, idx: int) -> int:
-    """Count burning propellant cells on an end slice, excluding the bore opening.
+    """
+    Count burning propellant cells on an end slice, excluding the bore opening.
 
     The bore opening is identified as the burning (0-valued) cells in the
     adjacent interior slice — this matches how the FMM code defines bore_mask.

--- a/tests/test_models/test_propulsion/test_grain/test_moi/test_bates_moi.py
+++ b/tests/test_models/test_propulsion/test_grain/test_moi/test_bates_moi.py
@@ -15,7 +15,7 @@ class TestBatesSegmentMomentOfInertia:
         outer_diameter = 0.117  # 117 mm
         core_diameter = 0.045  # 45 mm
         length = 0.2  # 200 mm
-        ideal_density = 1800.0  # kg/m³
+        ideal_density = 1800.0  # kg/m^3
 
         segment = BatesSegment(
             outer_diameter=outer_diameter,

--- a/tests/test_models/test_propulsion/test_grain/test_moi/test_fmm2d_moi.py
+++ b/tests/test_models/test_propulsion/test_grain/test_moi/test_fmm2d_moi.py
@@ -108,7 +108,7 @@ class TestFMM2DSegmentMomentOfInertia:
         )
 
         # Longer segment should have higher radial MOI (Iyy, Izz)
-        # because of both more mass and length² term in parallel axis theorem
+        # because of both more mass and length^2 term in parallel axis theorem
         assert moi_long[1, 1] > moi_short[1, 1]
         assert moi_long[2, 2] > moi_short[2, 2]
 

--- a/tests/test_models/test_propulsion/test_grain/test_moi/test_fmm3d_moi.py
+++ b/tests/test_models/test_propulsion/test_grain/test_moi/test_fmm3d_moi.py
@@ -107,7 +107,7 @@ class TestFMM3DSegmentMomentOfInertia:
         )
 
         # Longer segment should have higher radial MOI (Iyy, Izz)
-        # because of both more mass and length² term
+        # because of both more mass and length^2 term
         assert moi_long[1, 1] > moi_short[1, 1]
         assert moi_long[2, 2] > moi_short[2, 2]
 

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_json_loader.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_json_loader.py
@@ -305,7 +305,8 @@ class TestJSONFormulationLoading:
         ids=lambda p: p.stem,
     )
     def test_solid_formulations_can_be_evaluated_with_cea(self, json_file):
-        """Ensure a CEA-backed evaluation can run for each solid formulation.
+        """
+        Ensure a CEA-backed evaluation can run for each solid formulation.
 
         The formulation JSONs may include fixed properties; this test explicitly
         bypasses those to validate that the component-based CEA path still works.
@@ -337,7 +338,8 @@ class TestJSONFormulationLoading:
     def test_fixed_properties_are_reasonably_close_to_cea_for_selected_solids(
         self, json_stem
     ):
-        """Compare fixed JSON properties to a CEA reconstruction for a few solids.
+        """
+        Compare fixed JSON properties to a CEA reconstruction for a few solids.
 
         The fixed properties in JSON are treated as canonical reference values.
         This check is intentionally limited to a small representative set where

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_solid.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_solid.py
@@ -1,4 +1,5 @@
-"""Tests for solid propellant formulations.
+"""
+Tests for solid propellant formulations.
 
 This test suite automatically tests all solid propellant formulations
 defined in the formulations.solid module. Any new formulation added
@@ -208,7 +209,7 @@ class TestConsistency:
         if propellant.properties is not None:
             return
 
-        # Typical solid propellants: 1500-2000 kg/m³
+        # Typical solid propellants: 1500-2000 kg/m^3
         # Density is grain-specific, check ideal_density from propellant formulation
         if hasattr(propellant, "ideal_density"):
             density = propellant.ideal_density

--- a/tests/test_services/test_cea.py
+++ b/tests/test_services/test_cea.py
@@ -1,4 +1,5 @@
-"""Tests for RocketCEAService and create_cea_service factory function.
+"""
+Tests for RocketCEAService and create_cea_service factory function.
 
 Tests all three ways of creating/using the service:
 1. Via factory with solid propellant
@@ -140,10 +141,10 @@ class TestCreateCEAServiceBiliquidPropellant:
 
         # Test tank densities (biliquid specific)
         ox_dens, fuel_dens = service.get_tank_densities()
-        # Note: CEA returns densities in g/cm³
-        # LOX density ~1.14 g/cm³, RP1 ~0.54 g/cm³ (at boiling point)
-        assert 0.8 < ox_dens < 1.3, f"LOX density out of range: {ox_dens} g/cm³"
-        assert 0.5 < fuel_dens < 0.9, f"RP1 density out of range: {fuel_dens} g/cm³"
+        # Note: CEA returns densities in g/cm^3
+        # LOX density ~1.14 g/cm^3, RP1 ~0.54 g/cm^3 (at boiling point)
+        assert 0.8 < ox_dens < 1.3, f"LOX density out of range: {ox_dens} g/cm^3"
+        assert 0.5 < fuel_dens < 0.9, f"RP1 density out of range: {fuel_dens} g/cm^3"
 
     def test_lox_lh2_high_performance(self):
         """Test LOX/LH2 high-performance propellant."""
@@ -389,7 +390,8 @@ class TestServiceEdgeCases:
 
 
 class TestRegistryIsolation:
-    """Repeated calls with the same user-facing propellant name but different
+    """
+    Repeated calls with the same user-facing propellant name but different
     cards must not clobber each other in RocketCEA's process-global registry.
 
     Without name-mangling the second registration silently wins and both

--- a/tests/test_simulations/conftest.py
+++ b/tests/test_simulations/conftest.py
@@ -18,8 +18,10 @@ from machwave.simulation import (
 def run_simulation(
     motor: Motor, params: InternalBallisticsSimulationParams
 ) -> SimulationResult:
-    """Run InternalBallisticsSimulation end-to-end, suppressing the empirical
-    boundary-layer-loss warning that otherwise floods test output."""
+    """
+    Run InternalBallisticsSimulation end-to-end, suppressing the empirical
+    boundary-layer-loss warning that otherwise floods test output.
+    """
     simulation = InternalBallisticsSimulation(motor=motor, params=params)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
@@ -27,7 +29,8 @@ def run_simulation(
 
 
 def assert_recorded_arrays_aligned(result: SimulationResult) -> None:
-    """Every per-timestep series should have the same length as result.time.
+    """
+    Every per-timestep series should have the same length as result.time.
 
     Fields marked with ``metadata={"non_aligned": True}`` are skipped (e.g.
     arrays filtered to a subset of timesteps, or with a non-time leading axis).

--- a/tests/test_simulations/motor_builders.py
+++ b/tests/test_simulations/motor_builders.py
@@ -1,4 +1,5 @@
-"""Shared motor + simulation-params builders for end-to-end simulation tests
+"""
+Shared motor + simulation-params builders for end-to-end simulation tests
 and benchmarks.
 
 These configurations mirror the example scripts under examples/ (apcp_motor,

--- a/tests/test_simulations/test_liquid_engine_simulation.py
+++ b/tests/test_simulations/test_liquid_engine_simulation.py
@@ -1,4 +1,5 @@
-"""End-to-end integration tests for LiquidEngine internal ballistics
+"""
+End-to-end integration tests for LiquidEngine internal ballistics
 simulations.
 
 The motor configuration lives in tests/test_simulations/motor_builders.py so

--- a/tests/test_simulations/test_solid_motor_simulation.py
+++ b/tests/test_simulations/test_solid_motor_simulation.py
@@ -1,4 +1,5 @@
-"""End-to-end integration tests for SolidMotor internal ballistics simulations.
+"""
+End-to-end integration tests for SolidMotor internal ballistics simulations.
 
 The motor configurations live in tests/test_simulations/motor_builders.py so
 they can be reused by benchmarks under tests/benchmarks/.


### PR DESCRIPTION
Closes #277.

## Summary

- Configures ruff to enforce Google-style docstrings (`D213`, `D407`, `max-doc-length = 88`) across `machwave/` and `tests/`. Trivial methods, `__init__`, and magic methods are exempt; `tests/`, `examples/`, `scripts/`, and `docs/` are excluded from `D` rules entirely.
- Converts Sphinx-style (`:param:`/`:return:`) docstrings to Google style, replaces Unicode unit characters with ASCII (`^2`, `^3`, `um`, `-`), and adds class-level docstrings where the linter required them.
- Trims unused re-exports in `machwave/adapters/rocketpy/__init__.py` (`RocketPyAdapterError`, `RocketPyMotorAdapter`) and `machwave/models/propellants/categories/__init__.py` (`PropellantValidationError`, `BurnRateOutOfBoundsError`).
- Refactors the RocketPy adapter base module to import `rocketpy` once at module top instead of inside every method, dropping the `_require_rocketpy` helper.
- Rejects non-BATES grain geometries in `RocketPySolidMotorAdapter`, with tests covering each non-BATES geometry plus the BATES happy path.

## Test plan

- [x] `make check` (format, ruff, pyright) passes.
- [x] Full test suite passes (`643 passed` previously; new adapter tests also green).
- [x] CI passes on the PR.