### PR TITLE
Namespace imports

### DIFF
--- a/examples/1kn_lre.py
+++ b/examples/1kn_lre.py
@@ -2,21 +2,13 @@
 Sample 1kN biliquid rocket engine, similar to HalfCat's Sphinx.
 """
 
-from machwave import (
-    feed_systems,
-    motors,
-    propellants,
-    thrust_chamber as thrust_chamber_models,
-)
-from machwave.models.feed_systems import tanks
-from machwave.services.plots.internal_ballistics import (
-    plot_bipropellant_tank_profiles,
-    thrust_pressure_plot,
-)
-from machwave.simulation import (
-    InternalBallisticsSimulation,
-    InternalBallisticsSimulationParams,
-)
+import machwave.models.feed_systems as feed_systems
+import machwave.models.feed_systems.tanks as tanks
+import machwave.models.motors as motors_models
+import machwave.models.propellants as propellants
+import machwave.models.thrust_chamber as thrust_chamber_models
+import machwave.services.plots.internal_ballistics as internal_ballistics_plots
+import machwave.simulation as simulation_module
 
 FUEL_NAME = "Ethanol"
 OXIDIZER_NAME = "N2O"
@@ -93,7 +85,7 @@ def main():
         center_of_gravity_coordinate=(0.02, 0.0, 0.0),
     )
 
-    lre = motors.LiquidEngine(
+    lre = motors_models.LiquidEngine(
         propellant=propellant,
         feed_system=feed_system,
         thrust_chamber=thrust_chamber,
@@ -101,16 +93,20 @@ def main():
         fuel_tank_cog=0.4,
     )
 
-    sim_params = InternalBallisticsSimulationParams(
+    sim_params = simulation_module.InternalBallisticsSimulationParams(
         d_t=1e-4, igniter_pressure=1e6, external_pressure=1e5, other_losses=0.12
     )
-    simulation = InternalBallisticsSimulation(motor=lre, params=sim_params)
+    simulation = simulation_module.InternalBallisticsSimulation(
+        motor=lre, params=sim_params
+    )
 
     result = simulation.run()
 
     result.report()
-    thrust_pressure_plot(result.time, result.thrust, result.chamber_pressure).show()
-    plot_bipropellant_tank_profiles(
+    internal_ballistics_plots.thrust_pressure_plot(
+        result.time, result.thrust, result.chamber_pressure
+    ).show()
+    internal_ballistics_plots.plot_bipropellant_tank_profiles(
         result.time,
         result.oxidizer_tank_pressure,
         result.fuel_tank_pressure,

--- a/examples/apcp_motor.py
+++ b/examples/apcp_motor.py
@@ -4,18 +4,16 @@ an InternalBallisticsCoupled simulation that includes both
 internal ballistics and atmospheric flight.
 """
 
-from machwave import (
-    formulations,
-    grain as grain_models,
-    motors,
-    simulation,
-    thrust_chamber as thrust_chamber_models,
-)
-from machwave.common.decorators import timing
-from machwave.services.plots import internal_ballistics as internal_ballistics_plots
+import machwave.common.decorators as decorators
+import machwave.models.grain as grain_models
+import machwave.models.motors as motors_models
+import machwave.models.propellants.formulations as formulations
+import machwave.models.thrust_chamber as thrust_chamber_models
+import machwave.services.plots.internal_ballistics as internal_ballistics_plots
+import machwave.simulation as simulation
 
 
-@timing
+@decorators.timing
 def main():
     propellant = formulations.solid.MIT_CHERRY_LIMEADE
 
@@ -54,7 +52,7 @@ def main():
         center_of_gravity_coordinate=(0.35, 0.0, 0.0),
     )
 
-    motor = motors.SolidMotor(
+    motor = motors_models.SolidMotor(
         grain=grain, propellant=propellant, thrust_chamber=thrust_chamber
     )
 

--- a/examples/grain_geometries.py
+++ b/examples/grain_geometries.py
@@ -5,29 +5,20 @@ geometries within Machwave.
 
 import numpy as np
 
-from machwave.models.grain.geometries import (
-    BatesSegment,
-    ConicalGrainSegment,
-    DGrainSegment,
-    MultiPortGrainSegment,
-    StarGrainSegment,
-)
-from machwave.services.plots.fmm import (
-    plot_2d_face_map,
-    plot_2d_face_map_animated,
-)
+import machwave.models.grain.geometries as grain_geometries
+import machwave.services.plots.fmm as fmm_plots
 
 np.set_printoptions(precision=2, suppress=True)
 
 
 def main():
-    bates_segment = BatesSegment(
+    bates_segment = grain_geometries.BatesSegment(
         length=68e-3,
         outer_diameter=41e-3,
         core_diameter=15e-3,
     )
 
-    multiport_segment = MultiPortGrainSegment(
+    multiport_segment = grain_geometries.MultiPortGrainSegment(
         length=68e-3,
         outer_diameter=41e-3,
         port_diameter=3e-3,
@@ -35,20 +26,20 @@ def main():
         port_level_count=4,
     )
 
-    dgrain_segment = DGrainSegment(
+    dgrain_segment = grain_geometries.DGrainSegment(
         length=68e-3,
         outer_diameter=41e-3,
         slot_offset=10e-3,
     )
 
-    conical_segment = ConicalGrainSegment(
+    conical_segment = grain_geometries.ConicalGrainSegment(
         length=68e-3,
         outer_diameter=41e-3,
         upper_core_diameter=35e-3,
         lower_core_diameter=5e-3,
     )
 
-    star_segment = StarGrainSegment(
+    star_segment = grain_geometries.StarGrainSegment(
         length=68e-3,
         outer_diameter=41e-3,
         number_of_points=5,
@@ -75,7 +66,7 @@ def main():
     print(f"Dgrain grain area: {grain_area * 1e6:2f} mm^2")
     print(f"Dgrain grain port area: {port_area * 1e6:2f} mm^2")
     print(f"Dgrain center of gravity: {dgrain_segment.get_center_of_gravity(0)}")
-    plot_2d_face_map(face_map).show()
+    fmm_plots.plot_2d_face_map(face_map).show()
 
     grain_area = multiport_segment.get_burn_area(web_distance=web_distance)
     port_area = multiport_segment.get_port_area(web_distance=web_distance)
@@ -86,7 +77,7 @@ def main():
     print(
         f"Multiport center of gravity: {multiport_segment.get_center_of_gravity(web_distance)}"
     )
-    multiport_fig = plot_2d_face_map_animated(
+    multiport_fig = fmm_plots.plot_2d_face_map_animated(
         face_maps=np.array(
             [
                 multiport_segment.get_face_map(web_distance)
@@ -97,7 +88,7 @@ def main():
     )
     multiport_fig.show()
 
-    star_fig = plot_2d_face_map_animated(
+    star_fig = fmm_plots.plot_2d_face_map_animated(
         face_maps=np.array(
             [
                 star_segment.get_face_map(web_distance)

--- a/examples/grain_inhibitedends.py
+++ b/examples/grain_inhibitedends.py
@@ -2,12 +2,9 @@ import itertools
 
 import numpy as np
 
-from machwave.models import grain
-from machwave.models.grain import geometries
-from machwave.services.plots.fmm import (
-    plot_2d_face_map_animated,
-    plot_3d_face_map_animated,
-)
+import machwave.models.grain as grain
+import machwave.models.grain.geometries as geometries
+import machwave.services.plots.fmm as fmm_plots
 
 
 STAR_GRAIN_PARAMS = dict(
@@ -36,14 +33,14 @@ def _collect_face_maps(segment, n_steps: int = 20):
 
 def _show_2d(label: str, segment) -> None:
     face_maps, web_distances = _collect_face_maps(segment)
-    fig = plot_2d_face_map_animated(face_maps, web_distances)
+    fig = fmm_plots.plot_2d_face_map_animated(face_maps, web_distances)
     fig.update_layout(title=label)
     fig.show()
 
 
 def _show_3d(label: str, segment) -> None:
     face_maps, web_distances = _collect_face_maps(segment)
-    fig = plot_3d_face_map_animated(face_maps, web_distances)
+    fig = fmm_plots.plot_3d_face_map_animated(face_maps, web_distances)
     fig.update_layout(title=label)
     fig.show()
 

--- a/examples/grain_moment_of_inertia.py
+++ b/examples/grain_moment_of_inertia.py
@@ -9,10 +9,10 @@ trajectory modeling.
 
 import numpy as np
 
-from machwave.models.grain import Grain
-from machwave.models.grain.geometries.bates import BatesSegment
-from machwave.models.grain.geometries.conical import ConicalGrainSegment
-from machwave.models.grain.geometries.star import StarGrainSegment
+import machwave.models.grain as grain_models
+import machwave.models.grain.geometries.bates as bates_geometry
+import machwave.models.grain.geometries.conical as conical_geometry
+import machwave.models.grain.geometries.star as star_geometry
 
 
 def print_inertia_tensor(moi: np.ndarray, title: str = "Moment of Inertia Tensor"):
@@ -36,7 +36,7 @@ def example_single_segment():
     print("EXAMPLE 1: Single BATES Segment")
     print("=" * 60)
 
-    segment = BatesSegment(
+    segment = bates_geometry.BatesSegment(
         outer_diameter=0.117,  # 117 mm
         core_diameter=0.045,  # 45 mm
         length=0.200,  # 200 mm
@@ -69,10 +69,10 @@ def example_multi_segment():
     print("EXAMPLE 2: Three-Segment Grain Assembly")
     print("=" * 60)
 
-    grain = Grain(spacing=0.010)  # 10 mm spacing
+    grain = grain_models.Grain(spacing=0.010)  # 10 mm spacing
 
     for i in range(3):
-        segment = BatesSegment(
+        segment = bates_geometry.BatesSegment(
             outer_diameter=0.117,
             core_diameter=0.045,
             length=0.150,
@@ -104,10 +104,10 @@ def example_burn_progression():
     print("EXAMPLE 3: MOI Evolution During Burn")
     print("=" * 60)
 
-    grain = Grain(spacing=0.005)
+    grain = grain_models.Grain(spacing=0.005)
 
     for _ in range(2):
-        segment = BatesSegment(
+        segment = bates_geometry.BatesSegment(
             outer_diameter=0.117,
             core_diameter=0.045,
             length=0.200,
@@ -143,10 +143,10 @@ def example_asymmetric_grain():
     print("EXAMPLE 4: Asymmetric Grain (Different Density Ratios)")
     print("=" * 60)
 
-    grain = Grain(spacing=0.0)
+    grain = grain_models.Grain(spacing=0.0)
 
     # First segment: full density
-    segment1 = BatesSegment(
+    segment1 = bates_geometry.BatesSegment(
         outer_diameter=0.117,
         core_diameter=0.045,
         length=0.200,
@@ -154,7 +154,7 @@ def example_asymmetric_grain():
     )
 
     # Second segment: 80% density (damaged or intentionally lighter)
-    segment2 = BatesSegment(
+    segment2 = bates_geometry.BatesSegment(
         outer_diameter=0.117,
         core_diameter=0.045,
         length=0.200,
@@ -182,7 +182,7 @@ def example_2d_fmm_star_grain():
     print("EXAMPLE 5: 2D FMM Star Grain Segment")
     print("=" * 60)
 
-    star_segment = StarGrainSegment(
+    star_segment = star_geometry.StarGrainSegment(
         length=0.250,  # 250 mm
         outer_diameter=0.120,  # 120 mm
         number_of_points=5,
@@ -224,7 +224,7 @@ def example_3d_fmm_conical_grain():
     print("EXAMPLE 6: 3D FMM Conical Grain Segment")
     print("=" * 60)
 
-    conical_segment = ConicalGrainSegment(
+    conical_segment = conical_geometry.ConicalGrainSegment(
         length=0.300,  # 300 mm
         outer_diameter=0.130,  # 130 mm
         upper_core_diameter=0.040,  # 40 mm at top

--- a/examples/kappa_rnakka.py
+++ b/examples/kappa_rnakka.py
@@ -3,18 +3,16 @@ Example for the Kappa motor, developed by Richard Nakka.
 https://www.nakka-rocketry.net/kappa.html
 """
 
-from machwave import (
-    formulations,
-    grain as grain_models,
-    motors,
-    simulation,
-    thrust_chamber as thrust_chamber_models,
-)
-from machwave.common.decorators import timing
-from machwave.services.plots import internal_ballistics as internal_ballistics_plots
+import machwave.common.decorators as decorators
+import machwave.models.grain as grain_models
+import machwave.models.motors as motors_models
+import machwave.models.propellants.formulations as formulations
+import machwave.models.thrust_chamber as thrust_chamber_models
+import machwave.services.plots.internal_ballistics as internal_ballistics_plots
+import machwave.simulation as simulation
 
 
-@timing
+@decorators.timing
 def main():
     propellant = formulations.solid.KNDX
 
@@ -52,7 +50,7 @@ def main():
         center_of_gravity_coordinate=(0.035, 0.0, 0.0),
     )
 
-    motor = motors.SolidMotor(
+    motor = motors_models.SolidMotor(
         grain=grain, propellant=propellant, thrust_chamber=thrust_chamber
     )
 

--- a/examples/liquid_propellant_composition.py
+++ b/examples/liquid_propellant_composition.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from machwave.common.decorators import timing
-from machwave.models.propellants import categories as propellant_categories
-from machwave.models.propellants import components as propellant_components
+import machwave.common.decorators as decorators
+import machwave.models.propellants.categories as propellant_categories
+import machwave.models.propellants.components as propellant_components
 
 
-@timing
+@decorators.timing
 def main() -> None:
     lox = propellant_components.PropellantComponent(
         name="LOX",

--- a/examples/losses/boundary_layer.py
+++ b/examples/losses/boundary_layer.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 
 import pandas as pd
 
-from machwave.core import losses
+import machwave.core.compressible_flow.losses as losses
 
 CHAMBER_PRESSURES = (
     150,

--- a/examples/losses/divergent.py
+++ b/examples/losses/divergent.py
@@ -7,9 +7,7 @@ from textwrap import dedent
 
 import pandas as pd
 
-from machwave.core.compressible_flow.losses import (
-    get_nozzle_divergent_loss_fraction,
-)
+import machwave.core.compressible_flow.losses as losses
 
 DIVERGENT_ANGLES = (
     0.0,
@@ -27,7 +25,7 @@ DIVERGENT_ANGLES = (
 records: list[dict[str, float]] = []
 
 for angle in DIVERGENT_ANGLES:
-    divergent_loss = get_nozzle_divergent_loss_fraction(divergent_angle=angle)
+    divergent_loss = losses.get_nozzle_divergent_loss_fraction(divergent_angle=angle)
 
     records.append(
         {

--- a/examples/losses/kinetics.py
+++ b/examples/losses/kinetics.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 
 import pandas as pd
 
-from machwave.core.compressible_flow.losses import get_kinetics_loss_fraction
+import machwave.core.compressible_flow.losses as losses
 
 CHAMBER_PRESSURES_PSI = (
     150,
@@ -29,7 +29,7 @@ for P_ch, (i_sp_frozen, i_sp_shifting) in product(
     CHAMBER_PRESSURES_PSI,
     ISP_TH_PAIRS,
 ):
-    kinetics_loss = get_kinetics_loss_fraction(
+    kinetics_loss = losses.get_kinetics_loss_fraction(
         i_sp_th_frozen=i_sp_frozen,
         i_sp_th_shifting=i_sp_shifting,
         chamber_pressure_psi=P_ch,

--- a/examples/losses/two_phase.py
+++ b/examples/losses/two_phase.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 
 import pandas as pd
 
-from machwave.core import losses
+import machwave.core.compressible_flow.losses as losses
 
 CHAMBER_PRESSURES = (
     150,

--- a/examples/nero_motor.py
+++ b/examples/nero_motor.py
@@ -4,18 +4,16 @@ Supernova Rocketry UFJF in 2019. It is a class J KNDX motor with a
 maximum operating pressure of 7 MPa.
 """
 
-from machwave import (
-    formulations,
-    grain as grain_models,
-    motors,
-    simulation,
-    thrust_chamber as thrust_chamber_models,
-)
-from machwave.common.decorators import timing
-from machwave.services.plots import internal_ballistics as internal_ballistics_plots
+import machwave.common.decorators as decorators
+import machwave.models.grain as grain_models
+import machwave.models.motors as motors_models
+import machwave.models.propellants.formulations as formulations
+import machwave.models.thrust_chamber as thrust_chamber_models
+import machwave.services.plots.internal_ballistics as internal_ballistics_plots
+import machwave.simulation as simulation
 
 
-@timing
+@decorators.timing
 def main():
     propellant = formulations.solid.KNDX
 
@@ -53,7 +51,7 @@ def main():
         center_of_gravity_coordinate=(0.04, 0.0, 0.0),
     )
 
-    motor = motors.SolidMotor(
+    motor = motors_models.SolidMotor(
         grain=grain, propellant=propellant, thrust_chamber=thrust_chamber
     )
 

--- a/examples/olympus.py
+++ b/examples/olympus.py
@@ -5,18 +5,16 @@ never used in flight. The motor was successfully tested on July 2, 2022, and
 at the time, it was the largest experimental motor ever built in Latin America.
 """
 
-from machwave import (
-    formulations,
-    grain as grain_models,
-    motors,
-    simulation,
-    thrust_chamber as thrust_chamber_models,
-)
-from machwave.common.decorators import timing
-from machwave.services.plots import internal_ballistics as internal_ballistics_plots
+import machwave.common.decorators as decorators
+import machwave.models.grain as grain_models
+import machwave.models.motors as motors_models
+import machwave.models.propellants.formulations as formulations
+import machwave.models.thrust_chamber as thrust_chamber_models
+import machwave.services.plots.internal_ballistics as internal_ballistics_plots
+import machwave.simulation as simulation
 
 
-@timing
+@decorators.timing
 def main():
     propellant = formulations.solid.KNSB_NAKKA
 
@@ -63,7 +61,7 @@ def main():
         center_of_gravity_coordinate=(0.5, 0.0, 0.0),
     )
 
-    motor = motors.SolidMotor(
+    motor = motors_models.SolidMotor(
         grain=grain,
         propellant=propellant,
         thrust_chamber=thrust_chamber,

--- a/examples/olympus_montecarlo.py
+++ b/examples/olympus_montecarlo.py
@@ -1,17 +1,15 @@
-from machwave import (
-    formulations,
-    grain as grain_models,
-    montecarlo,
-    motors,
-    simulation,
-    thrust_chamber as thrust_chamber_models,
-)
-from machwave.common.decorators import timing
+import machwave.common.decorators as decorators
+import machwave.models.grain as grain_models
+import machwave.models.motors as motors_models
+import machwave.models.propellants.formulations as formulations
+import machwave.models.thrust_chamber as thrust_chamber_models
+import machwave.montecarlo as montecarlo
+import machwave.simulation as simulation
 
 MC_SAMPLES = 1000
 
 
-@timing
+@decorators.timing
 def main():
     propellant = formulations.solid.KNSB_NAKKA
 
@@ -58,7 +56,7 @@ def main():
         center_of_gravity_coordinate=(0.5, 0.0, 0.0),
     )
 
-    motor = motors.SolidMotor(
+    motor = motors_models.SolidMotor(
         grain=grain,
         propellant=propellant,
         thrust_chamber=thrust_chamber,

--- a/examples/rocketpy_srm_simulation.py
+++ b/examples/rocketpy_srm_simulation.py
@@ -8,15 +8,13 @@ This example demonstrates how to:
 3. Run a complete 6DOF flight simulation using RocketPy
 """
 
-from machwave import (
-    formulations,
-    grain as grain_models,
-    motors,
-    simulation,
-    thrust_chamber as thrust_chamber_models,
-)
-from machwave.adapters.rocketpy import RocketPySolidMotorAdapter
-from machwave.common import decorators
+import machwave.adapters.rocketpy as rocketpy_adapters
+import machwave.common.decorators as decorators
+import machwave.models.grain as grain_models
+import machwave.models.motors as motors_models
+import machwave.models.propellants.formulations as formulations
+import machwave.models.thrust_chamber as thrust_chamber_models
+import machwave.simulation as simulation
 from rocketpy import Environment, Flight, Rocket
 
 
@@ -57,7 +55,7 @@ def main():
         center_of_gravity_coordinate=(0.35, 0.0, 0.0),
     )
 
-    motor = motors.SolidMotor(
+    motor = motors_models.SolidMotor(
         grain=grain,
         propellant=propellant,
         thrust_chamber=thrust_chamber,
@@ -77,7 +75,9 @@ def main():
     result.report()
 
     # 3. Create RocketPy adapter
-    rocketpy_motor = RocketPySolidMotorAdapter(motor=motor, simulation_result=result)
+    rocketpy_motor = rocketpy_adapters.RocketPySolidMotorAdapter(
+        motor=motor, simulation_result=result
+    )
     print(f"  - Total impulse: {rocketpy_motor.total_impulse:.1f} N·s")
     print(f"  - Average thrust: {rocketpy_motor.average_thrust:.1f} N")
     print(f"  - Max thrust: {rocketpy_motor.max_thrust:.1f} N")

--- a/examples/solid_propellant_composition.py
+++ b/examples/solid_propellant_composition.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from machwave.common.decorators import timing
-from machwave.models.propellants import categories as propellant_categories
-from machwave.models.propellants import components as propellant_components
+import machwave.common.decorators as decorators
+import machwave.models.propellants.categories as propellant_categories
+import machwave.models.propellants.components as propellant_components
 
 
-@timing
+@decorators.timing
 def main() -> None:
     potassium_nitrate = propellant_components.PropellantComponent(
         name="Potassium Nitrate",

--- a/machwave/adapters/rocketpy/solid_motor.py
+++ b/machwave/adapters/rocketpy/solid_motor.py
@@ -2,17 +2,17 @@
 
 import typing
 
-from machwave.adapters.rocketpy.base import RocketPyMotorAdapter
-from machwave.models.grain.geometries import BatesSegment
+import machwave.adapters.rocketpy.base as rocketpy_base
+import machwave.models.grain.geometries as grain_geometries
 
 if typing.TYPE_CHECKING:
-    from machwave.models.motors import SolidMotor
-    from machwave.simulation.solid.results import (
-        SolidSimulationResult,  # noqa: F401
-    )
+    import machwave.models.motors as motors_models  # noqa: F401
+    import machwave.simulation.solid.results as solid_results  # noqa: F401
 
 
-class RocketPySolidMotorAdapter(RocketPyMotorAdapter["SolidSimulationResult"]):
+class RocketPySolidMotorAdapter(
+    rocketpy_base.RocketPyMotorAdapter["solid_results.SolidSimulationResult"]
+):
     """Adapter to use a simulation result and motor as a RocketPy SolidMotor."""
 
     _rocketpy_motor_class = "SolidMotor"
@@ -29,7 +29,7 @@ class RocketPySolidMotorAdapter(RocketPyMotorAdapter["SolidSimulationResult"]):
         """
         base_attrs = super()._get_rocketpy_attributes()
 
-        motor = typing.cast("SolidMotor", self.motor)
+        motor = typing.cast("motors_models.SolidMotor", self.motor)
         grain = motor.grain
 
         if not grain.segments:
@@ -47,7 +47,7 @@ class RocketPySolidMotorAdapter(RocketPyMotorAdapter["SolidSimulationResult"]):
         first_segment = grain.segments[0]
 
         # RocketPy's SolidMotor only supports a BATES geometry
-        if not isinstance(first_segment, BatesSegment):
+        if not isinstance(first_segment, grain_geometries.BatesSegment):
             raise ValueError(
                 "RocketPy SolidMotor only supports BATES grain geometry, got "
                 f"{type(first_segment).__name__}"

--- a/machwave/core/compressible_flow/losses.py
+++ b/machwave/core/compressible_flow/losses.py
@@ -13,7 +13,7 @@ References:
 
 import numpy as np
 
-from machwave.common import decorators
+import machwave.common.decorators as decorators
 
 KINETICS_LOSS_PRESSURE_THRESHOLD_PSI = 200  # psi
 

--- a/machwave/models/feed_systems/base.py
+++ b/machwave/models/feed_systems/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from machwave.models.feed_systems.tanks import Tank
+import machwave.models.feed_systems.tanks as tanks
 
 
 class FeedSystem(ABC):
@@ -16,7 +16,7 @@ class FeedSystem(ABC):
     schedule mass flow from pump curves or other internal logic can ignore them.
     """
 
-    def __init__(self, fuel_tank: Tank, oxidizer_tank: Tank):
+    def __init__(self, fuel_tank: tanks.Tank, oxidizer_tank: tanks.Tank):
         """
         Initialize the FeedSystem with associated tank objects.
 

--- a/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
+++ b/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
@@ -1,9 +1,9 @@
-from machwave.core.incompressible_flow import get_mass_flow_orifice
-from machwave.models.feed_systems.base import FeedSystem
-from machwave.models.feed_systems.tanks import Tank
+import machwave.core.incompressible_flow as incompressible_flow
+import machwave.models.feed_systems.base as feed_system_base
+import machwave.models.feed_systems.tanks as tanks
 
 
-class StackedTankPressureFedFeedSystem(FeedSystem):
+class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
     """
     Represents a bipropellant liquid rocket engine feed system with stacked tanks.
 
@@ -17,8 +17,8 @@ class StackedTankPressureFedFeedSystem(FeedSystem):
         oxidizer_line_length: float,
         fuel_line_diameter: float,
         fuel_line_length: float,
-        fuel_tank: Tank,
-        oxidizer_tank: Tank,
+        fuel_tank: tanks.Tank,
+        oxidizer_tank: tanks.Tank,
         piston_loss: float = 0.0,
     ):
         """
@@ -76,7 +76,7 @@ class StackedTankPressureFedFeedSystem(FeedSystem):
         p_down = chamber_pressure
         oxidizer_density = self.oxidizer_tank.get_density()
 
-        return get_mass_flow_orifice(
+        return incompressible_flow.get_mass_flow_orifice(
             discharge_coefficient=discharge_coefficient,
             area=injector_area,
             density=oxidizer_density,
@@ -118,7 +118,7 @@ class StackedTankPressureFedFeedSystem(FeedSystem):
         p_down = chamber_pressure
         fuel_density = self.fuel_tank.get_density()
 
-        return get_mass_flow_orifice(
+        return incompressible_flow.get_mass_flow_orifice(
             discharge_coefficient=discharge_coefficient,
             area=injector_area,
             density=fuel_density,

--- a/machwave/models/grain/fmm/_2d.py
+++ b/machwave/models/grain/fmm/_2d.py
@@ -6,19 +6,16 @@ from numpy.typing import NDArray
 from scipy.interpolate import interp1d
 from scipy.signal import savgol_filter
 
-from machwave.core.geometric import get_circle_area
-from machwave.core.mechanics import (
-    get_center_of_gravity,
-    get_moment_of_inertia_tensor,
-)
-from machwave.models.grain import GrainGeometryError, GrainSegment2D
-from machwave.models.grain.base import InhibitedSurfaces
+import machwave.core.geometric as geometric
+import machwave.core.mechanics as mechanics
+import machwave.models.grain as grain
+import machwave.models.grain.base as grain_base
 
-from .base import FMMGrainSegment
-from .contours import get_contours, get_length
+from . import base as fmm_base
+from . import contours as fmm_contours
 
 
-class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
+class FMMGrainSegment2D(fmm_base.FMMGrainSegment, grain.GrainSegment2D, ABC):
     """
     Fast Marching Method (FMM) implementation for 2D grain segment.
 
@@ -31,7 +28,7 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
         self,
         length: float,
         outer_diameter: float,
-        inhibited_surfaces: InhibitedSurfaces | None = None,
+        inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
         map_dim: int = 100,
         density_ratio: float = 1.0,
     ) -> None:
@@ -84,12 +81,12 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
         Each contour is typically an `(N, 2)` array of `(row, col)` points.
         """
         map_dist = self.normalize(web_distance)
-        return get_contours(self.get_regression_map(), map_dist)
+        return fmm_contours.get_contours(self.get_regression_map(), map_dist)
 
     def get_port_area(self, web_distance: float) -> float:
         """Return the open cross-sectional port area [m^2]."""
         face_area = self.get_face_area(web_distance)
-        return get_circle_area(self.outer_diameter) - face_area
+        return geometric.get_circle_area(self.outer_diameter) - face_area
 
     def get_face_area_interp_func(self) -> Callable[[float], float]:
         """Return an interpolator mapping normalized web distance to face area [m^2]."""
@@ -162,10 +159,12 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
 
             perimeter_values = np.empty_like(distances, dtype=np.float64)
             for i, dist in enumerate(distances):
-                contours = get_contours(regression_map, float(dist))
+                contours = fmm_contours.get_contours(regression_map, float(dist))
                 perimeter_values[i] = float(
                     sum(
-                        self.map_to_length(get_length(contour, self.map_dim))
+                        self.map_to_length(
+                            fmm_contours.get_length(contour, self.map_dim)
+                        )
                         for contour in contours
                     )
                 )
@@ -214,7 +213,7 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
         contours = self.get_contours(web_distance)
         return float(
             sum(
-                self.map_to_length(get_length(contour, self.map_dim))
+                self.map_to_length(fmm_contours.get_length(contour, self.map_dim))
                 for contour in contours
             )
         )
@@ -235,7 +234,7 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
             GrainGeometryError: If web distance exceeds web thickness.
         """
         if web_distance > self.get_web_thickness():
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 "The web distance traveled is greater than the grain segment's web thickness."
             )
 
@@ -259,7 +258,7 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
         y_indices, x_indices = np.where(mask)
 
         if len(x_indices) == 0 or len(y_indices) == 0:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 "No active material found at the given web distance."
             )
 
@@ -308,7 +307,7 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
 
         z_phys = np.full_like(x_phys, axial_cog)
 
-        return get_center_of_gravity(x_phys, y_phys, z_phys)
+        return mechanics.get_center_of_gravity(x_phys, y_phys, z_phys)
 
     def get_moment_of_inertia(
         self, ideal_density: float, web_distance: float = 0.0
@@ -349,7 +348,7 @@ class FMMGrainSegment2D(FMMGrainSegment, GrainSegment2D, ABC):
         element_mass = total_mass / n_elements
 
         # Get base inertia from point masses (radial only)
-        moi = get_moment_of_inertia_tensor(x_rel, y_rel, z_rel, element_mass)
+        moi = mechanics.get_moment_of_inertia_tensor(x_rel, y_rel, z_rel, element_mass)
 
         # For 2D grain (uniform along axial direction), add axial contribution
         # For a uniform rod of length L with mass M: I_axial = M*L^2/12 (about CoG)

--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -5,19 +5,16 @@ import numpy as np
 from numpy.typing import NDArray
 from scipy.interpolate import interp1d
 
-from machwave.core.geometric import get_circle_area
-from machwave.core.mechanics import (
-    get_center_of_gravity,
-    get_moment_of_inertia_tensor,
-)
-from machwave.models.grain import GrainGeometryError, GrainSegment3D
-from machwave.models.grain.base import InhibitedSurfaces
+import machwave.core.geometric as geometric
+import machwave.core.mechanics as mechanics
+import machwave.models.grain as grain
+import machwave.models.grain.base as grain_base
 
-from .base import FMMGrainSegment
-from .contours import get_contours, get_length
+from . import base as fmm_base
+from . import contours as fmm_contours
 
 
-class FMMGrainSegment3D(FMMGrainSegment, GrainSegment3D, ABC):
+class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
     """
     Fast Marching Method (FMM) implementation for 3D grain segment.
 
@@ -31,7 +28,7 @@ class FMMGrainSegment3D(FMMGrainSegment, GrainSegment3D, ABC):
         self,
         length: float,
         outer_diameter: float,
-        inhibited_surfaces: InhibitedSurfaces | None = None,
+        inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
         map_dim: int = 100,
         density_ratio: float = 1.0,
     ) -> None:
@@ -71,7 +68,7 @@ class FMMGrainSegment3D(FMMGrainSegment, GrainSegment3D, ABC):
         z_index = 0 if z_index < 0 else (max_index if z_index > max_index else z_index)
 
         face_area = float(self.map_to_area(float(np.count_nonzero(solid[z_index]))))
-        return get_circle_area(self.outer_diameter) - face_area
+        return geometric.get_circle_area(self.outer_diameter) - face_area
 
     def get_normalized_length(self) -> int:
         return int(self.map_dim * self.length / self.outer_diameter)
@@ -142,7 +139,7 @@ class FMMGrainSegment3D(FMMGrainSegment, GrainSegment3D, ABC):
         z_index = int(round(length_normalized))
         boolean_slice_2d = boolean_3d[z_index]
 
-        return get_contours(
+        return fmm_contours.get_contours(
             boolean_slice_2d,
             map_dist,
         )
@@ -157,9 +154,9 @@ class FMMGrainSegment3D(FMMGrainSegment, GrainSegment3D, ABC):
         total = 0.0
         for z_index in range(self.get_normalized_length()):
             boolean_slice_2d = boolean_3d[z_index]
-            contours = get_contours(boolean_slice_2d, map_dist)
+            contours = fmm_contours.get_contours(boolean_slice_2d, map_dist)
             perimeter = sum(
-                self.map_to_length(get_length(contour, self.map_dim))
+                self.map_to_length(fmm_contours.get_length(contour, self.map_dim))
                 for contour in contours
             )
             total += float(perimeter) * float(length_factor)
@@ -229,7 +226,7 @@ class FMMGrainSegment3D(FMMGrainSegment, GrainSegment3D, ABC):
             GrainGeometryError: If web distance exceeds web thickness.
         """
         if web_distance > self.get_web_thickness():
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 "The web distance traveled is greater than the grain "
                 "segment's web thickness."
             )
@@ -254,7 +251,7 @@ class FMMGrainSegment3D(FMMGrainSegment, GrainSegment3D, ABC):
         z_indices, y_indices, x_indices = np.where(mask)
 
         if len(x_indices) == 0:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 "No active material found at the given web distance."
             )
 
@@ -310,7 +307,7 @@ class FMMGrainSegment3D(FMMGrainSegment, GrainSegment3D, ABC):
         y_phys = np.asarray(self.map_to_length(y_coords), dtype=np.float64)
         z_phys = np.asarray(self.map_to_length(z_coords), dtype=np.float64)
 
-        return get_center_of_gravity(x_phys, y_phys, z_phys)
+        return mechanics.get_center_of_gravity(x_phys, y_phys, z_phys)
 
     def get_moment_of_inertia(
         self, ideal_density: float, web_distance: float = 0.0
@@ -355,4 +352,4 @@ class FMMGrainSegment3D(FMMGrainSegment, GrainSegment3D, ABC):
         element_mass = element_volume * ideal_density * self.density_ratio
 
         # Use core function to compute inertia tensor
-        return get_moment_of_inertia_tensor(x_rel, y_rel, z_rel, element_mass)
+        return mechanics.get_moment_of_inertia_tensor(x_rel, y_rel, z_rel, element_mass)

--- a/machwave/models/grain/fmm/base.py
+++ b/machwave/models/grain/fmm/base.py
@@ -6,13 +6,13 @@ import skfmm
 from scipy.ndimage import binary_erosion
 from numpy.typing import NDArray
 
-from machwave.models.grain import GrainGeometryError, GrainSegment
-from machwave.models.grain.base import InhibitedSurfaces
+import machwave.models.grain as grain
+import machwave.models.grain.base as grain_base
 
 MINIMUM_MAP_DIMENSION = 100
 
 
-class FMMGrainSegment(GrainSegment, ABC):
+class FMMGrainSegment(grain.GrainSegment, ABC):
     """
     Fast Marching Method (FMM) implementation of a grain segment.
 
@@ -27,7 +27,7 @@ class FMMGrainSegment(GrainSegment, ABC):
         map_dim: int,
         length: float,
         outer_diameter: float,
-        inhibited_surfaces: InhibitedSurfaces | None = None,
+        inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -88,7 +88,7 @@ class FMMGrainSegment(GrainSegment, ABC):
         """
         super().validate()
         if not self.map_dim >= MINIMUM_MAP_DIMENSION:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Map dimension must be at least {MINIMUM_MAP_DIMENSION}, "
                 f"got {self.map_dim}"
             )

--- a/machwave/models/grain/fmm/stl.py
+++ b/machwave/models/grain/fmm/stl.py
@@ -3,12 +3,12 @@ from abc import ABC
 import numpy as np
 import trimesh
 
-from machwave.models.grain import GrainGeometryError
-from machwave.models.grain.base import InhibitedSurfaces
-from machwave.models.grain.fmm import FMMGrainSegment3D
+import machwave.models.grain as grain
+import machwave.models.grain.base as grain_base
+import machwave.models.grain.fmm as grain_fmm
 
 
-class FMMSTLGrainSegment(FMMGrainSegment3D, ABC):
+class FMMSTLGrainSegment(grain_fmm.FMMGrainSegment3D, ABC):
     """FMM grain segment loaded from an STL mesh."""
 
     def __init__(
@@ -16,7 +16,7 @@ class FMMSTLGrainSegment(FMMGrainSegment3D, ABC):
         file_path: str,
         outer_diameter: float,
         length: float,
-        inhibited_surfaces: InhibitedSurfaces | None = None,
+        inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
         map_dim: int = 50,
     ) -> None:
         """
@@ -46,7 +46,7 @@ class FMMSTLGrainSegment(FMMGrainSegment3D, ABC):
     def validate(self) -> None:
         """Validate STL grain segment geometry."""
         if not self.map_dim >= 20:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Map dimension must be at least 20 for STL grains, got {self.map_dim}"
             )
 

--- a/machwave/models/grain/geometries/bates.py
+++ b/machwave/models/grain/geometries/bates.py
@@ -1,17 +1,14 @@
 import numpy as np
 
-from machwave.core.geometric import (
-    get_circle_area,
-    get_cylinder_surface_area,
-)
-from machwave.models.grain import GrainGeometryError, GrainSegment2D
-from machwave.models.grain.base import InhibitedSurfaces
+import machwave.core.geometric as geometric
+import machwave.models.grain as grain
+import machwave.models.grain.base as grain_base
 
 
-class BatesSegment(GrainSegment2D):
+class BatesSegment(grain.GrainSegment2D):
     """BATES grain segment: cylindrical with circular central port."""
 
-    INHIBITED_SURFACES = InhibitedSurfaces(
+    INHIBITED_SURFACES = grain_base.InhibitedSurfaces(
         outer_surface=True,
         inner_surface=False,
         upper_end=False,
@@ -48,12 +45,12 @@ class BatesSegment(GrainSegment2D):
         super().validate()
 
         if not self.outer_diameter > self.core_diameter:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Outer diameter ({self.outer_diameter}) must be greater than "
                 f"core diameter ({self.core_diameter})"
             )
         if not self.core_diameter > 0:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Core diameter must be positive, got {self.core_diameter}"
             )
 
@@ -63,13 +60,13 @@ class BatesSegment(GrainSegment2D):
 
     def get_port_area(self, web_distance: float) -> float:
         """Return the port area at a given web distance [m^2]."""
-        return get_circle_area(diameter=self.get_core_diameter(web_distance))
+        return geometric.get_circle_area(diameter=self.get_core_diameter(web_distance))
 
     def get_core_area(self, web_distance: float) -> float:
         """Return the core (inner cylindrical) surface area [m^2]."""
         length = self.get_length(web_distance=web_distance)
         core_diameter = self.core_diameter + 2 * web_distance
-        return get_cylinder_surface_area(length, core_diameter)
+        return geometric.get_cylinder_surface_area(length, core_diameter)
 
     def get_face_area(self, web_distance: float) -> float:
         """Return the annular face area at a given web distance [m^2]."""

--- a/machwave/models/grain/geometries/conical.py
+++ b/machwave/models/grain/geometries/conical.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from machwave.models.grain import GrainGeometryError
-from machwave.models.grain.base import InhibitedSurfaces
-from machwave.models.grain.fmm import FMMGrainSegment3D
+import machwave.models.grain as grain
+import machwave.models.grain.base as grain_base
+import machwave.models.grain.fmm as grain_fmm
 
 
-class ConicalGrainSegment(FMMGrainSegment3D):
+class ConicalGrainSegment(grain_fmm.FMMGrainSegment3D):
     """Grain segment with a conical port tapering between two diameters."""
 
     def __init__(
@@ -14,7 +14,7 @@ class ConicalGrainSegment(FMMGrainSegment3D):
         outer_diameter: float,
         upper_core_diameter: float,
         lower_core_diameter: float,
-        inhibited_surfaces: InhibitedSurfaces | None = None,
+        inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -43,20 +43,20 @@ class ConicalGrainSegment(FMMGrainSegment3D):
         super().validate()
 
         if not self.upper_core_diameter > 0:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Upper core diameter must be positive, got {self.upper_core_diameter}"
             )
         if not self.upper_core_diameter < self.outer_diameter:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Upper core diameter ({self.upper_core_diameter}) must be less than "
                 f"outer diameter ({self.outer_diameter})"
             )
         if not self.lower_core_diameter > 0:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Lower core diameter must be positive, got {self.lower_core_diameter}"
             )
         if not self.lower_core_diameter < self.outer_diameter:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Lower core diameter ({self.lower_core_diameter}) must be less than "
                 f"outer diameter ({self.outer_diameter})"
             )

--- a/machwave/models/grain/geometries/d_grain.py
+++ b/machwave/models/grain/geometries/d_grain.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from machwave.models.grain import GrainGeometryError
-from machwave.models.grain.base import InhibitedSurfaces
-from machwave.models.grain.fmm import FMMGrainSegment2D
+import machwave.models.grain as grain
+import machwave.models.grain.base as grain_base
+import machwave.models.grain.fmm as grain_fmm
 
 
-class DGrainSegment(FMMGrainSegment2D):
+class DGrainSegment(grain_fmm.FMMGrainSegment2D):
     """D-shaped grain segment with a single offset planar slot."""
 
     def __init__(
@@ -13,7 +13,7 @@ class DGrainSegment(FMMGrainSegment2D):
         length: float,
         outer_diameter: float,
         slot_offset: float,
-        inhibited_surfaces: InhibitedSurfaces | None = None,
+        inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -40,12 +40,12 @@ class DGrainSegment(FMMGrainSegment2D):
         super().validate()
 
         if not self.slot_offset >= 0:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Slot offset must be non-negative, got {self.slot_offset}"
             )
         max_slot_offset = self.outer_diameter / 2
         if not self.slot_offset < max_slot_offset:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Slot offset ({self.slot_offset}) must be less than "
                 f"half the outer diameter ({max_slot_offset})"
             )

--- a/machwave/models/grain/geometries/multi_port.py
+++ b/machwave/models/grain/geometries/multi_port.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from machwave.models.grain import GrainGeometryError
-from machwave.models.grain.base import InhibitedSurfaces
-from machwave.models.grain.fmm import FMMGrainSegment2D
+import machwave.models.grain as grain
+import machwave.models.grain.base as grain_base
+import machwave.models.grain.fmm as grain_fmm
 
 
-class MultiPortGrainSegment(FMMGrainSegment2D):
+class MultiPortGrainSegment(grain_fmm.FMMGrainSegment2D):
     """Grain segment with multiple circular ports arranged radially."""
 
     def __init__(
@@ -15,7 +15,7 @@ class MultiPortGrainSegment(FMMGrainSegment2D):
         port_diameter: float,
         port_radial_count: float,
         port_level_count: float,
-        inhibited_surfaces: InhibitedSurfaces | None = None,
+        inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -46,22 +46,22 @@ class MultiPortGrainSegment(FMMGrainSegment2D):
         super().validate()
 
         if not self.port_diameter > 0:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Port diameter must be positive, got {self.port_diameter}"
             )
         if not self.port_level_count > 0:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Port level count must be positive, got {self.port_level_count}"
             )
         max_port_size = self.outer_diameter / 2
         total_port_size = self.port_level_count * self.port_diameter
         if not total_port_size < max_port_size:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Total port size ({total_port_size}) must be less than "
                 f"half the outer diameter ({max_port_size})"
             )
         if not self.port_radial_count > 0:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Port radial count must be positive, got {self.port_radial_count}"
             )
 

--- a/machwave/models/grain/geometries/rod_and_tube.py
+++ b/machwave/models/grain/geometries/rod_and_tube.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from machwave.models.grain import GrainGeometryError
-from machwave.models.grain.base import InhibitedSurfaces
-from machwave.models.grain.fmm import FMMGrainSegment2D
+import machwave.models.grain as grain
+import machwave.models.grain.base as grain_base
+import machwave.models.grain.fmm as grain_fmm
 
 
-class RodAndTubeGrainSegment(FMMGrainSegment2D):
+class RodAndTubeGrainSegment(grain_fmm.FMMGrainSegment2D):
     """Rod-and-tube grain segment: central rod inside a concentric tube."""
 
     def __init__(
@@ -14,7 +14,7 @@ class RodAndTubeGrainSegment(FMMGrainSegment2D):
         outer_diameter: float,
         rod_outer_diameter: float,
         tube_inner_diameter: float,
-        inhibited_surfaces: InhibitedSurfaces | None = None,
+        inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -43,16 +43,16 @@ class RodAndTubeGrainSegment(FMMGrainSegment2D):
         super().validate()
 
         if not self.rod_outer_diameter > 0:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Rod outer diameter must be positive, got {self.rod_outer_diameter}"
             )
         if not self.tube_inner_diameter > self.rod_outer_diameter:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Tube inner diameter ({self.tube_inner_diameter}) must be greater than "
                 f"rod outer diameter ({self.rod_outer_diameter})"
             )
         if not self.tube_inner_diameter < self.outer_diameter:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Tube inner diameter ({self.tube_inner_diameter}) must be less than "
                 f"outer diameter ({self.outer_diameter})"
             )

--- a/machwave/models/grain/geometries/star.py
+++ b/machwave/models/grain/geometries/star.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from machwave.models.grain import GrainGeometryError
-from machwave.models.grain.base import InhibitedSurfaces
-from machwave.models.grain.fmm import FMMGrainSegment2D
+import machwave.models.grain as grain
+import machwave.models.grain.base as grain_base
+import machwave.models.grain.fmm as grain_fmm
 
 
-class StarGrainSegment(FMMGrainSegment2D):
+class StarGrainSegment(grain_fmm.FMMGrainSegment2D):
     """Star grain segment with a radial point pattern as the port."""
 
     def __init__(
@@ -15,7 +15,7 @@ class StarGrainSegment(FMMGrainSegment2D):
         number_of_points: int,
         point_length: float,
         point_width: float,
-        inhibited_surfaces: InhibitedSurfaces | None = None,
+        inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -46,23 +46,23 @@ class StarGrainSegment(FMMGrainSegment2D):
         super().validate()
 
         if not self.number_of_points > 0:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Number of points must be positive, got {self.number_of_points}"
             )
         if not self.number_of_points < 12:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Number of points must be less than 12, got {self.number_of_points}"
             )
         if not isinstance(self.number_of_points, int):
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Number of points must be an integer, got {type(self.number_of_points).__name__}"
             )
         if not self.point_length > 0:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Point length must be positive, got {self.point_length}"
             )
         if not self.point_width > 0:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Point width must be positive, got {self.point_width}"
             )
 

--- a/machwave/models/grain/geometries/wagon_wheel.py
+++ b/machwave/models/grain/geometries/wagon_wheel.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from machwave.models.grain import GrainGeometryError
-from machwave.models.grain.base import InhibitedSurfaces
-from machwave.models.grain.fmm import FMMGrainSegment2D
+import machwave.models.grain as grain
+import machwave.models.grain.base as grain_base
+import machwave.models.grain.fmm as grain_fmm
 
 
-class WagonWheelGrainSegment(FMMGrainSegment2D):
+class WagonWheelGrainSegment(grain_fmm.FMMGrainSegment2D):
     """Wagon-wheel grain segment with a central core and radial spoke ports."""
 
     def __init__(
@@ -17,7 +17,7 @@ class WagonWheelGrainSegment(FMMGrainSegment2D):
         port_inner_diameter: float,
         port_outer_diameter: float,
         port_angular_width: float,
-        inhibited_surfaces: InhibitedSurfaces | None = None,
+        inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -52,38 +52,38 @@ class WagonWheelGrainSegment(FMMGrainSegment2D):
         super().validate()
 
         if not self.number_of_ports > 0:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Number of ports must be positive, got {self.number_of_ports}"
             )
         if not self.number_of_ports < 12:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Number of ports must be less than 12, got {self.number_of_ports}"
             )
         if not self.number_of_ports % 2 == 0:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Number of ports must be even, got {self.number_of_ports}"
             )
         if not isinstance(self.number_of_ports, int):
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Number of ports must be an integer, got {type(self.number_of_ports).__name__}"
             )
         if not self.port_inner_diameter > self.core_diameter:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Port inner diameter ({self.port_inner_diameter}) must be greater than "
                 f"core diameter ({self.core_diameter})"
             )
         if not self.port_outer_diameter > self.port_inner_diameter:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Port outer diameter ({self.port_outer_diameter}) must be greater than "
                 f"port inner diameter ({self.port_inner_diameter})"
             )
         if not self.port_angular_width > 0:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Port angular width must be positive, got {self.port_angular_width}"
             )
         max_angular_width = 360 / self.number_of_ports
         if not self.port_angular_width < max_angular_width:
-            raise GrainGeometryError(
+            raise grain.GrainGeometryError(
                 f"Port angular width ({self.port_angular_width}) must be less than "
                 f"{max_angular_width} (360 / {self.number_of_ports})"
             )

--- a/machwave/models/motors/base.py
+++ b/machwave/models/motors/base.py
@@ -3,14 +3,12 @@ from typing import Generic, TypeVar
 
 import numpy as np
 
-from machwave.core.compressible_flow.nozzle import (
-    get_thrust_from_thrust_coefficient,
-)
-from machwave.models.propellants import Propellant
-from machwave.models.thrust_chamber import ThrustChamber
+import machwave.core.compressible_flow.nozzle as nozzle_core
+import machwave.models.propellants as propellants
+import machwave.models.thrust_chamber as thrust_chamber_models
 
-P = TypeVar("P", bound=Propellant)
-T = TypeVar("T", bound=ThrustChamber)
+P = TypeVar("P", bound=propellants.Propellant)
+T = TypeVar("T", bound=thrust_chamber_models.ThrustChamber)
 
 
 class Motor(Generic[P, T], ABC):
@@ -74,7 +72,7 @@ class Motor(Generic[P, T], ABC):
         Returns:
             Instantaneous thrust [N].
         """
-        return get_thrust_from_thrust_coefficient(
+        return nozzle_core.get_thrust_from_thrust_coefficient(
             cf,
             chamber_pressure,
             self.thrust_chamber.nozzle.get_throat_area(),

--- a/machwave/models/motors/liquid.py
+++ b/machwave/models/motors/liquid.py
@@ -1,20 +1,24 @@
 import numpy as np
 
-from machwave.models.feed_systems.base import FeedSystem
-from machwave.models.propellants import BiliquidPropellant
-from machwave.models.thrust_chamber import LiquidEngineThrustChamber
+import machwave.models.feed_systems.base as feed_system_base
+import machwave.models.propellants as propellants
+import machwave.models.thrust_chamber as thrust_chamber_models
 
-from .base import Motor
+from . import base as motor_base
 
 
-class LiquidEngine(Motor[BiliquidPropellant, LiquidEngineThrustChamber]):
+class LiquidEngine(
+    motor_base.Motor[
+        propellants.BiliquidPropellant, thrust_chamber_models.LiquidEngineThrustChamber
+    ]
+):
     """Liquid rocket engine with bi-liquid propellant and a feed system."""
 
     def __init__(
         self,
-        propellant: BiliquidPropellant,
-        thrust_chamber: LiquidEngineThrustChamber,
-        feed_system: FeedSystem,
+        propellant: propellants.BiliquidPropellant,
+        thrust_chamber: thrust_chamber_models.LiquidEngineThrustChamber,
+        feed_system: feed_system_base.FeedSystem,
         oxidizer_tank_cog: float | None = None,
         fuel_tank_cog: float | None = None,
     ) -> None:

--- a/machwave/models/propellants/categories/base.py
+++ b/machwave/models/propellants/categories/base.py
@@ -4,10 +4,10 @@ import abc
 import enum
 import functools
 
-from machwave.services import cea as cea_service
+import machwave.services.cea as cea_service
 
-from ..components import PropellantComponent
-from ..properties import ThermochemicalProperties
+from .. import components as propellant_components
+from .. import properties as propellant_properties
 
 
 class PropellantValidationError(Exception):
@@ -38,7 +38,7 @@ class Propellant(abc.ABC):
     def __init__(
         self,
         name: str,
-        components: list[PropellantComponent] | None = None,
+        components: list[propellant_components.PropellantComponent] | None = None,
         combustion_efficiency: float = 0.95,
     ):
         """
@@ -89,7 +89,7 @@ class Propellant(abc.ABC):
         chamber_pressure: float,
         expansion_ratio: float = 8.0,
         mixture_ratio: float | None = None,
-    ) -> ThermochemicalProperties:
+    ) -> propellant_properties.ThermochemicalProperties:
         """
         Evaluate thermochemical properties at given conditions.
 
@@ -134,7 +134,7 @@ class Propellant(abc.ABC):
             mixture_ratio=mixture_ratio,
         )
 
-        properties = ThermochemicalProperties(
+        properties = propellant_properties.ThermochemicalProperties(
             k_chamber=k_chamber,
             k_exhaust=k_exhaust,
             adiabatic_flame_temperature=adiabatic_flame_temperature,

--- a/machwave/models/propellants/categories/biliquid.py
+++ b/machwave/models/propellants/categories/biliquid.py
@@ -1,23 +1,23 @@
 """Liquid propellant categories (biliquid)."""
 
-from machwave.services.cea import create_cea_service
+import machwave.services.cea as cea_service
 
-from ..components import ComponentRole, PropellantComponent
-from ..properties import ThermochemicalProperties
-from .base import MixtureType, Propellant, PropellantValidationError
+from .. import components as propellant_components
+from .. import properties as propellant_properties
+from . import base as propellant_base
 
 
-class BiliquidPropellant(Propellant):
+class BiliquidPropellant(propellant_base.Propellant):
     """Biliquid propellant with separate oxidizer and fuel."""
 
-    mixture_type = MixtureType.BILIQUID
+    mixture_type = propellant_base.MixtureType.BILIQUID
 
     def __init__(
         self,
         name: str,
-        components: list[PropellantComponent] | None = None,
+        components: list[propellant_components.PropellantComponent] | None = None,
         combustion_efficiency: float = 0.95,
-        properties: ThermochemicalProperties | None = None,
+        properties: propellant_properties.ThermochemicalProperties | None = None,
         oxidizer_to_fuel_ratio: float | None = None,
     ):
         """
@@ -51,28 +51,28 @@ class BiliquidPropellant(Propellant):
             PropellantValidationError: If validation fails.
         """
         if not self.components or len(self.components) != 2:
-            raise PropellantValidationError(
+            raise propellant_base.PropellantValidationError(
                 f"Biliquid propellant '{self.name}' requires exactly two components"
             )
 
         _ = self._get_fuel()  # check fuel
         _ = self._get_oxidizer()  # check oxidizer
 
-    def _get_fuel(self) -> PropellantComponent:
+    def _get_fuel(self) -> propellant_components.PropellantComponent:
         """Get the fuel component."""
         for c in self.components:
-            if c.role == ComponentRole.FUEL:
+            if c.role == propellant_components.ComponentRole.FUEL:
                 return c
-        raise PropellantValidationError(
+        raise propellant_base.PropellantValidationError(
             f"Biliquid propellant '{self.name}' has no fuel component"
         )
 
-    def _get_oxidizer(self) -> PropellantComponent:
+    def _get_oxidizer(self) -> propellant_components.PropellantComponent:
         """Get the oxidizer component."""
         for c in self.components:
-            if c.role == ComponentRole.OXIDIZER:
+            if c.role == propellant_components.ComponentRole.OXIDIZER:
                 return c
-        raise PropellantValidationError(
+        raise propellant_base.PropellantValidationError(
             f"Biliquid propellant '{self.name}' has no oxidizer component"
         )
 
@@ -86,7 +86,7 @@ class BiliquidPropellant(Propellant):
         fuel = self._get_fuel()
         oxidizer = self._get_oxidizer()
 
-        return create_cea_service(
+        return cea_service.create_cea_service(
             oxidizer_name=oxidizer.name,
             fuel_name=fuel.name,
             oxidizer_to_fuel_ratio=self.oxidizer_to_fuel_ratio,

--- a/machwave/models/propellants/categories/solid.py
+++ b/machwave/models/propellants/categories/solid.py
@@ -1,14 +1,10 @@
 """Solid propellant category."""
 
-from machwave.services.cea import (
-    create_cea_service,
-    generate_card_string,
-    normalize_custom_propellant_name,
-)
+import machwave.services.cea as cea_service
 
-from ..components import ComponentRole, PropellantComponent
-from ..properties import ThermochemicalProperties
-from .base import MixtureType, Propellant, PropellantValidationError
+from .. import components as propellant_components
+from .. import properties as propellant_properties
+from . import base as propellant_base
 
 MASS_FRACTION_SUM_TOLERANCE = 1e-6
 
@@ -29,18 +25,18 @@ class BurnRateOutOfBoundsError(Exception):
         )
 
 
-class SolidPropellant(Propellant):
+class SolidPropellant(propellant_base.Propellant):
     """Solid propellant with burn rate model."""
 
-    mixture_type = MixtureType.SOLID
+    mixture_type = propellant_base.MixtureType.SOLID
 
     def __init__(
         self,
         name: str,
-        components: list[PropellantComponent] | None = None,
+        components: list[propellant_components.PropellantComponent] | None = None,
         mass_fractions: list[float] | None = None,
         combustion_efficiency: float = 0.95,
-        properties: ThermochemicalProperties | None = None,
+        properties: propellant_properties.ThermochemicalProperties | None = None,
         burn_rate_map: list[dict[str, float | int]] | None = None,
     ):
         """
@@ -66,7 +62,7 @@ class SolidPropellant(Propellant):
         self.mass_fractions = mass_fractions if mass_fractions is not None else []
 
     @property
-    def properties(self) -> ThermochemicalProperties | None:
+    def properties(self) -> propellant_properties.ThermochemicalProperties | None:
         """Expose pre-defined thermochemical properties when present."""
         return self._properties
 
@@ -80,43 +76,48 @@ class SolidPropellant(Propellant):
         # Allow empty components if properties are pre-defined (for formulations)
         if not self.components:
             if self._properties is None:
-                raise PropellantValidationError(
+                raise propellant_base.PropellantValidationError(
                     f"Solid propellant '{self.name}' has no components or pre-defined "
                     "properties"
                 )
             return
 
         if not self.mass_fractions:
-            raise PropellantValidationError(
+            raise propellant_base.PropellantValidationError(
                 f"Solid propellant '{self.name}' requires mass_fractions for its "
                 "components"
             )
         if len(self.mass_fractions) != len(self.components):
-            raise PropellantValidationError(
+            raise propellant_base.PropellantValidationError(
                 f"Solid propellant '{self.name}' mass_fractions length must match "
                 "components length"
             )
         if any(mf < 0 for mf in self.mass_fractions):
-            raise PropellantValidationError(
+            raise propellant_base.PropellantValidationError(
                 f"Solid propellant '{self.name}' mass_fractions must be non-negative"
             )
         mf_sum = sum(self.mass_fractions)
         if abs(mf_sum - 1.0) > MASS_FRACTION_SUM_TOLERANCE:
-            raise PropellantValidationError(
+            raise propellant_base.PropellantValidationError(
                 f"Solid propellant '{self.name}' mass_fractions must sum to 1.0 (got "
                 f"{mf_sum:.6f})"
             )
 
-        has_oxidizer = any(c.role == ComponentRole.OXIDIZER for c in self.components)
-        has_fuel = any(c.role == ComponentRole.FUEL for c in self.components)
+        has_oxidizer = any(
+            c.role == propellant_components.ComponentRole.OXIDIZER
+            for c in self.components
+        )
+        has_fuel = any(
+            c.role == propellant_components.ComponentRole.FUEL for c in self.components
+        )
 
         if not has_oxidizer:
-            raise PropellantValidationError(
+            raise propellant_base.PropellantValidationError(
                 f"Solid propellant '{self.name}' requires at least one oxidizer "
                 "component"
             )
         if not has_fuel:
-            raise PropellantValidationError(
+            raise propellant_base.PropellantValidationError(
                 f"Solid propellant '{self.name}' requires at least one fuel component"
             )
 
@@ -133,13 +134,13 @@ class SolidPropellant(Propellant):
                 comp.to_cea_dict(weight_percent=mf * 100.0)
                 for comp, mf in zip(self.components, self.mass_fractions)
             ]
-            card_string = generate_card_string(components_data)
-            return create_cea_service(
-                propellant_name=normalize_custom_propellant_name(self.name),
+            card_string = cea_service.generate_card_string(components_data)
+            return cea_service.create_cea_service(
+                propellant_name=cea_service.normalize_custom_propellant_name(self.name),
                 card_string=card_string,
             )
         else:
-            raise PropellantValidationError(
+            raise propellant_base.PropellantValidationError(
                 f"Cannot create thermochemical service without components for "
                 f"propellant '{self.name}'"
             )
@@ -149,7 +150,7 @@ class SolidPropellant(Propellant):
         chamber_pressure: float,
         expansion_ratio: float = 8.0,
         mixture_ratio: float | None = None,
-    ) -> ThermochemicalProperties:
+    ) -> propellant_properties.ThermochemicalProperties:
         """
         Evaluate thermochemical properties.
 
@@ -204,7 +205,7 @@ class SolidPropellant(Propellant):
             PropellantValidationError: If the burn rate model is not defined.
         """
         if not self.burn_rate_map:
-            raise PropellantValidationError(
+            raise propellant_base.PropellantValidationError(
                 f"Burn rate model not defined for propellant '{self.name}'"
             )
 

--- a/machwave/models/propellants/components.py
+++ b/machwave/models/propellants/components.py
@@ -7,10 +7,7 @@ Provides classes representing the role and properties of each component.
 import dataclasses
 import enum
 
-from machwave.core.conversions import (
-    convert_joules_per_mol_to_cal_per_mol,
-    convert_kgm3_to_gcc,
-)
+import machwave.core.conversions as conversions
 
 
 class ComponentRole(enum.StrEnum):
@@ -53,8 +50,10 @@ class PropellantComponent:
             CEA format with name, formula, weight_percent,
             heat_of_formation (cal/mol), temperature [K], and density [g/cc].
         """
-        heat_of_formation_cal = convert_joules_per_mol_to_cal_per_mol(self.enthalpy)
-        density_gcc = convert_kgm3_to_gcc(self.density)
+        heat_of_formation_cal = conversions.convert_joules_per_mol_to_cal_per_mol(
+            self.enthalpy
+        )
+        density_gcc = conversions.convert_kgm3_to_gcc(self.density)
 
         return {
             "name": self.name,

--- a/machwave/models/thrust_chamber/base.py
+++ b/machwave/models/thrust_chamber/base.py
@@ -2,11 +2,9 @@ import abc
 
 import numpy as np
 
-from machwave.models.thrust_chamber.combustion_chamber import (
-    CombustionChamber,
-)
-from machwave.models.thrust_chamber.injector import BipropellantInjector
-from machwave.models.thrust_chamber.nozzle import Nozzle
+import machwave.models.thrust_chamber.combustion_chamber as combustion_chamber_models
+import machwave.models.thrust_chamber.injector as injector_models
+import machwave.models.thrust_chamber.nozzle as nozzle_models
 
 
 class ThrustChamber(abc.ABC):
@@ -14,8 +12,8 @@ class ThrustChamber(abc.ABC):
 
     def __init__(
         self,
-        nozzle: Nozzle,
-        combustion_chamber: CombustionChamber,
+        nozzle: nozzle_models.Nozzle,
+        combustion_chamber: combustion_chamber_models.CombustionChamber,
         dry_mass: float,
         center_of_gravity_coordinate: tuple[float, float, float] | None = None,
     ):
@@ -46,8 +44,8 @@ class SolidMotorThrustChamber(ThrustChamber):
 
     def __init__(
         self,
-        nozzle: Nozzle,
-        combustion_chamber: CombustionChamber,
+        nozzle: nozzle_models.Nozzle,
+        combustion_chamber: combustion_chamber_models.CombustionChamber,
         dry_mass: float,
         nozzle_exit_to_grain_port_distance: float,
         center_of_gravity_coordinate: tuple[float, float, float] | None = None,
@@ -77,9 +75,9 @@ class LiquidEngineThrustChamber(ThrustChamber):
 
     def __init__(
         self,
-        nozzle: Nozzle,
-        injector: BipropellantInjector,
-        combustion_chamber: CombustionChamber,
+        nozzle: nozzle_models.Nozzle,
+        injector: injector_models.BipropellantInjector,
+        combustion_chamber: combustion_chamber_models.CombustionChamber,
         dry_mass: float,
         center_of_gravity_coordinate: tuple[float, float, float] | None = None,
     ):

--- a/machwave/models/thrust_chamber/nozzle.py
+++ b/machwave/models/thrust_chamber/nozzle.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from machwave.core.geometric import get_circle_area
+import machwave.core.geometric as geometric
 
 
 class Nozzle:
@@ -55,4 +55,4 @@ class Nozzle:
 
     def get_throat_area(self) -> float:
         """Return the nozzle throat area [m^2]."""
-        return get_circle_area(self.throat_diameter)
+        return geometric.get_circle_area(self.throat_diameter)

--- a/machwave/montecarlo/base.py
+++ b/machwave/montecarlo/base.py
@@ -6,10 +6,10 @@ from dataclasses import dataclass
 import numpy as np
 import scipy.stats as scipy_stats
 
-from machwave.common.objects import get_object_dict
-from machwave.montecarlo import random
-from machwave.services.plots import montecarlo as plot_service
-from machwave.simulation import InternalBallisticsSimulation
+import machwave.common.objects as common_objects
+import machwave.montecarlo.random as random
+import machwave.services.plots.montecarlo as plot_service
+import machwave.simulation as machwave_simulation
 
 SEARCH_TREE_DEPTH_LIMIT = 20
 
@@ -59,7 +59,7 @@ class MonteCarloSimulation:
         self,
         parameters: list[typing.Any],
         number_of_scenarios: int,
-        simulation: type[InternalBallisticsSimulation],
+        simulation: type[machwave_simulation.InternalBallisticsSimulation],
     ) -> None:
         """
         Initialize a Monte Carlo driver.
@@ -106,7 +106,7 @@ class MonteCarloSimulation:
         """
         parameter_uuid = uuid.uuid4()
         self._object_store[parameter_uuid] = parameter
-        search_tree = {parameter_uuid: get_object_dict(parameter)}
+        search_tree = {parameter_uuid: common_objects.get_object_dict(parameter)}
 
         i = 0
         while search_tree and i < SEARCH_TREE_DEPTH_LIMIT:
@@ -124,11 +124,15 @@ class MonteCarloSimulation:
                             if isinstance(item, dict):
                                 continue
                             self._object_store[object_uuid] = item
-                            new_search_tree[object_uuid] = get_object_dict(item)
+                            new_search_tree[object_uuid] = (
+                                common_objects.get_object_dict(item)
+                            )
                     else:
                         object_uuid = uuid.uuid4()
                         self._object_store[object_uuid] = attr
-                        new_search_tree[object_uuid] = get_object_dict(attr)
+                        new_search_tree[object_uuid] = common_objects.get_object_dict(
+                            attr
+                        )
 
             search_tree = new_search_tree
 

--- a/machwave/services/cea.py
+++ b/machwave/services/cea.py
@@ -10,11 +10,7 @@ from rocketcea.cea_obj import (
     add_new_propellant,
 )
 
-from machwave.core.conversions import (
-    convert_lbft3_to_kgm3,
-    convert_pa_to_psi,
-    convert_rankine_to_kelvin,
-)
+import machwave.core.conversions as conversions
 
 
 def normalize_custom_propellant_name(name: str) -> str:
@@ -183,13 +179,13 @@ class RocketCEAService:
         self, chamber_pressure: float, mixture_ratio: float | None = None
     ) -> float:
         """Get adiabatic flame temperature [K]."""
-        chamber_pressure_psi = convert_pa_to_psi(chamber_pressure)
+        chamber_pressure_psi = conversions.convert_pa_to_psi(chamber_pressure)
         mr = self._resolve_mixture_ratio(mixture_ratio)
         if mr is not None:
             temp_rankine = self.cea_obj.get_Tcomb(Pc=chamber_pressure_psi, MR=mr)
         else:
             temp_rankine = self.cea_obj.get_Tcomb(Pc=chamber_pressure_psi)
-        return convert_rankine_to_kelvin(temp_rankine)
+        return conversions.convert_rankine_to_kelvin(temp_rankine)
 
     def get_chamber_properties(
         self,
@@ -198,7 +194,7 @@ class RocketCEAService:
         mixture_ratio: float | None = None,
     ) -> tuple[float, float]:
         """Get chamber molecular weight [kg/mol] and isentropic exponent."""
-        chamber_pressure_psi = convert_pa_to_psi(chamber_pressure)
+        chamber_pressure_psi = conversions.convert_pa_to_psi(chamber_pressure)
         mr = self._resolve_mixture_ratio(mixture_ratio)
         if mr is not None:
             mw_g, k = self.cea_obj.get_Chamber_MolWt_gamma(
@@ -219,7 +215,7 @@ class RocketCEAService:
         mixture_ratio: float | None = None,
     ) -> tuple[float, float]:
         """Get exhaust molecular weight [kg/mol] and isentropic exponent (frozen flow)."""
-        chamber_pressure_psi = convert_pa_to_psi(chamber_pressure)
+        chamber_pressure_psi = conversions.convert_pa_to_psi(chamber_pressure)
         mr = self._resolve_mixture_ratio(mixture_ratio)
 
         if mr is not None:
@@ -270,7 +266,7 @@ class RocketCEAService:
         mixture_ratio: float | None = None,
     ) -> tuple[float, float]:
         """Get specific impulse [s]: (frozen, shifting)."""
-        chamber_pressure_psi = convert_pa_to_psi(chamber_pressure)
+        chamber_pressure_psi = conversions.convert_pa_to_psi(chamber_pressure)
         mr = self._resolve_mixture_ratio(mixture_ratio)
 
         if mr is not None:
@@ -302,7 +298,7 @@ class RocketCEAService:
         mixture_ratio: float | None = None,
     ) -> tuple[float, float]:
         """Get condensed phase mass fractions: (chamber, exhaust)."""
-        chamber_pressure_psi = convert_pa_to_psi(chamber_pressure)
+        chamber_pressure_psi = conversions.convert_pa_to_psi(chamber_pressure)
         mr = self._resolve_mixture_ratio(mixture_ratio)
 
         qsi_chamber = 0.0
@@ -330,6 +326,6 @@ class RocketCEAService:
         """Get tank densities [kg/m^3]: (oxidizer, fuel)."""
         densities_lb_per_ft3 = self.cea_obj.get_Densities()
         return (
-            convert_lbft3_to_kgm3(densities_lb_per_ft3[0]),
-            convert_lbft3_to_kgm3(densities_lb_per_ft3[1]),
+            conversions.convert_lbft3_to_kgm3(densities_lb_per_ft3[0]),
+            conversions.convert_lbft3_to_kgm3(densities_lb_per_ft3[1]),
         )

--- a/machwave/services/plots/fmm/face_map.py
+++ b/machwave/services/plots/fmm/face_map.py
@@ -2,7 +2,7 @@ import numpy as np
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
-from machwave.common.arrays import replace_array_values
+import machwave.common.arrays as common_arrays
 
 
 def _create_plot_2d_frame(
@@ -31,7 +31,7 @@ def _create_plot_2d_frame(
         ),
         go.Contour(  # burn area contour
             name="Burn front",
-            z=replace_array_values(face_map, -1, 0),
+            z=common_arrays.replace_array_values(face_map, -1, 0),
             contours=dict(
                 start=-1,
                 end=1,
@@ -47,7 +47,7 @@ def _create_plot_2d_frame(
         ),
         go.Contour(  # inhibited area contour
             name="Inhibitor",
-            z=replace_array_values(face_map, 1, 0),
+            z=common_arrays.replace_array_values(face_map, 1, 0),
             contours=dict(
                 start=-1,
                 end=1,

--- a/machwave/simulation/base.py
+++ b/machwave/simulation/base.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 
-from machwave.models.motors import LiquidEngine, Motor, SolidMotor
-from machwave.simulation.liquid.states import LiquidEngineState
-from machwave.simulation.results import SimulationResult
-from machwave.simulation.solid.states import SolidMotorState
-from machwave.simulation.states import MotorState
+import machwave.models.motors as motors
+import machwave.simulation.liquid.states as liquid_states
+import machwave.simulation.results as simulation_results
+import machwave.simulation.solid.states as solid_states
+import machwave.simulation.states as simulation_states
 
 
 @dataclass
@@ -37,7 +37,7 @@ class InternalBallisticsSimulation:
 
     def __init__(
         self,
-        motor: Motor,
+        motor: motors.Motor,
         params: InternalBallisticsSimulationParams,
     ) -> None:
         """
@@ -47,20 +47,20 @@ class InternalBallisticsSimulation:
             motor: Motor model to simulate.
             params: Simulation parameters.
         """
-        self.motor: Motor = motor
+        self.motor: motors.Motor = motor
         self.params: InternalBallisticsSimulationParams = params
 
-    def _build_motor_state(self) -> MotorState:
+    def _build_motor_state(self) -> simulation_states.MotorState:
         """Build the motor state matching the configured motor type."""
-        if isinstance(self.motor, SolidMotor):
-            return SolidMotorState(
+        if isinstance(self.motor, motors.SolidMotor):
+            return solid_states.SolidMotorState(
                 motor=self.motor,
                 igniter_pressure=self.params.igniter_pressure,
                 external_pressure=self.params.external_pressure,
                 other_losses=self.params.other_losses,
             )
-        if isinstance(self.motor, LiquidEngine):
-            return LiquidEngineState(
+        if isinstance(self.motor, motors.LiquidEngine):
+            return liquid_states.LiquidEngineState(
                 motor=self.motor,
                 igniter_pressure=self.params.igniter_pressure,
                 external_pressure=self.params.external_pressure,
@@ -68,7 +68,7 @@ class InternalBallisticsSimulation:
             )
         raise ValueError("Unsupported motor type.")
 
-    def run(self) -> SimulationResult:
+    def run(self) -> simulation_results.SimulationResult:
         """Run the simulation to thrust termination and return its result."""
         motor_state = self._build_motor_state()
 

--- a/machwave/simulation/liquid/results.py
+++ b/machwave/simulation/liquid/results.py
@@ -5,26 +5,30 @@ from typing import IO, TYPE_CHECKING, Any
 
 import numpy as np
 
-from machwave.simulation.results import SimulationResult, SimulationResultArray
+import machwave.simulation.results as simulation_results
 
 if TYPE_CHECKING:
-    from machwave.simulation.liquid.states import LiquidEngineState
+    import machwave.simulation.liquid.states as liquid_states
 
 
 @dataclass(frozen=True, kw_only=True)
-class LiquidSimulationResult(SimulationResult["LiquidEngineState"]):
+class LiquidSimulationResult(
+    simulation_results.SimulationResult["liquid_states.LiquidEngineState"]
+):
     """Simulation result for a liquid engine run."""
 
-    oxidizer_mass: SimulationResultArray
-    fuel_mass: SimulationResultArray
-    nozzle_correction_factor: SimulationResultArray
-    fuel_tank_pressure: SimulationResultArray
-    oxidizer_tank_pressure: SimulationResultArray
+    oxidizer_mass: simulation_results.SimulationResultArray
+    fuel_mass: simulation_results.SimulationResultArray
+    nozzle_correction_factor: simulation_results.SimulationResultArray
+    fuel_tank_pressure: simulation_results.SimulationResultArray
+    oxidizer_tank_pressure: simulation_results.SimulationResultArray
     final_oxidizer_mass: float
     final_fuel_mass: float
 
     @classmethod
-    def _collect_extra_fields(cls, state: "LiquidEngineState") -> dict[str, Any]:
+    def _collect_extra_fields(
+        cls, state: "liquid_states.LiquidEngineState"
+    ) -> dict[str, Any]:
         oxidizer_mass = np.asarray(state.oxidizer_mass)
         fuel_mass = np.asarray(state.fuel_mass)
         return {

--- a/machwave/simulation/liquid/states.py
+++ b/machwave/simulation/liquid/states.py
@@ -7,15 +7,15 @@ import machwave.core.conversions as conversions
 import machwave.core.mass_balance as mass_balance
 import machwave.core.solvers.rk4 as rk4
 import machwave.models.motors as motors
+import machwave.simulation.liquid.results as liquid_results
 import machwave.simulation.states as simulation_states
-from machwave.simulation.liquid.results import LiquidSimulationResult
 
 
 class LiquidEngineState(simulation_states.MotorState):
     """State for a Liquid Rocket Engine."""
 
     motor: motors.LiquidEngine
-    result_class = LiquidSimulationResult
+    result_class = liquid_results.LiquidSimulationResult
 
     def __init__(
         self,

--- a/machwave/simulation/results.py
+++ b/machwave/simulation/results.py
@@ -9,11 +9,11 @@ import numpy as np
 import numpy.typing as npt
 
 import machwave.core.performance as performance
-from machwave.simulation.states import MotorState
+import machwave.simulation.states as simulation_states
 
 SimulationResultArray: TypeAlias = npt.NDArray[np.float64]
 
-StateT = TypeVar("StateT", bound=MotorState)
+StateT = TypeVar("StateT", bound=simulation_states.MotorState)
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/machwave/simulation/solid/results.py
+++ b/machwave/simulation/solid/results.py
@@ -6,40 +6,48 @@ from typing import IO, TYPE_CHECKING, Any
 import numpy as np
 
 import machwave.core.conversions as conversions
-from machwave.simulation.results import SimulationResult, SimulationResultArray
+import machwave.simulation.results as simulation_results
 
 if TYPE_CHECKING:
-    from machwave.simulation.solid.states import SolidMotorState
+    import machwave.simulation.solid.states as solid_states
 
 
 @dataclass(frozen=True, kw_only=True)
-class SolidSimulationResult(SimulationResult["SolidMotorState"]):
+class SolidSimulationResult(
+    simulation_results.SimulationResult["solid_states.SolidMotorState"]
+):
     """Simulation result for a solid motor run."""
 
-    free_chamber_volume: SimulationResultArray
-    web: SimulationResultArray
-    burn_area: SimulationResultArray
-    propellant_volume: SimulationResultArray
-    burn_rate: SimulationResultArray
-    divergent_loss: SimulationResultArray
-    kinetics_loss: SimulationResultArray
-    boundary_layer_loss: SimulationResultArray
-    two_phase_loss: SimulationResultArray
-    nozzle_efficiency: SimulationResultArray
-    overall_efficiency: SimulationResultArray
-    propellant_cog: SimulationResultArray
-    propellant_moi: SimulationResultArray
+    free_chamber_volume: simulation_results.SimulationResultArray
+    web: simulation_results.SimulationResultArray
+    burn_area: simulation_results.SimulationResultArray
+    propellant_volume: simulation_results.SimulationResultArray
+    burn_rate: simulation_results.SimulationResultArray
+    divergent_loss: simulation_results.SimulationResultArray
+    kinetics_loss: simulation_results.SimulationResultArray
+    boundary_layer_loss: simulation_results.SimulationResultArray
+    two_phase_loss: simulation_results.SimulationResultArray
+    nozzle_efficiency: simulation_results.SimulationResultArray
+    overall_efficiency: simulation_results.SimulationResultArray
+    propellant_cog: simulation_results.SimulationResultArray
+    propellant_moi: simulation_results.SimulationResultArray
     # klemmung is filtered to burn_area > 0, so its length is < len(time).
-    klemmung: SimulationResultArray = field(metadata={"non_aligned": True})
+    klemmung: simulation_results.SimulationResultArray = field(
+        metadata={"non_aligned": True}
+    )
     # grain_mass_flux is shaped [segment_count, time_count]; axis 0 is segments.
-    grain_mass_flux: SimulationResultArray = field(metadata={"non_aligned": True})
+    grain_mass_flux: simulation_results.SimulationResultArray = field(
+        metadata={"non_aligned": True}
+    )
     initial_to_final_klemmung_ratio: float
     volumetric_efficiency: float
     burn_profile: str
     max_mass_flux: float
 
     @classmethod
-    def _collect_extra_fields(cls, state: "SolidMotorState") -> dict[str, Any]:
+    def _collect_extra_fields(
+        cls, state: "solid_states.SolidMotorState"
+    ) -> dict[str, Any]:
         motor = state.motor
         nozzle = motor.thrust_chamber.nozzle
         chamber_volume = motor.thrust_chamber.combustion_chamber.internal_volume
@@ -84,8 +92,8 @@ class SolidSimulationResult(SimulationResult["SolidMotorState"]):
 
     @staticmethod
     def _get_klemmung(
-        burn_area: SimulationResultArray, throat_area: float
-    ) -> SimulationResultArray:
+        burn_area: simulation_results.SimulationResultArray, throat_area: float
+    ) -> simulation_results.SimulationResultArray:
         """
         Return Klemmung (Kn) over non-zero burn-area samples.
 
@@ -96,7 +104,7 @@ class SolidSimulationResult(SimulationResult["SolidMotorState"]):
 
     @staticmethod
     def _classify_burn_profile(
-        klemmung: SimulationResultArray, deviancy: float = 0.02
+        klemmung: simulation_results.SimulationResultArray, deviancy: float = 0.02
     ) -> str:
         """
         Classify a burn profile as "regressive", "progressive", or "neutral".

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -10,14 +10,14 @@ import machwave.core.conversions as conversions
 import machwave.core.mass_balance as mass_balance
 import machwave.core.solvers.rk4 as rk4
 import machwave.models.motors as motors
+import machwave.simulation.solid.results as solid_results
 import machwave.simulation.states as simulation_states
-from machwave.simulation.solid.results import SolidSimulationResult
 
 
 class SolidMotorState(simulation_states.MotorState):
     """State for a Solid Rocket Motor."""
 
-    result_class = SolidSimulationResult
+    result_class = solid_results.SolidSimulationResult
 
     def __init__(
         self,

--- a/machwave/simulation/states.py
+++ b/machwave/simulation/states.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar, TypeAlias
 
-from machwave.models.motors import Motor
+import machwave.models.motors as motors
 
 if TYPE_CHECKING:
-    from machwave.simulation.results import SimulationResult
+    import machwave.simulation.results as simulation_results
 
 SimulationStateArray: TypeAlias = list[float]
 
@@ -14,11 +14,11 @@ SimulationStateArray: TypeAlias = list[float]
 class MotorState(ABC):
     """Defines the states and iteration step for a motor operation."""
 
-    result_class: ClassVar[type["SimulationResult"]]
+    result_class: ClassVar[type["simulation_results.SimulationResult"]]
 
     def __init__(
         self,
-        motor: Motor,
+        motor: motors.Motor,
         igniter_pressure: float,
         external_pressure: float,
         other_losses: float,
@@ -60,7 +60,7 @@ class MotorState(ABC):
     def run_timestep(self, *args, **kwargs) -> None:
         """Advance the per-step accumulators by one time increment."""
 
-    def build_result(self) -> "SimulationResult":
+    def build_result(self) -> "simulation_results.SimulationResult":
         """Return a frozen ``SimulationResult`` snapshot of this state."""
         return self.result_class.from_state(self)
 

--- a/tests/benchmarks/test_simulation_loop.py
+++ b/tests/benchmarks/test_simulation_loop.py
@@ -6,11 +6,14 @@ import warnings
 import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
 
-from machwave.simulation import InternalBallisticsSimulation
+import machwave.simulation as simulation_module
+
 from tests.test_simulations import motor_builders
 
 
-def _run_simulation_silently(simulation: InternalBallisticsSimulation) -> None:
+def _run_simulation_silently(
+    simulation: simulation_module.InternalBallisticsSimulation,
+) -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
         simulation.run()
@@ -18,10 +21,14 @@ def _run_simulation_silently(simulation: InternalBallisticsSimulation) -> None:
 
 @pytest.mark.benchmark(group="simulation-loop")
 def test_solid_motor_simulation_loop(benchmark: BenchmarkFixture) -> None:
-    def setup() -> tuple[tuple[InternalBallisticsSimulation], dict[str, object]]:
+    def setup() -> tuple[
+        tuple[simulation_module.InternalBallisticsSimulation], dict[str, object]
+    ]:
         motor, params = motor_builders.build_kappa_rnakka_motor()
         params = dataclasses.replace(params, d_t=0.01)
-        simulation = InternalBallisticsSimulation(motor=motor, params=params)
+        simulation = simulation_module.InternalBallisticsSimulation(
+            motor=motor, params=params
+        )
         return (simulation,), {}
 
     benchmark.pedantic(
@@ -35,10 +42,14 @@ def test_solid_motor_simulation_loop(benchmark: BenchmarkFixture) -> None:
 
 @pytest.mark.benchmark(group="simulation-loop")
 def test_liquid_engine_simulation_loop(benchmark: BenchmarkFixture) -> None:
-    def setup() -> tuple[tuple[InternalBallisticsSimulation], dict[str, object]]:
+    def setup() -> tuple[
+        tuple[simulation_module.InternalBallisticsSimulation], dict[str, object]
+    ]:
         motor, params = motor_builders.build_1kn_lre()
         params = dataclasses.replace(params, d_t=4e-4)
-        simulation = InternalBallisticsSimulation(motor=motor, params=params)
+        simulation = simulation_module.InternalBallisticsSimulation(
+            motor=motor, params=params
+        )
         return (simulation,), {}
 
     benchmark.pedantic(

--- a/tests/factories/feed_systems.py
+++ b/tests/factories/feed_systems.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from machwave.models import feed_systems as feed_systems_models
-from machwave.models.feed_systems import tanks
+import machwave.models.feed_systems as feed_systems_models
+import machwave.models.feed_systems.tanks as tanks
 
 
 class TankFactory:

--- a/tests/factories/grain.py
+++ b/tests/factories/grain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from machwave.models.grain import geometries as grain_geometries
+import machwave.models.grain.geometries as grain_geometries
 
 
 class BatesSegmentFactory:

--- a/tests/factories/motors.py
+++ b/tests/factories/motors.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from machwave.models import grain as grain_models
-from machwave.models import motors
-from machwave.models.propellants.formulations import solid as solid_propellants
+import machwave.models.grain as grain_models
+import machwave.models.motors as motors_models
+import machwave.models.propellants.formulations.solid as solid_propellants
 
 from tests.factories.feed_systems import StackedTankPressureFedFeedSystemFactory
 from tests.factories.grain import BatesSegmentFactory
@@ -19,7 +19,7 @@ class SolidMotorFactory:
     """Defaults to a single-segment BATES motor with KNDX propellant."""
 
     @classmethod
-    def build(cls, **overrides: Any) -> motors.SolidMotor:
+    def build(cls, **overrides: Any) -> motors_models.SolidMotor:
         grain = overrides.pop("grain", None)
         if grain is None:
             grain = grain_models.Grain()
@@ -37,14 +37,14 @@ class SolidMotorFactory:
             thrust_chamber=thrust_chamber,
         )
         kwargs.update(overrides)
-        return motors.SolidMotor(**kwargs)
+        return motors_models.SolidMotor(**kwargs)
 
 
 class LiquidEngineFactory:
     """Defaults to an N2O/Ethanol engine on a pressure-fed feed system."""
 
     @classmethod
-    def build(cls, **overrides: Any) -> motors.LiquidEngine:
+    def build(cls, **overrides: Any) -> motors_models.LiquidEngine:
         propellant = (
             overrides.pop("propellant", None) or BiliquidPropellantFactory.build()
         )
@@ -65,4 +65,4 @@ class LiquidEngineFactory:
             fuel_tank_cog=0.4,
         )
         kwargs.update(overrides)
-        return motors.LiquidEngine(**kwargs)
+        return motors_models.LiquidEngine(**kwargs)

--- a/tests/factories/propellants.py
+++ b/tests/factories/propellants.py
@@ -10,7 +10,9 @@ from typing import Any
 
 from polyfactory.factories import DataclassFactory
 
-from machwave.models.propellants import categories, components, properties
+import machwave.models.propellants.categories as categories
+import machwave.models.propellants.components as components
+import machwave.models.propellants.properties as properties
 
 
 class SolidPropellantPropertiesFactory(

--- a/tests/factories/thrust_chamber.py
+++ b/tests/factories/thrust_chamber.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from machwave.models import thrust_chamber as thrust_chamber_models
+import machwave.models.thrust_chamber as thrust_chamber_models
 
 
 class NozzleFactory:

--- a/tests/test_adapters/test_rocketpy_solid_motor.py
+++ b/tests/test_adapters/test_rocketpy_solid_motor.py
@@ -5,8 +5,8 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
-from machwave.adapters.rocketpy import RocketPySolidMotorAdapter
-from machwave.models import grain as grain_models
+import machwave.adapters.rocketpy as rocketpy_adapters
+import machwave.models.grain as grain_models
 
 from tests.factories import (
     ConicalGrainSegmentFactory,
@@ -31,9 +31,11 @@ def _stub_simulation_result() -> SimpleNamespace:
     )
 
 
-def _build_adapter_without_init(motor) -> RocketPySolidMotorAdapter:
+def _build_adapter_without_init(motor) -> rocketpy_adapters.RocketPySolidMotorAdapter:
     """Bypass __init__ so the test isolates the geometry validation."""
-    adapter = RocketPySolidMotorAdapter.__new__(RocketPySolidMotorAdapter)
+    adapter = rocketpy_adapters.RocketPySolidMotorAdapter.__new__(
+        rocketpy_adapters.RocketPySolidMotorAdapter
+    )
     adapter.motor = motor
     adapter.simulation_result = _stub_simulation_result()
     return adapter

--- a/tests/test_core/test_compressible_flow/test_isentropic.py
+++ b/tests/test_core/test_compressible_flow/test_isentropic.py
@@ -1,6 +1,6 @@
 import pytest
 
-from machwave.core.compressible_flow import isentropic
+import machwave.core.compressible_flow.isentropic as isentropic
 
 
 def test_get_critical_pressure_ratio():

--- a/tests/test_core/test_compressible_flow/test_losses.py
+++ b/tests/test_core/test_compressible_flow/test_losses.py
@@ -1,6 +1,6 @@
 import pytest
 
-from machwave.core.compressible_flow import losses
+import machwave.core.compressible_flow.losses as losses
 
 pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 

--- a/tests/test_core/test_conversions.py
+++ b/tests/test_core/test_conversions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from machwave.core import conversions
+import machwave.core.conversions as conversions
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core/test_geometric.py
+++ b/tests/test_core/test_geometric.py
@@ -1,19 +1,13 @@
 import pytest
 
-from machwave.core.geometric import (
-    get_circle_area,
-    get_cylinder_surface_area,
-    get_cylinder_volume,
-    get_torus_area,
-    get_trapezoidal_area,
-)
+import machwave.core.geometric as geometric
 
 
 def test_get_circle_area():
     # Test case: Circle with diameter 4
     diameter = 4
     expected_area = 12.56637
-    assert pytest.approx(get_circle_area(diameter), rel=1e-4) == expected_area
+    assert pytest.approx(geometric.get_circle_area(diameter), rel=1e-4) == expected_area
 
 
 def test_get_torus_area():
@@ -22,7 +16,7 @@ def test_get_torus_area():
     minor_radius = 1
     expected_area = 78.95684
     assert (
-        pytest.approx(get_torus_area(major_radius, minor_radius), rel=1e-4)
+        pytest.approx(geometric.get_torus_area(major_radius, minor_radius), rel=1e-4)
         == expected_area
     )
 
@@ -33,7 +27,9 @@ def test_get_trapezoidal_area():
     tip_length = 6
     height = 3
     expected_area = 15.0
-    assert get_trapezoidal_area(base_length, tip_length, height) == expected_area
+    assert (
+        geometric.get_trapezoidal_area(base_length, tip_length, height) == expected_area
+    )
 
 
 def test_get_cylinder_surface_area():
@@ -42,7 +38,7 @@ def test_get_cylinder_surface_area():
     diameter = 2
     expected_area = 31.4159265359
     assert (
-        pytest.approx(get_cylinder_surface_area(length, diameter), rel=1e-4)
+        pytest.approx(geometric.get_cylinder_surface_area(length, diameter), rel=1e-4)
         == expected_area
     )
 
@@ -53,6 +49,6 @@ def test_get_cylinder_volume():
     diameter = 2
     expected_volume = 15.7079632679
     assert (
-        pytest.approx(get_cylinder_volume(diameter, length), rel=1e-4)
+        pytest.approx(geometric.get_cylinder_volume(diameter, length), rel=1e-4)
         == expected_volume
     )

--- a/tests/test_core/test_incompressible_flow.py
+++ b/tests/test_core/test_incompressible_flow.py
@@ -1,6 +1,6 @@
 import pytest
 
-from machwave.core.incompressible_flow import get_mass_flow_orifice
+import machwave.core.incompressible_flow as incompressible_flow
 
 
 @pytest.mark.parametrize(
@@ -21,7 +21,7 @@ def test_get_mass_flow_orifice(
     pressure_downstream,
     expected,
 ):
-    mass_flow = get_mass_flow_orifice(
+    mass_flow = incompressible_flow.get_mass_flow_orifice(
         discharge_coefficient,
         area,
         density,
@@ -36,7 +36,7 @@ def test_get_mass_flow_orifice_raises_value_error():
     with pytest.raises(
         ValueError, match="Pressure downstream cannot be greater than upstream"
     ):
-        get_mass_flow_orifice(
+        incompressible_flow.get_mass_flow_orifice(
             discharge_coefficient=0.8,
             area=0.001,
             density=1000,

--- a/tests/test_core/test_interpolation.py
+++ b/tests/test_core/test_interpolation.py
@@ -4,7 +4,7 @@ import math
 
 import pytest
 
-from machwave.core import interpolation
+import machwave.core.interpolation as interpolation
 
 
 def test_bounded_cubic_spline_returns_knot_values_at_knots():

--- a/tests/test_core/test_structural/test_bolted_joints.py
+++ b/tests/test_core/test_structural/test_bolted_joints.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from machwave.core.structural import bolted_joints
+import machwave.core.structural.bolted_joints as bolted_joints
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core/test_structural/test_pressure_vessels.py
+++ b/tests/test_core/test_structural/test_pressure_vessels.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from machwave.core.structural import pressure_vessels
+import machwave.core.structural.pressure_vessels as pressure_vessels
 
 
 def test_unit_pressure_stresses() -> None:

--- a/tests/test_io/test_eng.py
+++ b/tests/test_io/test_eng.py
@@ -46,7 +46,7 @@ Requirements for an .eng file:
 import numpy as np
 import pytest
 
-from machwave.io.eng import generate_eng_file_content
+import machwave.io.eng as eng_io
 
 
 @pytest.fixture
@@ -68,7 +68,7 @@ def payload_data():
 
 def test_eng_header_format(payload_data):
     """Test if the header in the .eng file is formatted correctly."""
-    content = generate_eng_file_content(
+    content = eng_io.generate_eng_file_content(
         time=payload_data["time"],
         thrust=payload_data["thrust"],
         propellant_mass=payload_data["propellant_mass"],
@@ -99,7 +99,7 @@ def test_eng_header_format(payload_data):
 
 def test_eng_data_format(payload_data):
     """Test if the time and thrust data in the .eng file are formatted correctly."""
-    content = generate_eng_file_content(
+    content = eng_io.generate_eng_file_content(
         time=payload_data["time"],
         thrust=payload_data["thrust"],
         propellant_mass=payload_data["propellant_mass"],
@@ -131,7 +131,7 @@ def test_eng_data_values(payload_data):
     - Time must be increasing and start from 0.
     - Thrust must be non-negative.
     """
-    content = generate_eng_file_content(
+    content = eng_io.generate_eng_file_content(
         time=payload_data["time"],
         thrust=payload_data["thrust"],
         propellant_mass=payload_data["propellant_mass"],
@@ -169,7 +169,7 @@ def test_eng_data_values(payload_data):
 
 def test_eng_file_ends_with_semicolon(payload_data):
     """Test if the .eng file ends with a semicolon."""
-    content = generate_eng_file_content(
+    content = eng_io.generate_eng_file_content(
         time=payload_data["time"],
         thrust=payload_data["thrust"],
         propellant_mass=payload_data["propellant_mass"],

--- a/tests/test_models/conftest.py
+++ b/tests/test_models/conftest.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from machwave.models.propellants.formulations import get_propellant_from_json
+import machwave.models.propellants.formulations as propellant_formulations
 
 from tests.factories import CombustionChamberFactory
 
@@ -19,27 +19,37 @@ FORMULATIONS_DIR = (
 
 @pytest.fixture
 def propellant_KNDX():
-    return get_propellant_from_json(FORMULATIONS_DIR / "kndx.json")
+    return propellant_formulations.get_propellant_from_json(
+        FORMULATIONS_DIR / "kndx.json"
+    )
 
 
 @pytest.fixture
 def propellant_KNER():
-    return get_propellant_from_json(FORMULATIONS_DIR / "kner.json")
+    return propellant_formulations.get_propellant_from_json(
+        FORMULATIONS_DIR / "kner.json"
+    )
 
 
 @pytest.fixture
 def propellant_KNSB():
-    return get_propellant_from_json(FORMULATIONS_DIR / "knsb.json")
+    return propellant_formulations.get_propellant_from_json(
+        FORMULATIONS_DIR / "knsb.json"
+    )
 
 
 @pytest.fixture
 def propellant_KNSB_NAKKA():
-    return get_propellant_from_json(FORMULATIONS_DIR / "knsb_nakka.json")
+    return propellant_formulations.get_propellant_from_json(
+        FORMULATIONS_DIR / "knsb_nakka.json"
+    )
 
 
 @pytest.fixture
 def propellant_KNSU():
-    return get_propellant_from_json(FORMULATIONS_DIR / "knsu.json")
+    return propellant_formulations.get_propellant_from_json(
+        FORMULATIONS_DIR / "knsu.json"
+    )
 
 
 @pytest.fixture

--- a/tests/test_models/test_propulsion/test_feed_systems/test_components/test_specs.py
+++ b/tests/test_models/test_propulsion/test_feed_systems/test_components/test_specs.py
@@ -4,12 +4,7 @@ import dataclasses
 
 import pytest
 
-from machwave.models.feed_systems.components import (
-    GasGeneratorSpec,
-    PumpSpec,
-    RegenerativeJacketSpec,
-    TurbineSpec,
-)
+import machwave.models.feed_systems.components as feed_components
 
 
 def _valid_pump_spec_kwargs() -> dict:
@@ -57,7 +52,7 @@ def _valid_regenerative_jacket_spec_kwargs() -> dict:
 
 def test_pump_spec_constructs_with_valid_values():
     """A `PumpSpec` with valid fields must construct without error."""
-    spec = PumpSpec(**_valid_pump_spec_kwargs())
+    spec = feed_components.PumpSpec(**_valid_pump_spec_kwargs())
 
     assert spec.name == "oxidizer pump"
     assert spec.isentropic_efficiency == pytest.approx(0.7)
@@ -65,7 +60,7 @@ def test_pump_spec_constructs_with_valid_values():
 
 def test_turbine_spec_constructs_with_valid_values():
     """A `TurbineSpec` with valid fields must construct without error."""
-    spec = TurbineSpec(**_valid_turbine_spec_kwargs())
+    spec = feed_components.TurbineSpec(**_valid_turbine_spec_kwargs())
 
     assert spec.name == "oxidizer turbine"
     assert spec.pressure_ratio == pytest.approx(20.0)
@@ -73,7 +68,7 @@ def test_turbine_spec_constructs_with_valid_values():
 
 def test_gas_generator_spec_constructs_with_valid_values():
     """A `GasGeneratorSpec` with valid fields must construct without error."""
-    spec = GasGeneratorSpec(**_valid_gas_generator_spec_kwargs())
+    spec = feed_components.GasGeneratorSpec(**_valid_gas_generator_spec_kwargs())
 
     assert spec.name == "gas generator"
     assert spec.mixture_ratio == pytest.approx(0.3)
@@ -81,7 +76,9 @@ def test_gas_generator_spec_constructs_with_valid_values():
 
 def test_regenerative_jacket_spec_constructs_with_valid_values():
     """A `RegenerativeJacketSpec` with valid fields must construct without error."""
-    spec = RegenerativeJacketSpec(**_valid_regenerative_jacket_spec_kwargs())
+    spec = feed_components.RegenerativeJacketSpec(
+        **_valid_regenerative_jacket_spec_kwargs()
+    )
 
     assert spec.name == "chamber jacket"
     assert spec.coolant_temperature_rise == pytest.approx(200.0)
@@ -93,7 +90,7 @@ def test_pump_spec_rejects_efficiency_above_one():
     kwargs["isentropic_efficiency"] = 1.5
 
     with pytest.raises(ValueError, match="isentropic_efficiency"):
-        PumpSpec(**kwargs)
+        feed_components.PumpSpec(**kwargs)
 
 
 def test_pump_spec_rejects_non_positive_pressure_rise():
@@ -102,7 +99,7 @@ def test_pump_spec_rejects_non_positive_pressure_rise():
     kwargs["pressure_rise"] = 0.0
 
     with pytest.raises(ValueError, match="pressure_rise"):
-        PumpSpec(**kwargs)
+        feed_components.PumpSpec(**kwargs)
 
 
 def test_turbine_spec_rejects_pressure_ratio_at_or_below_one():
@@ -111,7 +108,7 @@ def test_turbine_spec_rejects_pressure_ratio_at_or_below_one():
     kwargs["pressure_ratio"] = 1.0
 
     with pytest.raises(ValueError, match="pressure_ratio"):
-        TurbineSpec(**kwargs)
+        feed_components.TurbineSpec(**kwargs)
 
 
 def test_gas_generator_spec_rejects_non_positive_gas_temperature():
@@ -120,7 +117,7 @@ def test_gas_generator_spec_rejects_non_positive_gas_temperature():
     kwargs["gas_temperature"] = 0.0
 
     with pytest.raises(ValueError, match="gas_temperature"):
-        GasGeneratorSpec(**kwargs)
+        feed_components.GasGeneratorSpec(**kwargs)
 
 
 def test_gas_generator_spec_rejects_non_positive_mixture_ratio():
@@ -129,7 +126,7 @@ def test_gas_generator_spec_rejects_non_positive_mixture_ratio():
     kwargs["mixture_ratio"] = 0.0
 
     with pytest.raises(ValueError, match="mixture_ratio"):
-        GasGeneratorSpec(**kwargs)
+        feed_components.GasGeneratorSpec(**kwargs)
 
 
 def test_regenerative_jacket_spec_rejects_negative_pressure_drop():
@@ -138,7 +135,7 @@ def test_regenerative_jacket_spec_rejects_negative_pressure_drop():
     kwargs["pressure_drop"] = -1.0
 
     with pytest.raises(ValueError, match="pressure_drop"):
-        RegenerativeJacketSpec(**kwargs)
+        feed_components.RegenerativeJacketSpec(**kwargs)
 
 
 def test_regenerative_jacket_spec_rejects_non_positive_temperature_rise():
@@ -147,22 +144,27 @@ def test_regenerative_jacket_spec_rejects_non_positive_temperature_rise():
     kwargs["coolant_temperature_rise"] = 0.0
 
     with pytest.raises(ValueError, match="coolant_temperature_rise"):
-        RegenerativeJacketSpec(**kwargs)
+        feed_components.RegenerativeJacketSpec(**kwargs)
 
 
 @pytest.mark.parametrize(
     "spec_class, kwargs_builder, field_name, new_value",
     [
-        (PumpSpec, _valid_pump_spec_kwargs, "name", "modified pump"),
-        (TurbineSpec, _valid_turbine_spec_kwargs, "name", "modified turbine"),
+        (feed_components.PumpSpec, _valid_pump_spec_kwargs, "name", "modified pump"),
         (
-            GasGeneratorSpec,
+            feed_components.TurbineSpec,
+            _valid_turbine_spec_kwargs,
+            "name",
+            "modified turbine",
+        ),
+        (
+            feed_components.GasGeneratorSpec,
             _valid_gas_generator_spec_kwargs,
             "name",
             "modified gas generator",
         ),
         (
-            RegenerativeJacketSpec,
+            feed_components.RegenerativeJacketSpec,
             _valid_regenerative_jacket_spec_kwargs,
             "name",
             "modified jacket",

--- a/tests/test_models/test_propulsion/test_feed_systems/test_tanks.py
+++ b/tests/test_models/test_propulsion/test_feed_systems/test_tanks.py
@@ -3,7 +3,7 @@ import CoolProp.CoolProp as CP
 import pytest
 import scipy.constants
 
-from machwave.models.feed_systems.tanks import Tank
+import machwave.models.feed_systems.tanks as tanks
 
 # A few (fluid, temperature) pairs for running tests.
 # Adjust temperatures to ensure we stay within valid ranges for each fluid in CoolProp.
@@ -36,7 +36,7 @@ def test_saturated_condition(fluid_name, temperature):
     m_vap = (p_sat * volume * molar_mass) / (R_universal * temperature)
 
     # 3) Put more mass than m_vap => ensures there's liquid
-    tank = Tank(
+    tank = tanks.Tank(
         fluid_name=fluid_name,
         volume=volume,
         temperature=temperature,
@@ -65,7 +65,7 @@ def test_all_vapor_condition(fluid_name, temperature):
 
     # Put slightly less than that => ensures no liquid
     mass = 0.5 * m_vap_sat
-    tank = Tank(
+    tank = tanks.Tank(
         fluid_name=fluid_name,
         volume=volume,
         temperature=temperature,
@@ -90,7 +90,7 @@ def test_remove_propellant(fluid_name, temperature):
     volume = 0.02
     initial_mass = 1.0
 
-    tank = Tank(
+    tank = tanks.Tank(
         fluid_name=fluid_name,
         volume=volume,
         temperature=temperature,
@@ -129,7 +129,7 @@ def test_two_phase_density_returns_saturated_liquid(fluid_name, temperature):
     R_universal = scipy.constants.R
     m_vap_sat = (p_sat * volume * molar_mass) / (R_universal * temperature)
 
-    tank = Tank(
+    tank = tanks.Tank(
         fluid_name=fluid_name,
         volume=volume,
         temperature=temperature,
@@ -153,7 +153,7 @@ def test_two_phase_density_constant_while_two_phase(fluid_name, temperature):
     R_universal = scipy.constants.R
     m_vap_sat = (p_sat * volume * molar_mass) / (R_universal * temperature)
 
-    tank = Tank(
+    tank = tanks.Tank(
         fluid_name=fluid_name,
         volume=volume,
         temperature=temperature,
@@ -168,7 +168,7 @@ def test_two_phase_density_constant_while_two_phase(fluid_name, temperature):
 
 def test_remove_negative_mass():
     """Removing negative mass should raise ValueError."""
-    tank = Tank("Water", 0.01, 300.0, 1.0)
+    tank = tanks.Tank("Water", 0.01, 300.0, 1.0)
     with pytest.raises(ValueError):
         tank.remove_propellant(-0.5)
 
@@ -184,7 +184,7 @@ def test_check_not_overfilled_rejects_overfill(fluid_name, temperature):
     overfill_mass = 2.0 * rho_liquid * volume
 
     with pytest.raises(ValueError, match="overfilled"):
-        Tank._check_not_overfilled(fluid_name, volume, temperature, overfill_mass)
+        tanks.Tank._check_not_overfilled(fluid_name, volume, temperature, overfill_mass)
 
 
 @pytest.mark.parametrize("fluid_name, temperature", TEST_FLUIDS)
@@ -197,7 +197,7 @@ def test_check_not_overfilled_accepts_fill_just_under_liquid(fluid_name, tempera
     volume = 1e-3
     mass = rho_liquid * volume * 0.99
 
-    Tank._check_not_overfilled(fluid_name, volume, temperature, mass)
+    tanks.Tank._check_not_overfilled(fluid_name, volume, temperature, mass)
 
 
 @pytest.mark.parametrize("fluid_name, temperature", TEST_FLUIDS)
@@ -208,9 +208,9 @@ def test_check_not_overfilled_accepts_within_tolerance(fluid_name, temperature):
     """
     rho_liquid = CP.PropsSI("D", "T", temperature, "Q", 0, fluid_name)
     volume = 1e-3
-    mass = rho_liquid * volume * (1 + Tank.OVERFILL_TOLERANCE / 2)
+    mass = rho_liquid * volume * (1 + tanks.Tank.OVERFILL_TOLERANCE / 2)
 
-    Tank._check_not_overfilled(fluid_name, volume, temperature, mass)
+    tanks.Tank._check_not_overfilled(fluid_name, volume, temperature, mass)
 
 
 @pytest.mark.parametrize("fluid_name, temperature", TEST_FLUIDS)
@@ -221,20 +221,20 @@ def test_check_not_overfilled_rejects_just_outside_tolerance(fluid_name, tempera
     """
     rho_liquid = CP.PropsSI("D", "T", temperature, "Q", 0, fluid_name)
     volume = 1e-3
-    mass = rho_liquid * volume * (1 + Tank.OVERFILL_TOLERANCE * 2)
+    mass = rho_liquid * volume * (1 + tanks.Tank.OVERFILL_TOLERANCE * 2)
 
     with pytest.raises(ValueError, match="overfilled"):
-        Tank._check_not_overfilled(fluid_name, volume, temperature, mass)
+        tanks.Tank._check_not_overfilled(fluid_name, volume, temperature, mass)
 
 
 def test_init_invokes_overfill_check():
     """
-    The constructor must call :meth:`Tank._check_not_overfilled` so an
+    The constructor must call :meth:`tanks.Tank._check_not_overfilled` so an
     overfilled tank fails fast at API boundaries rather than silently
     producing nonsensical pressure / density results downstream.
     """
     with pytest.raises(ValueError, match="overfilled"):
-        Tank(
+        tanks.Tank(
             fluid_name="Water",
             volume=1e-3,
             temperature=300.0,

--- a/tests/test_models/test_propulsion/test_grain/conftest.py
+++ b/tests/test_models/test_propulsion/test_grain/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from machwave.models.grain import Grain
+import machwave.models.grain as grain_models
 
 from tests.factories import BatesSegmentFactory
 
@@ -27,7 +27,7 @@ def bates_segment_olympus_60():
 
 @pytest.fixture
 def bates_grain_olympus(bates_segment_olympus_45, bates_segment_olympus_60):
-    grain = Grain(spacing=10e-3)
+    grain = grain_models.Grain(spacing=10e-3)
     for _ in range(4):
         grain.add_segment(bates_segment_olympus_45)
     for _ in range(3):

--- a/tests/test_models/test_propulsion/test_grain/test_cog/test_bates_cog.py
+++ b/tests/test_models/test_propulsion/test_grain/test_cog/test_bates_cog.py
@@ -1,7 +1,7 @@
 import numpy as np
 
-from machwave.models.grain import Grain
-from machwave.models.grain.geometries import BatesSegment
+import machwave.models.grain as grain_models
+import machwave.models.grain.geometries as grain_geometries
 
 
 class TestBatesGrainCenterOfGravity:
@@ -9,9 +9,9 @@ class TestBatesGrainCenterOfGravity:
 
     def test_single_segment_cog_position(self):
         """Test CoG with a single BATES segment of length 1.0m."""
-        grain = Grain(spacing=0.1)  # Spacing doesn't matter with 1 segment
+        grain = grain_models.Grain(spacing=0.1)  # Spacing doesn't matter with 1 segment
 
-        segment = BatesSegment(
+        segment = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=1.0,
@@ -27,16 +27,16 @@ class TestBatesGrainCenterOfGravity:
 
     def test_two_segments_equal_length_with_spacing(self):
         """Test CoG with 2 BATES segments of length 1.0m each with 0.1m spacing."""
-        grain = Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.1)
 
-        segment_1 = BatesSegment(
+        segment_1 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=1.0,
             density_ratio=1.0,
         )
 
-        segment_2 = BatesSegment(
+        segment_2 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=1.0,
@@ -53,23 +53,23 @@ class TestBatesGrainCenterOfGravity:
 
     def test_three_segments_equal_length_with_spacing(self):
         """Test CoG with 3 BATES segments of length 1.0m each with 0.2m spacing."""
-        grain = Grain(spacing=0.2)
+        grain = grain_models.Grain(spacing=0.2)
 
-        segment1 = BatesSegment(
+        segment1 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=1.0,
             density_ratio=1.0,
         )
 
-        segment2 = BatesSegment(
+        segment2 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=1.0,
             density_ratio=1.0,
         )
 
-        segment3 = BatesSegment(
+        segment3 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=1.0,
@@ -87,10 +87,10 @@ class TestBatesGrainCenterOfGravity:
 
     def test_three_segments_variable_length_with_spacing(self):
         """Test CoG with 3 BATES segments of different lengths with 0.2m spacing."""
-        grain = Grain(spacing=0.2)
+        grain = grain_models.Grain(spacing=0.2)
 
         # L1 = 1.0m
-        segment1 = BatesSegment(
+        segment1 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=1.0,
@@ -98,7 +98,7 @@ class TestBatesGrainCenterOfGravity:
         )
 
         # L2 = 2.0m
-        segment2 = BatesSegment(
+        segment2 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=2.0,
@@ -106,7 +106,7 @@ class TestBatesGrainCenterOfGravity:
         )
 
         # L3 = 3.0m
-        segment3 = BatesSegment(
+        segment3 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=3.0,
@@ -139,10 +139,10 @@ class TestBatesGrainCenterOfGravity:
         Test CoG with 2 BATES segments of same length but different core
         diameters.
         """
-        grain = Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.1)
 
         # Segment 1: 45mm core diameter
-        segment1 = BatesSegment(
+        segment1 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=1.0,
@@ -150,7 +150,7 @@ class TestBatesGrainCenterOfGravity:
         )
 
         # Segment 2: 60mm core diameter (larger core = less propellant mass)
-        segment2 = BatesSegment(
+        segment2 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=60e-3,
             length=1.0,
@@ -180,10 +180,10 @@ class TestBatesGrainCenterOfGravity:
         Test CoG with 2 BATES segments of same geometry but different
         densities.
         """
-        grain = Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.1)
 
         # Segment 1: full density
-        segment1 = BatesSegment(
+        segment1 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=1.0,
@@ -191,7 +191,7 @@ class TestBatesGrainCenterOfGravity:
         )
 
         # Segment 2: 70% density (e.g., foamed propellant)
-        segment2 = BatesSegment(
+        segment2 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=1.0,
@@ -223,16 +223,16 @@ class TestBatesGrainCenterOfGravity:
 
     def test_two_segments_zero_spacing(self):
         """Test CoG with 2 BATES segments with zero spacing (touching)."""
-        grain = Grain(spacing=0.0)
+        grain = grain_models.Grain(spacing=0.0)
 
-        segment1 = BatesSegment(
+        segment1 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=1.0,
             density_ratio=1.0,
         )
 
-        segment2 = BatesSegment(
+        segment2 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=1.0,
@@ -252,23 +252,23 @@ class TestBatesGrainCenterOfGravity:
         Test that CoG remains constant during burn for 3 identical BATES segments.
         BATES grains are symmetric, so CoG should not change as they burn.
         """
-        grain = Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.1)
 
-        segment1 = BatesSegment(
+        segment1 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=1.0,
             density_ratio=1.0,
         )
 
-        segment2 = BatesSegment(
+        segment2 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=1.0,
             density_ratio=1.0,
         )
 
-        segment3 = BatesSegment(
+        segment3 = grain_geometries.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=1.0,
@@ -303,10 +303,10 @@ class TestBatesGrainCenterOfGravity:
         Test CoG shift during burn with 2 segments of different web thickness.
         When the thinner segment burns out, CoG should be at center of remaining segment.
         """
-        grain = Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.1)
 
         # Segment 1: smaller web thickness (30mm core, wt ≈ 21.75mm)
-        segment1 = BatesSegment(
+        segment1 = grain_geometries.BatesSegment(
             outer_diameter=73.5e-3,
             core_diameter=30e-3,
             length=1.0,
@@ -314,7 +314,7 @@ class TestBatesGrainCenterOfGravity:
         )
 
         # Segment 2: larger web thickness (15mm core, wt ≈ 29.25mm)
-        segment2 = BatesSegment(
+        segment2 = grain_geometries.BatesSegment(
             outer_diameter=73.5e-3,
             core_diameter=15e-3,
             length=1.0,

--- a/tests/test_models/test_propulsion/test_grain/test_cog/test_fmm2d_cog.py
+++ b/tests/test_models/test_propulsion/test_grain/test_cog/test_fmm2d_cog.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from machwave.models.grain import Grain
+import machwave.models.grain as grain_models
 from tests.test_models.test_propulsion.test_grain.test_cog.conftest import (
     fmm2d_geometries,
 )
@@ -53,7 +53,7 @@ class TestFMM2DGrainMultiSegmentCoG:
 
     def test_single_segment_cog_position(self, segment_factory, geometry_name):
         """Test CoG with a single 2D segment of length 1.0m."""
-        grain = Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.1)
         segment = segment_factory(length=1.0, outer_diameter=0.1)
         grain.add_segment(segment)
 
@@ -67,7 +67,7 @@ class TestFMM2DGrainMultiSegmentCoG:
         self, segment_factory, geometry_name
     ):
         """Test CoG with 2 2D segments of length 1.0m each with 0.1m spacing."""
-        grain = Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.1)
 
         segment1 = segment_factory(length=1.0, outer_diameter=0.1)
         segment2 = segment_factory(length=1.0, outer_diameter=0.1)
@@ -84,7 +84,7 @@ class TestFMM2DGrainMultiSegmentCoG:
 
     def test_two_segments_zero_spacing(self, segment_factory, geometry_name):
         """Test CoG with 2 2D segments with zero spacing (touching)."""
-        grain = Grain(spacing=0.0)
+        grain = grain_models.Grain(spacing=0.0)
 
         segment1 = segment_factory(length=1.0, outer_diameter=0.1)
         segment2 = segment_factory(length=1.0, outer_diameter=0.1)
@@ -102,7 +102,7 @@ class TestFMM2DGrainMultiSegmentCoG:
         self, segment_factory, geometry_name
     ):
         """Test that CoG remains relatively constant during burn for 3 identical 2D segments."""
-        grain = Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.1)
 
         segment1 = segment_factory(length=1.0, outer_diameter=0.1)
         segment2 = segment_factory(length=1.0, outer_diameter=0.1)
@@ -130,7 +130,7 @@ class TestFMM2DGrainMultiSegmentCoG:
 
     def test_two_segments_different_densities(self, segment_factory, geometry_name):
         """Test CoG with 2 2D segments of same geometry but different densities."""
-        grain = Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.1)
 
         segment1 = segment_factory(length=1.0, outer_diameter=0.1, density_ratio=1.0)
         segment2 = segment_factory(length=1.0, outer_diameter=0.1, density_ratio=0.7)

--- a/tests/test_models/test_propulsion/test_grain/test_cog/test_fmm3d_cog.py
+++ b/tests/test_models/test_propulsion/test_grain/test_cog/test_fmm3d_cog.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from machwave.models.grain import Grain
+import machwave.models.grain as grain_models
 from tests.test_models.test_propulsion.test_grain.test_cog.conftest import (
     fmm3d_geometries,
 )
@@ -67,7 +67,7 @@ class TestFMM3DGrainMultiSegmentCoG:
 
     def test_single_segment_cog_position(self, segment_factory, geometry_name):
         """Test CoG with a single 3D segment of length 1.0m."""
-        grain = Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.1)
         segment = segment_factory(length=1.0, outer_diameter=0.1)
         grain.add_segment(segment)
 
@@ -81,7 +81,7 @@ class TestFMM3DGrainMultiSegmentCoG:
         self, segment_factory, geometry_name
     ):
         """Test CoG with 2 3D segments of length 1.0m each with 0.1m spacing."""
-        grain = Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.1)
 
         segment1 = segment_factory(length=1.0, outer_diameter=0.1)
         segment2 = segment_factory(length=1.0, outer_diameter=0.1)
@@ -97,7 +97,7 @@ class TestFMM3DGrainMultiSegmentCoG:
 
     def test_two_segments_zero_spacing(self, segment_factory, geometry_name):
         """Test CoG with 2 3D segments with zero spacing."""
-        grain = Grain(spacing=0.0)
+        grain = grain_models.Grain(spacing=0.0)
 
         segment1 = segment_factory(length=1.0, outer_diameter=0.1)
         segment2 = segment_factory(length=1.0, outer_diameter=0.1)
@@ -115,7 +115,7 @@ class TestFMM3DGrainMultiSegmentCoG:
         self, segment_factory, geometry_name
     ):
         """Test that CoG remains relatively constant during burn for 3 identical 3D segments."""
-        grain = Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.1)
 
         segment1 = segment_factory(length=1.0, outer_diameter=0.1)
         segment2 = segment_factory(length=1.0, outer_diameter=0.1)
@@ -142,7 +142,7 @@ class TestFMM3DGrainMultiSegmentCoG:
 
     def test_two_segments_different_densities(self, segment_factory, geometry_name):
         """Test CoG with 2 3D segments of same geometry but different densities."""
-        grain = Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.1)
 
         segment1 = segment_factory(length=1.0, outer_diameter=0.1, density_ratio=1.0)
         segment2 = segment_factory(length=1.0, outer_diameter=0.1, density_ratio=0.7)

--- a/tests/test_models/test_propulsion/test_grain/test_grain_spacing.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grain_spacing.py
@@ -7,8 +7,8 @@ attribute and not as a GrainSegment attribute.
 
 import pytest
 
-from machwave.models.grain import Grain
-from machwave.models.grain.geometries.bates import BatesSegment
+import machwave.models.grain as grain_models
+import machwave.models.grain.geometries.bates as bates_geometry
 
 
 class TestGrainSpacing:
@@ -16,25 +16,25 @@ class TestGrainSpacing:
 
     def test_grain_default_spacing(self):
         """Test that Grain has default spacing of 0.0."""
-        grain = Grain()
+        grain = grain_models.Grain()
         assert grain.spacing == 0.0
 
     def test_grain_custom_spacing(self):
         """Test that Grain accepts custom spacing value."""
         spacing = 0.01
-        grain = Grain(spacing=spacing)
+        grain = grain_models.Grain(spacing=spacing)
         assert grain.spacing == spacing
 
     def test_grain_negative_spacing(self):
         """Test that Grain can have negative spacing (overlapping segments)."""
         # Negative spacing might be used for overlapping segments
         spacing = -0.005
-        grain = Grain(spacing=spacing)
+        grain = grain_models.Grain(spacing=spacing)
         assert grain.spacing == spacing
 
     def test_segment_no_spacing_attribute(self):
         """Test that GrainSegment does not have a spacing attribute."""
-        segment = BatesSegment(
+        segment = bates_geometry.BatesSegment(
             outer_diameter=0.086,
             core_diameter=0.032,
             length=0.150,
@@ -46,7 +46,7 @@ class TestGrainSpacing:
     def test_segment_init_rejects_spacing(self):
         """Test that passing spacing to a segment raises TypeError."""
         with pytest.raises(TypeError, match="unexpected keyword argument"):
-            BatesSegment(
+            bates_geometry.BatesSegment(
                 outer_diameter=0.086,
                 core_diameter=0.032,
                 length=0.150,
@@ -55,9 +55,9 @@ class TestGrainSpacing:
 
     def test_total_length_with_no_spacing(self):
         """Test total_length calculation with zero spacing."""
-        grain = Grain(spacing=0.0)
+        grain = grain_models.Grain(spacing=0.0)
 
-        segment = BatesSegment(
+        segment = bates_geometry.BatesSegment(
             outer_diameter=0.086,
             core_diameter=0.032,
             length=0.150,
@@ -74,9 +74,9 @@ class TestGrainSpacing:
     def test_total_length_with_spacing(self):
         """Test total_length calculation with positive spacing."""
         spacing = 0.01
-        grain = Grain(spacing=spacing)
+        grain = grain_models.Grain(spacing=spacing)
 
-        segment = BatesSegment(
+        segment = bates_geometry.BatesSegment(
             outer_diameter=0.086,
             core_diameter=0.032,
             length=0.150,
@@ -93,9 +93,9 @@ class TestGrainSpacing:
     def test_total_length_single_segment_ignores_spacing(self):
         """Test that spacing is ignored for single segment."""
         spacing = 0.01
-        grain = Grain(spacing=spacing)
+        grain = grain_models.Grain(spacing=spacing)
 
-        segment = BatesSegment(
+        segment = bates_geometry.BatesSegment(
             outer_diameter=0.086,
             core_diameter=0.032,
             length=0.150,
@@ -110,9 +110,9 @@ class TestGrainSpacing:
     def test_total_length_with_negative_spacing(self):
         """Test total_length calculation with negative spacing (overlapping)."""
         spacing = -0.005  # 5mm overlap
-        grain = Grain(spacing=spacing)
+        grain = grain_models.Grain(spacing=spacing)
 
-        segment = BatesSegment(
+        segment = bates_geometry.BatesSegment(
             outer_diameter=0.086,
             core_diameter=0.032,
             length=0.150,
@@ -127,19 +127,17 @@ class TestGrainSpacing:
 
     def test_spacing_affects_cog_calculation(self):
         """Test that spacing is properly used in center of gravity calculations."""
-        from machwave.models.grain.geometries.bates import BatesSegment
-
         spacing = 0.01
-        grain = Grain(spacing=spacing)
+        grain = grain_models.Grain(spacing=spacing)
 
-        segment1 = BatesSegment(
+        segment1 = bates_geometry.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=200e-3,
             density_ratio=1.0,
         )
 
-        segment2 = BatesSegment(
+        segment2 = bates_geometry.BatesSegment(
             outer_diameter=117e-3,
             core_diameter=45e-3,
             length=200e-3,
@@ -160,37 +158,37 @@ class TestGrainSpacing:
 
     def test_spacing_multiple_segments_different_spacing_values(self):
         """Test that changing spacing value affects different grain instances."""
-        segment1 = BatesSegment(
+        segment1 = bates_geometry.BatesSegment(
             outer_diameter=0.086,
             core_diameter=0.032,
             length=0.150,
         )
 
-        segment2 = BatesSegment(
+        segment2 = bates_geometry.BatesSegment(
             outer_diameter=0.086,
             core_diameter=0.032,
             length=0.150,
         )
 
-        segment3 = BatesSegment(
+        segment3 = bates_geometry.BatesSegment(
             outer_diameter=0.086,
             core_diameter=0.032,
             length=0.150,
         )
 
-        segment4 = BatesSegment(
+        segment4 = bates_geometry.BatesSegment(
             outer_diameter=0.086,
             core_diameter=0.032,
             length=0.150,
         )
 
         # Grain with 1mm spacing
-        grain1 = Grain(spacing=0.001)
+        grain1 = grain_models.Grain(spacing=0.001)
         grain1.add_segment(segment1)
         grain1.add_segment(segment2)
 
         # Grain with 10mm spacing
-        grain2 = Grain(spacing=0.010)
+        grain2 = grain_models.Grain(spacing=0.010)
         grain2.add_segment(segment3)
         grain2.add_segment(segment4)
 

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment/__init__.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment/__init__.py
@@ -1,52 +1,52 @@
 import pytest
 
-from machwave.models.grain import GrainGeometryError, InhibitedSurfaces
-from machwave.models.grain.geometries.bates import BatesSegment
+import machwave.models.grain as grain_models
+import machwave.models.grain.geometries.bates as bates_geometry
 
 
 def test_inhibited_surfaces_valid_combinations():
-    """Valid InhibitedSurfaces configurations should not raise."""
+    """Valid grain_models.InhibitedSurfaces configurations should not raise."""
     # Default: outer_surface=True, rest False
-    _ = InhibitedSurfaces()
+    _ = grain_models.InhibitedSurfaces()
 
     # All False
-    _ = InhibitedSurfaces(
+    _ = grain_models.InhibitedSurfaces(
         outer_surface=False, inner_surface=False, upper_end=False, lower_end=False
     )
 
     # Only inner surface inhibited
-    _ = InhibitedSurfaces(inner_surface=True)
+    _ = grain_models.InhibitedSurfaces(inner_surface=True)
 
     # Both ends inhibited
-    _ = InhibitedSurfaces(upper_end=True, lower_end=True)
+    _ = grain_models.InhibitedSurfaces(upper_end=True, lower_end=True)
 
     # Three surfaces inhibited (still valid)
-    _ = InhibitedSurfaces(
+    _ = grain_models.InhibitedSurfaces(
         outer_surface=True, inner_surface=True, upper_end=True, lower_end=False
     )
 
 
 def test_inhibited_surfaces_all_true_raises():
     """All four surfaces inhibited at once is invalid."""
-    with pytest.raises(GrainGeometryError):
-        _ = InhibitedSurfaces(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_models.InhibitedSurfaces(
             outer_surface=True, inner_surface=True, upper_end=True, lower_end=True
         )
 
 
 def test_inhibited_surfaces_frozen():
-    """InhibitedSurfaces should be immutable."""
-    surfaces = InhibitedSurfaces()
+    """grain_models.InhibitedSurfaces should be immutable."""
+    surfaces = grain_models.InhibitedSurfaces()
     with pytest.raises(AttributeError):
         surfaces.outer_surface = False  # type: ignore[misc]
 
 
 def test_grain_segment_accepts_inhibited_surfaces():
-    """Concrete GrainSegment should accept InhibitedSurfaces."""
-    surfaces = InhibitedSurfaces(
+    """Concrete GrainSegment should accept grain_models.InhibitedSurfaces."""
+    surfaces = grain_models.InhibitedSurfaces(
         outer_surface=True, inner_surface=False, upper_end=False, lower_end=False
     )
-    segment = BatesSegment(
+    segment = bates_geometry.BatesSegment(
         outer_diameter=0.1,
         core_diameter=0.05,
         length=0.2,

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/__init__.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/__init__.py
@@ -1,25 +1,25 @@
 import pytest
 
-from machwave.models.grain import GrainGeometryError, GrainSegment2D
+import machwave.models.grain as grain_models
 
 
 def test_grain_segment_2d_geometry_validation():
     # Control group:
-    _ = GrainSegment2D(
+    _ = grain_models.GrainSegment2D(
         outer_diameter=100e-3,
         length=120e-3,
     )
 
     # Negative outer diameter:
-    with pytest.raises(GrainGeometryError):
-        _ = GrainSegment2D(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_models.GrainSegment2D(
             outer_diameter=-100e-3,
             length=120e-3,
         )
 
     # Negative length:
-    with pytest.raises(GrainGeometryError):
-        _ = GrainSegment2D(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_models.GrainSegment2D(
             outer_diameter=100e-3,
             length=-120e-3,
         )

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/test_bates.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/test_bates.py
@@ -1,36 +1,36 @@
 import pytest
 
-from machwave.models.grain import GrainGeometryError
-from machwave.models.grain.geometries import BatesSegment
+import machwave.models.grain as grain_models
+import machwave.models.grain.geometries as grain_geometries
 
 
 def test_bates_segment_geometry_validation():
     # Control group:
-    _ = BatesSegment(
+    _ = grain_geometries.BatesSegment(
         outer_diameter=100e-3,
         core_diameter=30e-3,
         length=120e-3,
     )
 
     # Larger core diameter than outer diameter:
-    with pytest.raises(GrainGeometryError):
-        _ = BatesSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.BatesSegment(
             outer_diameter=100e-3,
             core_diameter=300e-3,
             length=120e-3,
         )
 
     # Negative core diameter:
-    with pytest.raises(GrainGeometryError):
-        _ = BatesSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.BatesSegment(
             outer_diameter=100e-3,
             core_diameter=-30e-3,
             length=120e-3,
         )
 
     # Negative length:
-    with pytest.raises(GrainGeometryError):
-        _ = BatesSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.BatesSegment(
             outer_diameter=100e-3,
             core_diameter=30e-3,
             length=-120e-3,

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/test_dgrain.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/test_dgrain.py
@@ -1,28 +1,28 @@
 import pytest
 
-from machwave.models.grain import GrainGeometryError
-from machwave.models.grain.geometries import DGrainSegment
+import machwave.models.grain as grain_models
+import machwave.models.grain.geometries as grain_geometries
 
 
 def test_dgrain_segment_geometry_validation():
     # Control group:
-    _ = DGrainSegment(
+    _ = grain_geometries.DGrainSegment(
         outer_diameter=100e-3,
         slot_offset=30e-3,
         length=120e-3,
     )
 
     # Negative slot offset:
-    with pytest.raises(GrainGeometryError):
-        _ = DGrainSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.DGrainSegment(
             outer_diameter=100e-3,
             slot_offset=-30e-3,
             length=120e-3,
         )
 
     # Slot offset larget than segment radius:
-    with pytest.raises(GrainGeometryError):
-        _ = DGrainSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.DGrainSegment(
             outer_diameter=100e-3,
             slot_offset=55e-3,
             length=120e-3,

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/test_rodandtube.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/test_rodandtube.py
@@ -1,14 +1,12 @@
 import pytest
 
-from machwave.models.grain import GrainGeometryError
-from machwave.models.grain.geometries import (
-    RodAndTubeGrainSegment,
-)
+import machwave.models.grain as grain_models
+import machwave.models.grain.geometries as grain_geometries
 
 
 def test_rodandtube_segment_geometry_validation():
     # Control group:
-    _ = RodAndTubeGrainSegment(
+    _ = grain_geometries.RodAndTubeGrainSegment(
         outer_diameter=100e-3,
         rod_outer_diameter=30e-3,
         tube_inner_diameter=40e-3,
@@ -16,8 +14,8 @@ def test_rodandtube_segment_geometry_validation():
     )
 
     # Negative rod outer diameter:
-    with pytest.raises(GrainGeometryError):
-        _ = RodAndTubeGrainSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.RodAndTubeGrainSegment(
             outer_diameter=100e-3,
             rod_outer_diameter=-30e-3,
             tube_inner_diameter=40e-3,
@@ -25,8 +23,8 @@ def test_rodandtube_segment_geometry_validation():
         )
 
     # Negative tube inner diameter:
-    with pytest.raises(GrainGeometryError):
-        _ = RodAndTubeGrainSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.RodAndTubeGrainSegment(
             outer_diameter=100e-3,
             rod_outer_diameter=30e-3,
             tube_inner_diameter=-40e-3,
@@ -34,8 +32,8 @@ def test_rodandtube_segment_geometry_validation():
         )
 
     # Rod outer diameter larger than tube inner diameter:
-    with pytest.raises(GrainGeometryError):
-        _ = RodAndTubeGrainSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.RodAndTubeGrainSegment(
             outer_diameter=100e-3,
             rod_outer_diameter=50e-3,
             tube_inner_diameter=40e-3,

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/test_star.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/test_star.py
@@ -1,12 +1,12 @@
 import pytest
 
-from machwave.models.grain import GrainGeometryError
-from machwave.models.grain.geometries import StarGrainSegment
+import machwave.models.grain as grain_models
+import machwave.models.grain.geometries as grain_geometries
 
 
 def test_star_segment_geometry_validation():
     # Control group:
-    _ = StarGrainSegment(
+    _ = grain_geometries.StarGrainSegment(
         outer_diameter=41e-3,
         length=0.5,
         number_of_points=5,
@@ -15,8 +15,8 @@ def test_star_segment_geometry_validation():
     )
 
     # Negative number of points:
-    with pytest.raises(GrainGeometryError):
-        _ = StarGrainSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.StarGrainSegment(
             outer_diameter=41e-3,
             length=0.5,
             number_of_points=-5,
@@ -25,8 +25,8 @@ def test_star_segment_geometry_validation():
         )
 
     # Too many points:
-    with pytest.raises(GrainGeometryError):
-        _ = StarGrainSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.StarGrainSegment(
             outer_diameter=41e-3,
             length=0.5,
             number_of_points=13,
@@ -35,8 +35,8 @@ def test_star_segment_geometry_validation():
         )
 
     # Negative point length:
-    with pytest.raises(GrainGeometryError):
-        _ = StarGrainSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.StarGrainSegment(
             outer_diameter=41e-3,
             length=0.5,
             number_of_points=5,
@@ -45,8 +45,8 @@ def test_star_segment_geometry_validation():
         )
 
     # Negative point width:
-    with pytest.raises(GrainGeometryError):
-        _ = StarGrainSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.StarGrainSegment(
             outer_diameter=41e-3,
             length=0.5,
             number_of_points=5,

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/test_wagonwheel.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/test_wagonwheel.py
@@ -1,14 +1,12 @@
 import pytest
 
-from machwave.models.grain import GrainGeometryError
-from machwave.models.grain.geometries import (
-    WagonWheelGrainSegment,
-)
+import machwave.models.grain as grain_models
+import machwave.models.grain.geometries as grain_geometries
 
 
 def test_star_segment_geometry_validation():
     # Control group:
-    _ = WagonWheelGrainSegment(
+    _ = grain_geometries.WagonWheelGrainSegment(
         outer_diameter=41e-3,
         length=0.5,
         core_diameter=8e-3,
@@ -19,8 +17,8 @@ def test_star_segment_geometry_validation():
     )
 
     # Negative core diameter:
-    with pytest.raises(GrainGeometryError):
-        _ = WagonWheelGrainSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.WagonWheelGrainSegment(
             outer_diameter=41e-3,
             length=0.5,
             core_diameter=-8e-3,
@@ -31,8 +29,8 @@ def test_star_segment_geometry_validation():
         )
 
     # Port inner diameter smaller than core diameter:
-    with pytest.raises(GrainGeometryError):
-        _ = WagonWheelGrainSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.WagonWheelGrainSegment(
             outer_diameter=41e-3,
             length=0.5,
             core_diameter=8e-3,
@@ -43,8 +41,8 @@ def test_star_segment_geometry_validation():
         )
 
     # Port outer diameter smaller than inner diameter:
-    with pytest.raises(GrainGeometryError):
-        _ = WagonWheelGrainSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.WagonWheelGrainSegment(
             outer_diameter=41e-3,
             length=0.5,
             core_diameter=8e-3,
@@ -55,8 +53,8 @@ def test_star_segment_geometry_validation():
         )
 
     # Negative number of ports:
-    with pytest.raises(GrainGeometryError):
-        _ = WagonWheelGrainSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.WagonWheelGrainSegment(
             outer_diameter=41e-3,
             length=0.5,
             core_diameter=8e-3,
@@ -67,8 +65,8 @@ def test_star_segment_geometry_validation():
         )
 
     # Too many points:
-    with pytest.raises(GrainGeometryError):
-        _ = WagonWheelGrainSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.WagonWheelGrainSegment(
             outer_diameter=41e-3,
             length=0.5,
             core_diameter=8e-3,
@@ -79,8 +77,8 @@ def test_star_segment_geometry_validation():
         )
 
     # Negative port angle:
-    with pytest.raises(GrainGeometryError):
-        _ = WagonWheelGrainSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.WagonWheelGrainSegment(
             outer_diameter=41e-3,
             length=0.5,
             core_diameter=8e-3,
@@ -91,8 +89,8 @@ def test_star_segment_geometry_validation():
         )
 
     # Port angle too large:
-    with pytest.raises(GrainGeometryError):
-        _ = WagonWheelGrainSegment(
+    with pytest.raises(grain_models.GrainGeometryError):
+        _ = grain_geometries.WagonWheelGrainSegment(
             outer_diameter=41e-3,
             length=0.5,
             core_diameter=8e-3,

--- a/tests/test_models/test_propulsion/test_grain/test_inhibition/test_fmm_inhibition.py
+++ b/tests/test_models/test_propulsion/test_grain/test_inhibition/test_fmm_inhibition.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 
-from machwave.models.grain import InhibitedSurfaces
-from machwave.models.grain.geometries import ConicalGrainSegment, StarGrainSegment
+import machwave.models.grain as grain_models
+import machwave.models.grain.geometries as grain_geometries
 
 # ── shared geometry params ────────────────────────────────────────────────────
 
@@ -75,7 +75,9 @@ def _end_burning_cells(masked_face_3d, idx: int) -> int:
 
 def test_2d_outer_surface_inhibited_by_default():
     """Default config: outer surface IS inhibited → boundary ring = all propellant (1s)."""
-    seg = StarGrainSegment(**STAR_PARAMS)  # outer_surface=True by default
+    seg = grain_geometries.StarGrainSegment(
+        **STAR_PARAMS
+    )  # outer_surface=True by default
     mf = seg.get_masked_face()
 
     from scipy.ndimage import binary_erosion
@@ -90,8 +92,9 @@ def test_2d_outer_surface_inhibited_by_default():
 
 def test_2d_outer_surface_exposed():
     """OD=F → outer boundary ring must contain burning cells."""
-    seg = StarGrainSegment(
-        **STAR_PARAMS, inhibited_surfaces=InhibitedSurfaces(outer_surface=False)
+    seg = grain_geometries.StarGrainSegment(
+        **STAR_PARAMS,
+        inhibited_surfaces=grain_models.InhibitedSurfaces(outer_surface=False),
     )
     mf = seg.get_masked_face()
 
@@ -109,16 +112,16 @@ def test_2d_outer_surface_exposed():
 
 def test_2d_inner_surface_exposed_by_default():
     """Default config: inner surface NOT inhibited → bore pixels are burning (0)."""
-    seg = StarGrainSegment(**STAR_PARAMS)
+    seg = grain_geometries.StarGrainSegment(**STAR_PARAMS)
     mf = seg.get_masked_face()
     assert _burning_cells(mf) > 0, "Bore should be burning by default."
 
 
 def test_2d_inner_surface_inhibited():
     """ID=T → bore pixels are masked out, not burning."""
-    seg = StarGrainSegment(
+    seg = grain_geometries.StarGrainSegment(
         **STAR_PARAMS,
-        inhibited_surfaces=InhibitedSurfaces(inner_surface=True),
+        inhibited_surfaces=grain_models.InhibitedSurfaces(inner_surface=True),
     )
     mf = seg.get_masked_face()
     # All unmasked region should be propellant (1), not bore
@@ -132,9 +135,11 @@ def test_2d_inner_surface_inhibited():
 
 def test_2d_outer_exposed_inner_inhibited():
     """OD=F, ID=T → outer boundary burns, bore is masked; they must not cancel each other."""
-    seg = StarGrainSegment(
+    seg = grain_geometries.StarGrainSegment(
         **STAR_PARAMS,
-        inhibited_surfaces=InhibitedSurfaces(outer_surface=False, inner_surface=True),
+        inhibited_surfaces=grain_models.InhibitedSurfaces(
+            outer_surface=False, inner_surface=True
+        ),
     )
     mf = seg.get_masked_face()
 
@@ -155,9 +160,9 @@ def test_2d_outer_exposed_inner_inhibited():
 
 def test_3d_upper_end_exposed_by_default():
     """Default: UE=F → upper end slice has burning cells beyond the bore."""
-    seg = ConicalGrainSegment(
+    seg = grain_geometries.ConicalGrainSegment(
         **CONICAL_PARAMS,
-        inhibited_surfaces=InhibitedSurfaces(outer_surface=False),
+        inhibited_surfaces=grain_models.InhibitedSurfaces(outer_surface=False),
     )
     mf = seg.get_masked_face()
     assert _end_burning_cells(mf, -1) > 0, "Upper end should be burning by default."
@@ -165,9 +170,11 @@ def test_3d_upper_end_exposed_by_default():
 
 def test_3d_upper_end_inhibited():
     """UE=T → upper end slice has no burning cells beyond the bore."""
-    seg = ConicalGrainSegment(
+    seg = grain_geometries.ConicalGrainSegment(
         **CONICAL_PARAMS,
-        inhibited_surfaces=InhibitedSurfaces(outer_surface=False, upper_end=True),
+        inhibited_surfaces=grain_models.InhibitedSurfaces(
+            outer_surface=False, upper_end=True
+        ),
     )
     mf = seg.get_masked_face()
     assert _end_burning_cells(mf, -1) == 0, (
@@ -177,9 +184,9 @@ def test_3d_upper_end_inhibited():
 
 def test_3d_lower_end_exposed_by_default():
     """Default: LE=F → lower end slice has burning cells beyond the bore."""
-    seg = ConicalGrainSegment(
+    seg = grain_geometries.ConicalGrainSegment(
         **CONICAL_PARAMS,
-        inhibited_surfaces=InhibitedSurfaces(outer_surface=False),
+        inhibited_surfaces=grain_models.InhibitedSurfaces(outer_surface=False),
     )
     mf = seg.get_masked_face()
     assert _end_burning_cells(mf, 0) > 0, "Lower end should be burning by default."
@@ -187,9 +194,11 @@ def test_3d_lower_end_exposed_by_default():
 
 def test_3d_lower_end_inhibited():
     """LE=T → lower end slice has no burning cells beyond the bore."""
-    seg = ConicalGrainSegment(
+    seg = grain_geometries.ConicalGrainSegment(
         **CONICAL_PARAMS,
-        inhibited_surfaces=InhibitedSurfaces(outer_surface=False, lower_end=True),
+        inhibited_surfaces=grain_models.InhibitedSurfaces(
+            outer_surface=False, lower_end=True
+        ),
     )
     mf = seg.get_masked_face()
     assert _end_burning_cells(mf, 0) == 0, (
@@ -199,9 +208,9 @@ def test_3d_lower_end_inhibited():
 
 def test_3d_both_ends_inhibited():
     """UE=T, LE=T → neither end slice has burning cells beyond the bore."""
-    seg = ConicalGrainSegment(
+    seg = grain_geometries.ConicalGrainSegment(
         **CONICAL_PARAMS,
-        inhibited_surfaces=InhibitedSurfaces(
+        inhibited_surfaces=grain_models.InhibitedSurfaces(
             outer_surface=False, upper_end=True, lower_end=True
         ),
     )
@@ -215,9 +224,11 @@ def test_3d_both_ends_inhibited():
 
 def test_3d_outer_exposed_upper_end_inhibited():
     """OD=F, UE=T → outer surface burns along the body; upper face does not."""
-    seg = ConicalGrainSegment(
+    seg = grain_geometries.ConicalGrainSegment(
         **CONICAL_PARAMS,
-        inhibited_surfaces=InhibitedSurfaces(outer_surface=False, upper_end=True),
+        inhibited_surfaces=grain_models.InhibitedSurfaces(
+            outer_surface=False, upper_end=True
+        ),
     )
     mf = seg.get_masked_face()
 
@@ -236,9 +247,11 @@ def test_3d_outer_exposed_upper_end_inhibited():
 
 def test_3d_outer_exposed_lower_end_inhibited():
     """OD=F, LE=T → outer surface burns along the body; lower face does not."""
-    seg = ConicalGrainSegment(
+    seg = grain_geometries.ConicalGrainSegment(
         **CONICAL_PARAMS,
-        inhibited_surfaces=InhibitedSurfaces(outer_surface=False, lower_end=True),
+        inhibited_surfaces=grain_models.InhibitedSurfaces(
+            outer_surface=False, lower_end=True
+        ),
     )
     mf = seg.get_masked_face()
 

--- a/tests/test_models/test_propulsion/test_grain/test_moi/test_bates_moi.py
+++ b/tests/test_models/test_propulsion/test_grain/test_moi/test_bates_moi.py
@@ -3,8 +3,8 @@
 import numpy as np
 import pytest
 
-from machwave.models.grain import Grain
-from machwave.models.grain.geometries import BatesSegment
+import machwave.models.grain as grain_models
+import machwave.models.grain.geometries as grain_geometries
 
 
 class TestBatesSegmentMomentOfInertia:
@@ -17,7 +17,7 @@ class TestBatesSegmentMomentOfInertia:
         length = 0.2  # 200 mm
         ideal_density = 1800.0  # kg/m^3
 
-        segment = BatesSegment(
+        segment = grain_geometries.BatesSegment(
             outer_diameter=outer_diameter,
             core_diameter=core_diameter,
             length=length,
@@ -55,14 +55,14 @@ class TestBatesSegmentMomentOfInertia:
         core_diameter = 0.045
         ideal_density = 1800.0
 
-        segment_short = BatesSegment(
+        segment_short = grain_geometries.BatesSegment(
             outer_diameter=outer_diameter,
             core_diameter=core_diameter,
             length=0.1,
             density_ratio=1.0,
         )
 
-        segment_long = BatesSegment(
+        segment_long = grain_geometries.BatesSegment(
             outer_diameter=outer_diameter,
             core_diameter=core_diameter,
             length=0.3,
@@ -85,7 +85,7 @@ class TestBatesSegmentMomentOfInertia:
 
     def test_segment_moi_decreases_with_burn(self):
         """Test that MOI decreases as propellant burns (mass decreases)."""
-        segment = BatesSegment(
+        segment = grain_geometries.BatesSegment(
             outer_diameter=0.117,
             core_diameter=0.045,
             length=0.2,
@@ -111,7 +111,7 @@ class TestBatesSegmentMomentOfInertia:
 
     def test_segment_moi_scales_with_density(self):
         """Test that MOI scales linearly with density."""
-        segment = BatesSegment(
+        segment = grain_geometries.BatesSegment(
             outer_diameter=0.117,
             core_diameter=0.045,
             length=0.2,
@@ -139,7 +139,7 @@ class TestBatesSegmentMomentOfInertia:
         length = 0.3  # 300 mm
         ideal_density = 1800.0
 
-        segment = BatesSegment(
+        segment = grain_geometries.BatesSegment(
             outer_diameter=outer_diameter,
             core_diameter=core_diameter,
             length=length,
@@ -172,8 +172,8 @@ class TestBatesGrainMomentOfInertia:
 
     def test_single_segment_grain_moi(self):
         """Test MOI for a grain with a single BATES segment."""
-        grain = Grain(spacing=0.0)
-        segment = BatesSegment(
+        grain = grain_models.Grain(spacing=0.0)
+        segment = grain_geometries.BatesSegment(
             outer_diameter=0.117,
             core_diameter=0.045,
             length=0.2,
@@ -195,14 +195,14 @@ class TestBatesGrainMomentOfInertia:
 
     def test_two_segments_equal_moi(self):
         """Test MOI for two identical BATES segments."""
-        grain = Grain(spacing=0.0)
-        segment1 = BatesSegment(
+        grain = grain_models.Grain(spacing=0.0)
+        segment1 = grain_geometries.BatesSegment(
             outer_diameter=0.117,
             core_diameter=0.045,
             length=0.2,
             density_ratio=1.0,
         )
-        segment2 = BatesSegment(
+        segment2 = grain_geometries.BatesSegment(
             outer_diameter=0.117,
             core_diameter=0.045,
             length=0.2,
@@ -228,10 +228,10 @@ class TestBatesGrainMomentOfInertia:
 
     def test_three_segments_with_spacing(self):
         """Test MOI for three BATES segments with spacing."""
-        grain = Grain(spacing=0.05)  # 50mm spacing
+        grain = grain_models.Grain(spacing=0.05)  # 50mm spacing
 
         for _ in range(3):
-            segment = BatesSegment(
+            segment = grain_geometries.BatesSegment(
                 outer_diameter=0.117,
                 core_diameter=0.045,
                 length=0.2,
@@ -252,10 +252,10 @@ class TestBatesGrainMomentOfInertia:
 
     def test_moi_decreases_during_burn_multisegment(self):
         """Test that total MOI decreases as multi-segment grain burns."""
-        grain = Grain(spacing=0.0)
+        grain = grain_models.Grain(spacing=0.0)
 
         for _ in range(2):
-            segment = BatesSegment(
+            segment = grain_geometries.BatesSegment(
                 outer_diameter=0.117,
                 core_diameter=0.045,
                 length=0.2,
@@ -280,16 +280,16 @@ class TestBatesGrainMomentOfInertia:
 
     def test_different_density_ratios(self):
         """Test MOI calculation with segments of different density ratios."""
-        grain = Grain(spacing=0.0)
+        grain = grain_models.Grain(spacing=0.0)
 
-        segment1 = BatesSegment(
+        segment1 = grain_geometries.BatesSegment(
             outer_diameter=0.117,
             core_diameter=0.045,
             length=0.2,
             density_ratio=1.0,
         )
 
-        segment2 = BatesSegment(
+        segment2 = grain_geometries.BatesSegment(
             outer_diameter=0.117,
             core_diameter=0.045,
             length=0.2,
@@ -309,17 +309,17 @@ class TestBatesGrainMomentOfInertia:
 
     def test_parallel_axis_theorem_validation(self):
         """Validate that parallel axis theorem is correctly applied."""
-        grain = Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.1)
 
         # Create two different segments
-        segment1 = BatesSegment(
+        segment1 = grain_geometries.BatesSegment(
             outer_diameter=0.117,
             core_diameter=0.045,
             length=0.15,
             density_ratio=1.0,
         )
 
-        segment2 = BatesSegment(
+        segment2 = grain_geometries.BatesSegment(
             outer_diameter=0.117,
             core_diameter=0.045,
             length=0.25,

--- a/tests/test_models/test_propulsion/test_grain/test_moi/test_fmm2d_moi.py
+++ b/tests/test_models/test_propulsion/test_grain/test_moi/test_fmm2d_moi.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from machwave.models.grain import Grain
+import machwave.models.grain as grain_models
 from tests.test_models.test_propulsion.test_grain.test_moi.conftest import (
     fmm2d_geometries,
 )
@@ -119,7 +119,7 @@ class TestFMM2DGrainMultiSegmentMomentOfInertia:
 
     def test_single_segment_grain_moi(self, segment_factory, geometry_name):
         """Test MOI for a grain with a single 2D segment."""
-        grain = Grain(spacing=0.0)
+        grain = grain_models.Grain(spacing=0.0)
         segment = segment_factory(length=0.2, outer_diameter=0.1)
         grain.add_segment(segment)
 
@@ -137,7 +137,7 @@ class TestFMM2DGrainMultiSegmentMomentOfInertia:
 
     def test_two_segments_equal_moi(self, segment_factory, geometry_name):
         """Test MOI for two identical 2D segments."""
-        grain = Grain(spacing=0.0)
+        grain = grain_models.Grain(spacing=0.0)
         segment1 = segment_factory(length=0.2, outer_diameter=0.1)
         segment2 = segment_factory(length=0.2, outer_diameter=0.1)
 
@@ -161,7 +161,7 @@ class TestFMM2DGrainMultiSegmentMomentOfInertia:
 
     def test_three_segments_with_spacing(self, segment_factory, geometry_name):
         """Test MOI for three 2D segments with spacing."""
-        grain = Grain(spacing=0.05)  # 50mm spacing
+        grain = grain_models.Grain(spacing=0.05)  # 50mm spacing
 
         for _ in range(3):
             segment = segment_factory(length=0.2, outer_diameter=0.1)
@@ -179,7 +179,7 @@ class TestFMM2DGrainMultiSegmentMomentOfInertia:
         self, segment_factory, geometry_name
     ):
         """Test that total MOI decreases as multi-segment grain burns."""
-        grain = Grain(spacing=0.0)
+        grain = grain_models.Grain(spacing=0.0)
 
         for _ in range(2):
             segment = segment_factory(length=0.2, outer_diameter=0.1)
@@ -205,14 +205,14 @@ class TestFMM2DGrainMultiSegmentMomentOfInertia:
         ideal_density = 1800.0
 
         # Grain with no spacing
-        grain_no_spacing = Grain(spacing=0.0)
+        grain_no_spacing = grain_models.Grain(spacing=0.0)
         segment1 = segment_factory(length=0.2, outer_diameter=0.1)
         segment2 = segment_factory(length=0.2, outer_diameter=0.1)
         grain_no_spacing.add_segment(segment1)
         grain_no_spacing.add_segment(segment2)
 
         # Grain with spacing
-        grain_with_spacing = Grain(spacing=0.1)
+        grain_with_spacing = grain_models.Grain(spacing=0.1)
         segment3 = segment_factory(length=0.2, outer_diameter=0.1)
         segment4 = segment_factory(length=0.2, outer_diameter=0.1)
         grain_with_spacing.add_segment(segment3)

--- a/tests/test_models/test_propulsion/test_grain/test_moi/test_fmm3d_moi.py
+++ b/tests/test_models/test_propulsion/test_grain/test_moi/test_fmm3d_moi.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from machwave.models.grain import Grain
+import machwave.models.grain as grain_models
 from tests.test_models.test_propulsion.test_grain.test_moi.conftest import (
     fmm3d_geometries,
 )
@@ -138,7 +138,7 @@ class TestFMM3DGrainMultiSegmentMomentOfInertia:
 
     def test_single_segment_grain_moi(self, segment_factory, geometry_name):
         """Test MOI for a grain with a single 3D segment."""
-        grain = Grain(spacing=0.0)
+        grain = grain_models.Grain(spacing=0.0)
         segment = segment_factory(length=0.2, outer_diameter=0.1)
         grain.add_segment(segment)
 
@@ -156,7 +156,7 @@ class TestFMM3DGrainMultiSegmentMomentOfInertia:
 
     def test_two_segments_equal_moi(self, segment_factory, geometry_name):
         """Test MOI for two identical 3D segments."""
-        grain = Grain(spacing=0.0)
+        grain = grain_models.Grain(spacing=0.0)
         segment1 = segment_factory(length=0.2, outer_diameter=0.1)
         segment2 = segment_factory(length=0.2, outer_diameter=0.1)
 
@@ -180,7 +180,7 @@ class TestFMM3DGrainMultiSegmentMomentOfInertia:
 
     def test_three_segments_with_spacing(self, segment_factory, geometry_name):
         """Test MOI for three 3D segments with spacing."""
-        grain = Grain(spacing=0.05)  # 50mm spacing
+        grain = grain_models.Grain(spacing=0.05)  # 50mm spacing
 
         for _ in range(3):
             segment = segment_factory(length=0.2, outer_diameter=0.1)
@@ -198,7 +198,7 @@ class TestFMM3DGrainMultiSegmentMomentOfInertia:
         self, segment_factory, geometry_name
     ):
         """Test that total MOI decreases as multi-segment grain burns."""
-        grain = Grain(spacing=0.0)
+        grain = grain_models.Grain(spacing=0.0)
 
         for _ in range(2):
             segment = segment_factory(length=0.2, outer_diameter=0.1)
@@ -224,14 +224,14 @@ class TestFMM3DGrainMultiSegmentMomentOfInertia:
         ideal_density = 1800.0
 
         # Grain with no spacing
-        grain_no_spacing = Grain(spacing=0.0)
+        grain_no_spacing = grain_models.Grain(spacing=0.0)
         segment1 = segment_factory(length=0.2, outer_diameter=0.1)
         segment2 = segment_factory(length=0.2, outer_diameter=0.1)
         grain_no_spacing.add_segment(segment1)
         grain_no_spacing.add_segment(segment2)
 
         # Grain with spacing
-        grain_with_spacing = Grain(spacing=0.1)
+        grain_with_spacing = grain_models.Grain(spacing=0.1)
         segment3 = segment_factory(length=0.2, outer_diameter=0.1)
         segment4 = segment_factory(length=0.2, outer_diameter=0.1)
         grain_with_spacing.add_segment(segment3)
@@ -255,7 +255,7 @@ class TestFMM3DGrainMultiSegmentMomentOfInertia:
 
     def test_parallel_axis_theorem_validation(self, segment_factory, geometry_name):
         """Validate that parallel axis theorem is correctly applied in multi-segment grain."""
-        grain = Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.1)
 
         # Create two segments
         segment1 = segment_factory(length=0.2, outer_diameter=0.1)

--- a/tests/test_models/test_propulsion/test_grain/test_segment_mismatches.py
+++ b/tests/test_models/test_propulsion/test_grain/test_segment_mismatches.py
@@ -2,9 +2,9 @@
 
 import pytest
 
-from machwave.models.grain import Grain
-from machwave.models.grain.base import InhibitedSurfaces
-from machwave.models.grain.geometries import BatesSegment, StarGrainSegment
+import machwave.models.grain as grain_models
+import machwave.models.grain.base as grain_base
+import machwave.models.grain.geometries as grain_geometries
 
 
 def _bates(
@@ -13,8 +13,8 @@ def _bates(
     core_diameter: float = 0.030,
     length: float = 0.100,
     density_ratio: float = 1.0,
-) -> BatesSegment:
-    return BatesSegment(
+) -> grain_geometries.BatesSegment:
+    return grain_geometries.BatesSegment(
         outer_diameter=outer_diameter,
         core_diameter=core_diameter,
         length=length,
@@ -29,10 +29,10 @@ def _star(
     number_of_points: int = 5,
     point_length: float = 0.020,
     point_width: float = 0.010,
-    inhibited_surfaces: InhibitedSurfaces | None = None,
+    inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
     density_ratio: float = 1.0,
-) -> StarGrainSegment:
-    return StarGrainSegment(
+) -> grain_geometries.StarGrainSegment:
+    return grain_geometries.StarGrainSegment(
         outer_diameter=outer_diameter,
         length=length,
         number_of_points=number_of_points,
@@ -43,8 +43,8 @@ def _star(
     )
 
 
-def _grain(*segments) -> Grain:
-    grain = Grain()
+def _grain(*segments) -> grain_models.Grain:
+    grain = grain_models.Grain()
     for segment in segments:
         grain.add_segment(segment)
     return grain
@@ -52,7 +52,7 @@ def _grain(*segments) -> Grain:
 
 class TestGrainGetSegmentMismatches:
     def test_empty_grain(self):
-        assert Grain().get_segment_mismatches() == []
+        assert grain_models.Grain().get_segment_mismatches() == []
 
     def test_single_segment(self):
         assert _grain(_bates()).get_segment_mismatches() == []
@@ -79,7 +79,7 @@ class TestGrainGetSegmentMismatches:
         # the non-float equality branch.
         mismatches = _grain(
             _star(),
-            _star(inhibited_surfaces=InhibitedSurfaces(outer_surface=False)),
+            _star(inhibited_surfaces=grain_base.InhibitedSurfaces(outer_surface=False)),
         ).get_segment_mismatches()
 
         assert len(mismatches) == 1

--- a/tests/test_models/test_propulsion/test_motors/test_cog.py
+++ b/tests/test_models/test_propulsion/test_motors/test_cog.py
@@ -3,10 +3,8 @@
 import numpy as np
 import pytest
 
-from machwave.models import grain as grain_models
-from machwave.models.propellants.formulations import (
-    solid as solid_propellants,
-)
+import machwave.models.grain as grain_models
+import machwave.models.propellants.formulations.solid as solid_propellants
 
 from tests.factories import (
     BatesSegmentFactory,

--- a/tests/test_models/test_propulsion/test_nozzle.py
+++ b/tests/test_models/test_propulsion/test_nozzle.py
@@ -1,6 +1,6 @@
 import pytest
 
-from machwave.core.geometric import get_circle_area
+import machwave.core.geometric as geometric
 
 from tests.factories import NozzleFactory
 
@@ -34,7 +34,7 @@ class TestNozzleGeometry:
 
     def test_outlet_area_equals_expansion_ratio_times_throat_area(self, nozzle):
         """A_exit / A_throat = ε by definition."""
-        A_exit = get_circle_area(nozzle.outlet_diameter)
+        A_exit = geometric.get_circle_area(nozzle.outlet_diameter)
         assert A_exit == pytest.approx(2.0268299164e-3, rel=1e-6)
 
     def test_outlet_diameter_scales_with_expansion_ratio(self):

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_base.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_base.py
@@ -2,15 +2,9 @@
 
 import pytest
 
-from machwave.models.propellants.categories import MixtureType
-from machwave.models.propellants.components import ComponentRole
-from machwave.models.propellants.formulations.base import (
-    _create_propellant,
-    _parse_component,
-    _parse_components,
-    _parse_mixture_type,
-    _parse_properties,
-)
+import machwave.models.propellants.categories as propellant_categories
+import machwave.models.propellants.components as propellant_components
+import machwave.models.propellants.formulations.base as formulations_base
 
 
 class TestParseMixtureType:
@@ -18,28 +12,28 @@ class TestParseMixtureType:
 
     def test_parse_solid_mixture_type(self):
         data = {"mixture_type": "solid"}
-        result = _parse_mixture_type(data)
-        assert result == MixtureType.SOLID
+        result = formulations_base._parse_mixture_type(data)
+        assert result == propellant_categories.MixtureType.SOLID
 
     def test_parse_biliquid_mixture_type(self):
         data = {"mixture_type": "biliquid"}
-        result = _parse_mixture_type(data)
-        assert result == MixtureType.BILIQUID
+        result = formulations_base._parse_mixture_type(data)
+        assert result == propellant_categories.MixtureType.BILIQUID
 
     def test_parse_uppercase_mixture_type(self):
         data = {"mixture_type": "SOLID"}
-        result = _parse_mixture_type(data)
-        assert result == MixtureType.SOLID
+        result = formulations_base._parse_mixture_type(data)
+        assert result == propellant_categories.MixtureType.SOLID
 
     def test_missing_mixture_type_raises_error(self):
         data = {}
         with pytest.raises(ValueError, match="must contain 'mixture_type'"):
-            _parse_mixture_type(data)
+            formulations_base._parse_mixture_type(data)
 
     def test_invalid_mixture_type_raises_error(self):
         data = {"mixture_type": "invalid"}
         with pytest.raises(ValueError, match="Invalid mixture_type"):
-            _parse_mixture_type(data)
+            formulations_base._parse_mixture_type(data)
 
 
 class TestParseComponent:
@@ -55,10 +49,10 @@ class TestParseComponent:
             "enthalpy": -494600.0,
             "temperature": 298.15,
         }
-        result = _parse_component(comp_data)
+        result = formulations_base._parse_component(comp_data)
 
         assert result.name == "KNO3"
-        assert result.role == ComponentRole.OXIDIZER
+        assert result.role == propellant_components.ComponentRole.OXIDIZER
         assert result.density == 2109.0
         assert result.chemical_formula == {"K": 1, "N": 1, "O": 3}
         assert result.enthalpy == -494600.0
@@ -73,10 +67,10 @@ class TestParseComponent:
             "chemical_formula": {"C": 1, "H": 1.95},
             "enthalpy": -23500.0,
         }
-        result = _parse_component(comp_data)
+        result = formulations_base._parse_component(comp_data)
 
         assert result.name == "RP1"
-        assert result.role == ComponentRole.FUEL
+        assert result.role == propellant_components.ComponentRole.FUEL
         assert result.density == 820.0
 
     def test_parse_additive_component(self):
@@ -88,8 +82,8 @@ class TestParseComponent:
             "chemical_formula": {"Al": 1},
             "enthalpy": 0.0,
         }
-        result = _parse_component(comp_data)
-        assert result.role == ComponentRole.ADDITIVE
+        result = formulations_base._parse_component(comp_data)
+        assert result.role == propellant_components.ComponentRole.ADDITIVE
 
     def test_parse_component_with_default_temperature(self):
         comp_data = {
@@ -100,7 +94,7 @@ class TestParseComponent:
             "chemical_formula": {"H": 2},
             "enthalpy": 0.0,
         }
-        result = _parse_component(comp_data)
+        result = formulations_base._parse_component(comp_data)
 
         assert result.initial_temperature == 298.15
 
@@ -114,7 +108,7 @@ class TestParseComponent:
             "enthalpy": -494600.0,
         }
         with pytest.raises(KeyError):
-            _parse_component(comp_data)
+            formulations_base._parse_component(comp_data)
 
     def test_invalid_role_raises_error(self):
         comp_data = {
@@ -124,7 +118,7 @@ class TestParseComponent:
             "density": 1000.0,
         }
         with pytest.raises(ValueError, match="Invalid component role"):
-            _parse_component(comp_data)
+            formulations_base._parse_component(comp_data)
 
     def test_missing_required_field_raises_error(self):
         comp_data = {
@@ -135,7 +129,7 @@ class TestParseComponent:
             # Missing mass_fraction and chemical_formula
         }
         with pytest.raises(KeyError):
-            _parse_component(comp_data)
+            formulations_base._parse_component(comp_data)
 
 
 class TestParseComponents:
@@ -143,8 +137,8 @@ class TestParseComponents:
 
     def test_parse_empty_components(self):
         data = {}
-        components, mass_fractions = _parse_components(
-            data, mixture_type=MixtureType.SOLID
+        components, mass_fractions = formulations_base._parse_components(
+            data, mixture_type=propellant_categories.MixtureType.SOLID
         )
         assert components == []
         assert mass_fractions == []
@@ -162,8 +156,8 @@ class TestParseComponents:
                 }
             ]
         }
-        components, mass_fractions = _parse_components(
-            data, mixture_type=MixtureType.SOLID
+        components, mass_fractions = formulations_base._parse_components(
+            data, mixture_type=propellant_categories.MixtureType.SOLID
         )
 
         assert len(components) == 1
@@ -191,8 +185,8 @@ class TestParseComponents:
                 },
             ]
         }
-        components, mass_fractions = _parse_components(
-            data, mixture_type=MixtureType.SOLID
+        components, mass_fractions = formulations_base._parse_components(
+            data, mixture_type=propellant_categories.MixtureType.SOLID
         )
 
         assert len(components) == 2
@@ -218,7 +212,7 @@ class TestParseProperties:
                 "qsi_exhaust": 0.0,
             }
         }
-        result = _parse_properties(data)
+        result = formulations_base._parse_properties(data)
 
         assert result is not None
         assert result.k_chamber == 1.24
@@ -229,7 +223,7 @@ class TestParseProperties:
 
     def test_parse_properties_when_absent(self):
         data = {}
-        result = _parse_properties(data)
+        result = formulations_base._parse_properties(data)
         assert result is None
 
     def test_missing_required_property_raises_error(self):
@@ -240,15 +234,13 @@ class TestParseProperties:
             }
         }
         with pytest.raises(KeyError):
-            _parse_properties(data)
+            formulations_base._parse_properties(data)
 
 
 class TestCreatePropellant:
     """Tests for _create_propellant function."""
 
     def test_create_solid_propellant(self):
-        from machwave.models.propellants.categories import SolidPropellant
-
         data = {
             "name": "Test Solid",
             "combustion_efficiency": 0.95,
@@ -258,18 +250,20 @@ class TestCreatePropellant:
         mass_fractions = []
         properties = None
 
-        result = _create_propellant(
-            MixtureType.SOLID, data, components, mass_fractions, properties
+        result = formulations_base._create_propellant(
+            propellant_categories.MixtureType.SOLID,
+            data,
+            components,
+            mass_fractions,
+            properties,
         )
 
-        assert isinstance(result, SolidPropellant)
+        assert isinstance(result, propellant_categories.SolidPropellant)
         assert result.name == "Test Solid"
         assert result.combustion_efficiency == 0.95
         assert len(result.burn_rate_map) == 1
 
     def test_create_biliquid_propellant(self):
-        from machwave.models.propellants.categories import BiliquidPropellant
-
         data = {
             "name": "Test Biliquid",
             "combustion_efficiency": 0.98,
@@ -279,29 +273,33 @@ class TestCreatePropellant:
         mass_fractions = None
         properties = None
 
-        result = _create_propellant(
-            MixtureType.BILIQUID, data, components, mass_fractions, properties
+        result = formulations_base._create_propellant(
+            propellant_categories.MixtureType.BILIQUID,
+            data,
+            components,
+            mass_fractions,
+            properties,
         )
 
-        assert isinstance(result, BiliquidPropellant)
+        assert isinstance(result, propellant_categories.BiliquidPropellant)
         assert result.name == "Test Biliquid"
         assert result.combustion_efficiency == 0.98
         assert result.oxidizer_to_fuel_ratio == 2.5
 
     def test_create_solid_with_default_efficiency(self):
-        from machwave.models.propellants.categories import SolidPropellant
-
         data = {"name": "Test"}
-        result = _create_propellant(MixtureType.SOLID, data, [], [], None)
+        result = formulations_base._create_propellant(
+            propellant_categories.MixtureType.SOLID, data, [], [], None
+        )
 
-        assert isinstance(result, SolidPropellant)
+        assert isinstance(result, propellant_categories.SolidPropellant)
         assert result.combustion_efficiency == 0.95
 
     def test_create_biliquid_with_default_efficiency(self):
-        from machwave.models.propellants.categories import BiliquidPropellant
-
         data = {"name": "Test"}
-        result = _create_propellant(MixtureType.BILIQUID, data, [], None, None)
+        result = formulations_base._create_propellant(
+            propellant_categories.MixtureType.BILIQUID, data, [], None, None
+        )
 
-        assert isinstance(result, BiliquidPropellant)
+        assert isinstance(result, propellant_categories.BiliquidPropellant)
         assert result.combustion_efficiency == 0.98

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_biliquid.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_biliquid.py
@@ -1,31 +1,28 @@
 import pytest
 
-from machwave.models.propellants import BiliquidPropellant
-from machwave.models.propellants.components import (
-    ComponentRole,
-    PropellantComponent,
-)
+import machwave.models.propellants as propellants_models
+import machwave.models.propellants.components as propellant_components
 
 
 @pytest.fixture
-def lox_rp1_propellant() -> BiliquidPropellant:
-    oxidizer = PropellantComponent(
+def lox_rp1_propellant() -> propellants_models.BiliquidPropellant:
+    oxidizer = propellant_components.PropellantComponent(
         name="LOX",
         density=1141.0,
         chemical_formula={"O": 2},
         enthalpy=0.0,
         initial_temperature=298.15,
-        role=ComponentRole.OXIDIZER,
+        role=propellant_components.ComponentRole.OXIDIZER,
     )
-    fuel = PropellantComponent(
+    fuel = propellant_components.PropellantComponent(
         name="RP1",
         density=820.0,
         chemical_formula={"C": 12, "H": 26},
         enthalpy=0.0,
         initial_temperature=298.15,
-        role=ComponentRole.FUEL,
+        role=propellant_components.ComponentRole.FUEL,
     )
-    return BiliquidPropellant(
+    return propellants_models.BiliquidPropellant(
         name="LOX/RP1",
         components=[oxidizer, fuel],
         oxidizer_to_fuel_ratio=2.5,

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_json_loader.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_json_loader.py
@@ -5,15 +5,9 @@ from pathlib import Path
 
 import pytest
 
-from machwave.models.propellants.categories import (
-    BiliquidPropellant,
-    MixtureType,
-    SolidPropellant,
-)
-from machwave.models.propellants.components import ComponentRole
-from machwave.models.propellants.formulations import (
-    get_propellant_from_json,
-)
+import machwave.models.propellants.categories as propellant_categories
+import machwave.models.propellants.components as propellant_components
+import machwave.models.propellants.formulations as propellant_formulations
 
 # Get paths to formulation directories
 FORMULATIONS_DIR = (
@@ -60,15 +54,15 @@ class TestJSONFormulationLoading:
     def test_load_all_solid_formulations(self, json_file):
         """Test loading each solid propellant JSON file."""
         # Load the propellant
-        propellant = get_propellant_from_json(json_file)
+        propellant = propellant_formulations.get_propellant_from_json(json_file)
 
         # Verify it's a SolidPropellant
-        assert isinstance(propellant, SolidPropellant), (
+        assert isinstance(propellant, propellant_categories.SolidPropellant), (
             f"{json_file.stem}: Not a SolidPropellant instance"
         )
 
         # Verify mixture type
-        assert propellant.mixture_type == MixtureType.SOLID, (
+        assert propellant.mixture_type == propellant_categories.MixtureType.SOLID, (
             f"{json_file.stem}: Wrong mixture_type"
         )
 
@@ -83,7 +77,7 @@ class TestJSONFormulationLoading:
         for comp in propellant.components:
             assert comp.name, f"{json_file.stem}: Component missing name"
             assert comp.density > 0, f"{json_file.stem}: Invalid density"
-            assert isinstance(comp.role, ComponentRole), (
+            assert isinstance(comp.role, propellant_components.ComponentRole), (
                 f"{json_file.stem}: Invalid component role"
             )
             assert hasattr(comp, "chemical_formula"), (
@@ -134,15 +128,15 @@ class TestJSONFormulationLoading:
     def test_load_all_biliquid_formulations(self, json_file):
         """Test loading each liquid propellant JSON file."""
         # Load the propellant
-        propellant = get_propellant_from_json(json_file)
+        propellant = propellant_formulations.get_propellant_from_json(json_file)
 
         # Verify it's a BiliquidPropellant
-        assert isinstance(propellant, BiliquidPropellant), (
+        assert isinstance(propellant, propellant_categories.BiliquidPropellant), (
             f"{json_file.stem}: Not a BiliquidPropellant instance"
         )
 
         # Verify mixture type
-        assert propellant.mixture_type == MixtureType.BILIQUID, (
+        assert propellant.mixture_type == propellant_categories.MixtureType.BILIQUID, (
             f"{json_file.stem}: Wrong mixture_type"
         )
 
@@ -167,7 +161,7 @@ class TestJSONFormulationLoading:
         for comp in propellant.components:
             assert comp.name, f"{json_file.stem}: Component missing name"
             assert comp.density > 0, f"{json_file.stem}: Invalid density"
-            assert isinstance(comp.role, ComponentRole), (
+            assert isinstance(comp.role, propellant_components.ComponentRole), (
                 f"{json_file.stem}: Invalid component role"
             )
             assert hasattr(comp, "chemical_formula"), (
@@ -178,9 +172,9 @@ class TestJSONFormulationLoading:
                 f"{json_file.stem}: Invalid temperature"
             )
 
-            if comp.role == ComponentRole.OXIDIZER:
+            if comp.role == propellant_components.ComponentRole.OXIDIZER:
                 has_oxidizer = True
-            elif comp.role == ComponentRole.FUEL:
+            elif comp.role == propellant_components.ComponentRole.FUEL:
                 has_fuel = True
 
         assert has_oxidizer and has_fuel, (
@@ -219,7 +213,7 @@ class TestJSONFormulationLoading:
     def test_evaluate_with_predefined_properties(self):
         """Test that propellants with pre-defined properties evaluate correctly."""
         # Load a solid propellant
-        kndx = get_propellant_from_json(SOLID_DIR / "kndx.json")
+        kndx = propellant_formulations.get_propellant_from_json(SOLID_DIR / "kndx.json")
 
         # Verify it has pre-defined properties
         assert kndx.properties is not None, "KNDX should have pre-defined properties"
@@ -235,7 +229,7 @@ class TestJSONFormulationLoading:
     def test_component_to_cea_dict(self):
         """Test that components can be converted to CEA dict format."""
         # Load any propellant
-        prop = get_propellant_from_json(SOLID_DIR / "kndx.json")
+        prop = propellant_formulations.get_propellant_from_json(SOLID_DIR / "kndx.json")
 
         # Test to_cea_dict on first component
         comp = prop.components[0]
@@ -253,17 +247,17 @@ class TestJSONFormulationLoading:
         assert cea_dict["name"] == comp.name
         assert cea_dict["weight_percent"] == 50.0
         # Heat of formation is converted from J/mol to cal/mol
-        from machwave.core.conversions import convert_joules_per_mol_to_cal_per_mol
+        import machwave.core.conversions as conversions
 
-        assert cea_dict["heat_of_formation"] == convert_joules_per_mol_to_cal_per_mol(
-            comp.enthalpy
+        assert cea_dict["heat_of_formation"] == (
+            conversions.convert_joules_per_mol_to_cal_per_mol(comp.enthalpy)
         )
         assert cea_dict["formula"] == comp.chemical_formula
 
     def test_solid_burn_rate_calculation(self):
         """Test burn rate calculation for solid propellants."""
         # Load KNDX which has burn rate data
-        kndx = get_propellant_from_json(SOLID_DIR / "kndx.json")
+        kndx = propellant_formulations.get_propellant_from_json(SOLID_DIR / "kndx.json")
 
         # Calculate burn rate at 5 MPa
         burn_rate = kndx.get_burn_rate(5e6)
@@ -280,20 +274,20 @@ class TestJSONFormulationLoading:
             json.dump({"name": "Invalid", "components": []}, f)
 
         with pytest.raises(ValueError, match="mixture_type"):
-            get_propellant_from_json(invalid_json)
+            propellant_formulations.get_propellant_from_json(invalid_json)
 
     def test_nonexistent_file_raises_error(self):
         """Test that loading non-existent file raises FileNotFoundError."""
         with pytest.raises(FileNotFoundError):
-            get_propellant_from_json("nonexistent_file.json")
+            propellant_formulations.get_propellant_from_json("nonexistent_file.json")
 
     def test_mass_fractions_sum_approximately_to_one(self):
         """Test that component mass fractions sum to approximately 1.0."""
         all_files = list(SOLID_DIR.glob("*.json")) + list(BILIQUID_DIR.glob("*.json"))
 
         for json_file in all_files:
-            prop = get_propellant_from_json(json_file)
-            if isinstance(prop, SolidPropellant):
+            prop = propellant_formulations.get_propellant_from_json(json_file)
+            if isinstance(prop, propellant_categories.SolidPropellant):
                 total_mass_fraction = sum(prop.mass_fractions)
                 assert 0.99 <= total_mass_fraction <= 1.01, (
                     f"{json_file.stem}: Mass fractions sum to {total_mass_fraction}, expected ~1.0"
@@ -311,12 +305,12 @@ class TestJSONFormulationLoading:
         The formulation JSONs may include fixed properties; this test explicitly
         bypasses those to validate that the component-based CEA path still works.
         """
-        loaded = get_propellant_from_json(json_file)
-        assert isinstance(loaded, SolidPropellant)
+        loaded = propellant_formulations.get_propellant_from_json(json_file)
+        assert isinstance(loaded, propellant_categories.SolidPropellant)
         assert loaded.components, f"{json_file.stem}: expected components"
         assert loaded.mass_fractions, f"{json_file.stem}: expected mass_fractions"
 
-        cea_propellant = SolidPropellant(
+        cea_propellant = propellant_categories.SolidPropellant(
             name=f"{loaded.name}__CEA__{json_file.stem}",
             components=loaded.components,
             mass_fractions=loaded.mass_fractions,
@@ -346,11 +340,11 @@ class TestJSONFormulationLoading:
         the CEA reconstruction is expected to be in the same ballpark.
         """
         json_file = SOLID_DIR / f"{json_stem}.json"
-        loaded = get_propellant_from_json(json_file)
-        assert isinstance(loaded, SolidPropellant)
+        loaded = propellant_formulations.get_propellant_from_json(json_file)
+        assert isinstance(loaded, propellant_categories.SolidPropellant)
         assert loaded.properties is not None, f"{json_stem}: expected fixed properties"
 
-        cea_propellant = SolidPropellant(
+        cea_propellant = propellant_categories.SolidPropellant(
             name=f"{loaded.name}__CEA__{json_stem}",
             components=loaded.components,
             mass_fractions=loaded.mass_fractions,

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_solid.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_solid.py
@@ -8,11 +8,9 @@ to the module will automatically be tested.
 
 import pytest
 
+import machwave.models.propellants as propellants_models
+import machwave.models.propellants.categories.solid as solid_propellant_category
 import machwave.models.propellants.formulations.solid as solid_formulations
-from machwave.models.propellants import SolidPropellant
-from machwave.models.propellants.categories.solid import (
-    BurnRateOutOfBoundsError,
-)
 
 
 def get_all_solid_propellants():
@@ -20,7 +18,7 @@ def get_all_solid_propellants():
     propellants = []
     for name in dir(solid_formulations):
         obj = getattr(solid_formulations, name)
-        if isinstance(obj, SolidPropellant):
+        if isinstance(obj, propellants_models.SolidPropellant):
             propellants.append((name, obj))
     return propellants
 
@@ -38,7 +36,7 @@ class TestAllSolidPropellants:
     @pytest.mark.parametrize("name,propellant", ALL_SOLID_PROPELLANTS)
     def test_is_solid_propellant(self, name, propellant):
         """Verify formulation is instance of SolidPropellant."""
-        assert isinstance(propellant, SolidPropellant), (
+        assert isinstance(propellant, propellants_models.SolidPropellant), (
             f"{name} is not a SolidPropellant"
         )
         assert propellant.mixture_type in ("solid", "hybrid"), (
@@ -149,7 +147,7 @@ class TestBurnRateBehavior:
             max_pressure = max(segment["max"] for segment in propellant.burn_rate_map)
             out_of_bounds_pressure = max_pressure * 2
 
-            with pytest.raises(BurnRateOutOfBoundsError):
+            with pytest.raises(solid_propellant_category.BurnRateOutOfBoundsError):
                 propellant.get_burn_rate(out_of_bounds_pressure)
 
 

--- a/tests/test_models/test_propulsion/test_propellants/test_properties.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_properties.py
@@ -5,9 +5,7 @@ import math
 import pytest
 import scipy.constants
 
-from machwave.models.propellants.properties import (
-    ThermochemicalProperties,
-)
+import machwave.models.propellants.properties as propellant_properties
 from tests.factories import (
     LiquidPropellantPropertiesFactory,
     SolidPropellantPropertiesFactory,
@@ -21,7 +19,7 @@ class TestThermochemicalPropertiesBasics:
         """Test that properties can be instantiated and are immutable."""
         props = SolidPropellantPropertiesFactory.build()
 
-        assert isinstance(props, ThermochemicalProperties)
+        assert isinstance(props, propellant_properties.ThermochemicalProperties)
 
         with pytest.raises(AttributeError):
             props.k_chamber = 1.5
@@ -70,7 +68,7 @@ class TestInputValidation:
         base_data["k_chamber"] = 0.9  # Below minimum
 
         with pytest.raises(ValueError, match="outside valid range"):
-            ThermochemicalProperties(**base_data)
+            propellant_properties.ThermochemicalProperties(**base_data)
 
     def test_invalid_molecular_weight_raises_error(self):
         """Test that molecular weight outside valid range raises ValueError."""
@@ -78,7 +76,7 @@ class TestInputValidation:
         base_data["molecular_weight_chamber"] = 0.0  # At minimum (exclusive)
 
         with pytest.raises(ValueError, match="outside valid range"):
-            ThermochemicalProperties(**base_data)
+            propellant_properties.ThermochemicalProperties(**base_data)
 
     def test_invalid_temperature_raises_error(self):
         """Test that temperature outside valid range raises ValueError."""
@@ -86,7 +84,7 @@ class TestInputValidation:
         base_data["adiabatic_flame_temperature"] = -100.0  # Below minimum
 
         with pytest.raises(ValueError, match="outside valid range"):
-            ThermochemicalProperties(**base_data)
+            propellant_properties.ThermochemicalProperties(**base_data)
 
     def test_invalid_isp_raises_error(self):
         """Test that specific impulse outside valid range raises ValueError."""
@@ -94,7 +92,7 @@ class TestInputValidation:
         base_data["i_sp_frozen"] = 700.0  # Above maximum
 
         with pytest.raises(ValueError, match="outside valid range"):
-            ThermochemicalProperties(**base_data)
+            propellant_properties.ThermochemicalProperties(**base_data)
 
     def test_invalid_qsi_raises_error(self):
         """Test that qsi outside valid range raises ValueError."""
@@ -102,7 +100,7 @@ class TestInputValidation:
         base_data["qsi_chamber"] = 1.5  # Above maximum
 
         with pytest.raises(ValueError, match="outside valid range"):
-            ThermochemicalProperties(**base_data)
+            propellant_properties.ThermochemicalProperties(**base_data)
 
     def test_shifting_less_than_frozen_raises_error(self):
         """Test that i_sp_shifting < i_sp_frozen raises ValueError."""
@@ -111,7 +109,7 @@ class TestInputValidation:
         base_data["i_sp_shifting"] = 290.0  # Less than frozen
 
         with pytest.raises(ValueError, match="must be >="):
-            ThermochemicalProperties(**base_data)
+            propellant_properties.ThermochemicalProperties(**base_data)
 
 
 class TestSolidPropellantBehavior:

--- a/tests/test_montecarlo/test_random.py
+++ b/tests/test_montecarlo/test_random.py
@@ -1,12 +1,7 @@
 import numpy as np
 import pytest
 
-from machwave.montecarlo.random import (
-    NormalRandomGenerator,
-    UniformRandomGenerator,
-    get_random_generator,
-    register_random_generator,
-)
+import machwave.montecarlo.random as montecarlo_random
 
 
 @pytest.mark.parametrize(
@@ -38,7 +33,7 @@ def test_normal_generator_bounds(
         rng_seed (int): Seed for reproducibility.
         nsamples (int): Number of random draws to perform.
     """
-    gen = NormalRandomGenerator(value=value, spread=spread)
+    gen = montecarlo_random.NormalRandomGenerator(value=value, spread=spread)
     np.random.seed(rng_seed)
     samples = np.array([gen.get_value() for _ in range(nsamples)])
 
@@ -77,7 +72,7 @@ def test_uniform_generator_bounds(
         rng_seed (int): Seed for reproducibility.
         nsamples (int): Number of random draws.
     """
-    gen = UniformRandomGenerator(value=value, spread=spread)
+    gen = montecarlo_random.UniformRandomGenerator(value=value, spread=spread)
     np.random.seed(rng_seed)
     samples = np.array([gen.get_value() for _ in range(nsamples)])
 
@@ -95,7 +90,10 @@ def test_uniform_generator_bounds(
     assert samples.mean() == pytest.approx(expected_mean, **tol)
 
 
-@pytest.mark.parametrize("cls", [NormalRandomGenerator, UniformRandomGenerator])
+@pytest.mark.parametrize(
+    "cls",
+    [montecarlo_random.NormalRandomGenerator, montecarlo_random.UniformRandomGenerator],
+)
 def test_negative_scalar_spread_raises(cls):
     with pytest.raises(ValueError):
         cls(value=0.0, spread=-1.0)
@@ -103,33 +101,37 @@ def test_negative_scalar_spread_raises(cls):
 
 def test_normal_tuple_spread_raises():
     with pytest.raises(ValueError):
-        NormalRandomGenerator(value=0.0, spread=(1.0, 1.0))
+        montecarlo_random.NormalRandomGenerator(value=0.0, spread=(1.0, 1.0))
 
 
 @pytest.mark.parametrize("bad_tuple", [(5.0, 5.0), (7.0, 3.0)])
 def test_uniform_invalid_tuple_bounds_raises(bad_tuple):
-    gen = UniformRandomGenerator(value=0.0, spread=bad_tuple)
+    gen = montecarlo_random.UniformRandomGenerator(value=0.0, spread=bad_tuple)
     with pytest.raises(ValueError):
         gen.get_value()
 
 
 def test_get_random_generator_returns_correct_instance():
-    gen = get_random_generator("normal", value=1.0, spread=3.0)
-    assert isinstance(gen, NormalRandomGenerator)
+    gen = montecarlo_random.get_random_generator("normal", value=1.0, spread=3.0)
+    assert isinstance(gen, montecarlo_random.NormalRandomGenerator)
 
 
 def test_register_random_generator_and_duplicate_guard():
-    class Dummy(NormalRandomGenerator):  # piggy-back on NormalRandomGenerator
+    class Dummy(
+        montecarlo_random.NormalRandomGenerator
+    ):  # piggy-back on NormalRandomGenerator
         pass
 
-    register_random_generator("dummy", Dummy)
-    assert isinstance(get_random_generator("dummy", value=0.0, spread=0.0), Dummy)
+    montecarlo_random.register_random_generator("dummy", Dummy)
+    assert isinstance(
+        montecarlo_random.get_random_generator("dummy", value=0.0, spread=0.0), Dummy
+    )
 
     # second registration of the same name should raise
     with pytest.raises(ValueError):
-        register_random_generator("dummy", Dummy)
+        montecarlo_random.register_random_generator("dummy", Dummy)
 
 
 def test_get_random_generator_unknown_distribution():
     with pytest.raises(ValueError):
-        get_random_generator("does-not-exist", value=0.0, spread=0.0)
+        montecarlo_random.get_random_generator("does-not-exist", value=0.0, spread=0.0)

--- a/tests/test_services/test_cea.py
+++ b/tests/test_services/test_cea.py
@@ -12,11 +12,7 @@ Also validates that returned parameter values are physically reasonable.
 import pytest
 from rocketcea.cea_obj import CEA_Obj
 
-from machwave.services.cea import (
-    RocketCEAService,
-    create_cea_service,
-    generate_card_string,
-)
+import machwave.services.cea as cea_service
 
 
 class TestCreateCEAServiceSolidPropellant:
@@ -24,10 +20,10 @@ class TestCreateCEAServiceSolidPropellant:
 
     def test_standard_solid_propellant(self):
         """Test factory with standard solid propellant."""
-        service = create_cea_service(propellant_name="AP")
+        service = cea_service.create_cea_service(propellant_name="AP")
 
         assert service is not None
-        assert isinstance(service, RocketCEAService)
+        assert isinstance(service, cea_service.RocketCEAService)
         assert service.cea_obj is not None
         assert service.oxidizer_to_fuel_ratio is None
 
@@ -58,7 +54,7 @@ class TestCreateCEAServiceSolidPropellant:
 
     def test_custom_solid_propellant(self):
         """Test factory with custom solid propellant card."""
-        card = generate_card_string(
+        card = cea_service.generate_card_string(
             [
                 {
                     "name": "KNO3",
@@ -79,11 +75,11 @@ class TestCreateCEAServiceSolidPropellant:
             ]
         )
 
-        service = create_cea_service(
+        service = cea_service.create_cea_service(
             propellant_name="TEST_KNSU_SERVICE", card_string=card
         )
 
-        assert isinstance(service, RocketCEAService)
+        assert isinstance(service, cea_service.RocketCEAService)
 
         # Validate KNSU properties
         chamber_pressure = 3e6
@@ -114,11 +110,11 @@ class TestCreateCEAServiceBiliquidPropellant:
 
     def test_standard_biliquid_propellant(self):
         """Test factory with standard biliquid propellant."""
-        service = create_cea_service(
+        service = cea_service.create_cea_service(
             oxidizer_name="LOX", fuel_name="RP1", oxidizer_to_fuel_ratio=2.5
         )
 
-        assert isinstance(service, RocketCEAService)
+        assert isinstance(service, cea_service.RocketCEAService)
         assert service.oxidizer_to_fuel_ratio == 2.5
 
         # Validate LOX/RP1 properties
@@ -148,7 +144,7 @@ class TestCreateCEAServiceBiliquidPropellant:
 
     def test_lox_lh2_high_performance(self):
         """Test LOX/LH2 high-performance propellant."""
-        service = create_cea_service(
+        service = cea_service.create_cea_service(
             oxidizer_name="LOX",
             fuel_name="LH2",
             oxidizer_to_fuel_ratio=5.5,  # Near optimal O/F
@@ -178,7 +174,7 @@ h,cal=-4676.0  t(k)=298.15  rho,g/cc=1.443"""
         fuel_card = """name CustomMMH  C 1 H 6 N 2  wt%=100.0
 h,cal=12800.0  t(k)=298.15  rho,g/cc=0.866"""
 
-        service = create_cea_service(
+        service = cea_service.create_cea_service(
             oxidizer_name="CUSTOM_N2O4_TEST_2",
             oxidizer_card_string=ox_card,
             fuel_name="CUSTOM_MMH_TEST_2",
@@ -186,7 +182,7 @@ h,cal=12800.0  t(k)=298.15  rho,g/cc=0.866"""
             oxidizer_to_fuel_ratio=1.65,
         )
 
-        assert isinstance(service, RocketCEAService)
+        assert isinstance(service, cea_service.RocketCEAService)
         assert service.oxidizer_to_fuel_ratio == 1.65
 
         # Validate properties are reasonable
@@ -205,9 +201,11 @@ class TestDirectRocketCEAServiceInstantiation:
         cea_obj = CEA_Obj(propName="AP")
 
         # Direct instantiation
-        service = RocketCEAService(cea_obj=cea_obj, oxidizer_to_fuel_ratio=None)
+        service = cea_service.RocketCEAService(
+            cea_obj=cea_obj, oxidizer_to_fuel_ratio=None
+        )
 
-        assert isinstance(service, RocketCEAService)
+        assert isinstance(service, cea_service.RocketCEAService)
         assert service.cea_obj is cea_obj
         assert service.oxidizer_to_fuel_ratio is None
 
@@ -221,9 +219,11 @@ class TestDirectRocketCEAServiceInstantiation:
         cea_obj = CEA_Obj(oxName="LOX", fuelName="RP1")
 
         # Direct instantiation with O/F ratio
-        service = RocketCEAService(cea_obj=cea_obj, oxidizer_to_fuel_ratio=2.5)
+        service = cea_service.RocketCEAService(
+            cea_obj=cea_obj, oxidizer_to_fuel_ratio=2.5
+        )
 
-        assert isinstance(service, RocketCEAService)
+        assert isinstance(service, cea_service.RocketCEAService)
         assert service.cea_obj is cea_obj
         assert service.oxidizer_to_fuel_ratio == 2.5
 
@@ -236,7 +236,7 @@ class TestDirectRocketCEAServiceInstantiation:
         from rocketcea.cea_obj import add_new_propellant
 
         # Manually register propellant
-        card = generate_card_string(
+        card = cea_service.generate_card_string(
             [
                 {
                     "name": "TestComp",
@@ -254,9 +254,9 @@ class TestDirectRocketCEAServiceInstantiation:
         cea_obj = CEA_Obj(propName="MANUAL_REG_TEST")
 
         # Direct instantiation
-        service = RocketCEAService(cea_obj=cea_obj)
+        service = cea_service.RocketCEAService(cea_obj=cea_obj)
 
-        assert isinstance(service, RocketCEAService)
+        assert isinstance(service, cea_service.RocketCEAService)
         # KNO3 alone won't burn, so CEA may return 0 or low temp
         # Just check service was created successfully
         assert service.cea_obj is not None
@@ -268,7 +268,7 @@ class TestServiceParameterValidation:
     @pytest.fixture
     def lox_rp1_service(self):
         """LOX/RP1 service fixture."""
-        return create_cea_service(
+        return cea_service.create_cea_service(
             oxidizer_name="LOX", fuel_name="RP1", oxidizer_to_fuel_ratio=2.5
         )
 
@@ -351,7 +351,7 @@ class TestServiceEdgeCases:
 
     def test_very_low_pressure(self):
         """Test service at very low chamber pressure."""
-        service = create_cea_service(
+        service = cea_service.create_cea_service(
             oxidizer_name="LOX", fuel_name="RP1", oxidizer_to_fuel_ratio=2.5
         )
 
@@ -366,7 +366,7 @@ class TestServiceEdgeCases:
 
     def test_very_high_pressure(self):
         """Test service at very high chamber pressure."""
-        service = create_cea_service(
+        service = cea_service.create_cea_service(
             oxidizer_name="LOX", fuel_name="RP1", oxidizer_to_fuel_ratio=2.5
         )
 
@@ -376,7 +376,7 @@ class TestServiceEdgeCases:
 
     def test_extreme_expansion_ratios(self):
         """Test service with extreme expansion ratios."""
-        service = create_cea_service(
+        service = cea_service.create_cea_service(
             oxidizer_name="LOX", fuel_name="RP1", oxidizer_to_fuel_ratio=2.5
         )
 
@@ -399,7 +399,7 @@ class TestRegistryIsolation:
     """
 
     def _kno3_sucrose_card(self, kno3_pct: float) -> str:
-        return generate_card_string(
+        return cea_service.generate_card_string(
             [
                 {
                     "name": "KNO3",
@@ -423,10 +423,10 @@ class TestRegistryIsolation:
     def test_same_name_different_cards_keep_distinct_properties(self):
         shared_name = "REGISTRY_ISOLATION_PROBE"
 
-        service_a = create_cea_service(
+        service_a = cea_service.create_cea_service(
             propellant_name=shared_name, card_string=self._kno3_sucrose_card(65.0)
         )
-        service_b = create_cea_service(
+        service_b = cea_service.create_cea_service(
             propellant_name=shared_name, card_string=self._kno3_sucrose_card(80.0)
         )
 
@@ -465,14 +465,14 @@ class TestRegistryIsolation:
             "h,cal=2000.0  t(k)=298.15  rho,g/cc=1.443"
         )
 
-        service_a = create_cea_service(
+        service_a = cea_service.create_cea_service(
             oxidizer_name=shared_ox_name,
             oxidizer_card_string=ox_card_a,
             fuel_name="REGISTRY_ISOLATION_FUEL_A",
             fuel_card_string=fuel_card,
             oxidizer_to_fuel_ratio=1.65,
         )
-        service_b = create_cea_service(
+        service_b = cea_service.create_cea_service(
             oxidizer_name=shared_ox_name,
             oxidizer_card_string=ox_card_b,
             fuel_name="REGISTRY_ISOLATION_FUEL_B",
@@ -511,7 +511,7 @@ def test_generate_card_string_utility():
         },
     ]
 
-    card = generate_card_string(components)
+    card = cea_service.generate_card_string(components)
 
     # Verify card string format
     assert "name KNO3" in card
@@ -523,13 +523,13 @@ def test_generate_card_string_utility():
 
     # Empty components should raise error
     with pytest.raises(ValueError, match="No components provided"):
-        generate_card_string([])
+        cea_service.generate_card_string([])
 
 
 class TestMixtureRatioOverride:
     @pytest.fixture
     def lox_rp1_service(self):
-        return create_cea_service(
+        return cea_service.create_cea_service(
             oxidizer_name="LOX", fuel_name="RP1", oxidizer_to_fuel_ratio=2.5
         )
 

--- a/tests/test_services/test_internal_ballistics_plots.py
+++ b/tests/test_services/test_internal_ballistics_plots.py
@@ -3,7 +3,7 @@
 import numpy as np
 import plotly.graph_objects as go
 
-from machwave.services.plots.internal_ballistics import thrust_coefficient_plot
+import machwave.services.plots.internal_ballistics as ib_plots
 
 
 class TestThrustCoefficientPlot:
@@ -15,7 +15,9 @@ class TestThrustCoefficientPlot:
         cf_ideal = np.linspace(1.5, 1.6, 10)
         cf_real = np.linspace(1.4, 1.5, 10)
 
-        fig = thrust_coefficient_plot(time, cf_ideal, cf_real, show_efficiency=True)
+        fig = ib_plots.thrust_coefficient_plot(
+            time, cf_ideal, cf_real, show_efficiency=True
+        )
 
         assert isinstance(fig, go.Figure)
         trace_names = [trace.name for trace in fig.data]
@@ -36,7 +38,9 @@ class TestThrustCoefficientPlot:
         cf_ideal = np.linspace(1.5, 1.6, 10)
         cf_real = np.linspace(1.4, 1.5, 10)
 
-        fig = thrust_coefficient_plot(time, cf_ideal, cf_real, show_efficiency=False)
+        fig = ib_plots.thrust_coefficient_plot(
+            time, cf_ideal, cf_real, show_efficiency=False
+        )
 
         assert isinstance(fig, go.Figure)
         trace_names = [trace.name for trace in fig.data]
@@ -51,7 +55,9 @@ class TestThrustCoefficientPlot:
         cf_ideal = np.array([0.0, 1.5, 1.6])
         cf_real = np.array([0.0, 1.4, 1.5])
 
-        fig = thrust_coefficient_plot(time, cf_ideal, cf_real, show_efficiency=True)
+        fig = ib_plots.thrust_coefficient_plot(
+            time, cf_ideal, cf_real, show_efficiency=True
+        )
 
         eta_trace = fig.data[2]
         assert np.isnan(eta_trace.y[0])

--- a/tests/test_simulations/conftest.py
+++ b/tests/test_simulations/conftest.py
@@ -7,28 +7,29 @@ import warnings
 
 import numpy as np
 
-from machwave.models.motors import Motor
-from machwave.simulation import (
-    InternalBallisticsSimulation,
-    InternalBallisticsSimulationParams,
-    SimulationResult,
-)
+import machwave.models.motors as motors_models
+import machwave.simulation as machwave_simulation
 
 
 def run_simulation(
-    motor: Motor, params: InternalBallisticsSimulationParams
-) -> SimulationResult:
+    motor: motors_models.Motor,
+    params: machwave_simulation.InternalBallisticsSimulationParams,
+) -> machwave_simulation.SimulationResult:
     """
     Run InternalBallisticsSimulation end-to-end, suppressing the empirical
     boundary-layer-loss warning that otherwise floods test output.
     """
-    simulation = InternalBallisticsSimulation(motor=motor, params=params)
+    simulation = machwave_simulation.InternalBallisticsSimulation(
+        motor=motor, params=params
+    )
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
         return simulation.run()
 
 
-def assert_recorded_arrays_aligned(result: SimulationResult) -> None:
+def assert_recorded_arrays_aligned(
+    result: machwave_simulation.SimulationResult,
+) -> None:
     """
     Every per-timestep series should have the same length as result.time.
 

--- a/tests/test_simulations/motor_builders.py
+++ b/tests/test_simulations/motor_builders.py
@@ -9,10 +9,10 @@ independent of the example layer.
 
 from __future__ import annotations
 
-from machwave.models import grain as grain_models
-from machwave.models import motors
-from machwave.models.propellants.formulations import solid as solid_propellants
-from machwave.simulation import InternalBallisticsSimulationParams
+import machwave.models.grain as grain_models
+import machwave.models.motors as motors_models
+import machwave.models.propellants.formulations.solid as solid_propellants
+import machwave.simulation as machwave_simulation
 from tests.factories import (
     BatesSegmentFactory,
     BiliquidPropellantFactory,
@@ -30,7 +30,9 @@ from tests.factories import (
 )
 
 
-def build_apcp_motor() -> tuple[motors.SolidMotor, InternalBallisticsSimulationParams]:
+def build_apcp_motor() -> tuple[
+    motors_models.SolidMotor, machwave_simulation.InternalBallisticsSimulationParams
+]:
     """MIT Cherry Limeade APCP motor with five identical BATES segments."""
     grain = grain_models.Grain(spacing=0.01)
     bates_segment = BatesSegmentFactory.build(
@@ -61,7 +63,7 @@ def build_apcp_motor() -> tuple[motors.SolidMotor, InternalBallisticsSimulationP
         propellant=solid_propellants.MIT_CHERRY_LIMEADE,
         thrust_chamber=thrust_chamber,
     )
-    params = InternalBallisticsSimulationParams(
+    params = machwave_simulation.InternalBallisticsSimulationParams(
         d_t=0.01,
         igniter_pressure=1e6,
         external_pressure=1e5,
@@ -71,7 +73,7 @@ def build_apcp_motor() -> tuple[motors.SolidMotor, InternalBallisticsSimulationP
 
 
 def build_kappa_rnakka_motor() -> tuple[
-    motors.SolidMotor, InternalBallisticsSimulationParams
+    motors_models.SolidMotor, machwave_simulation.InternalBallisticsSimulationParams
 ]:
     """Richard Nakka's Kappa motor (KNDX, four BATES segments)."""
     grain = grain_models.Grain(spacing=5e-3)
@@ -102,7 +104,7 @@ def build_kappa_rnakka_motor() -> tuple[
         propellant=solid_propellants.KNDX,
         thrust_chamber=thrust_chamber,
     )
-    params = InternalBallisticsSimulationParams(
+    params = machwave_simulation.InternalBallisticsSimulationParams(
         d_t=0.001,
         igniter_pressure=1e6,
         external_pressure=1e5,
@@ -111,7 +113,9 @@ def build_kappa_rnakka_motor() -> tuple[
     return motor, params
 
 
-def build_nero_motor() -> tuple[motors.SolidMotor, InternalBallisticsSimulationParams]:
+def build_nero_motor() -> tuple[
+    motors_models.SolidMotor, machwave_simulation.InternalBallisticsSimulationParams
+]:
     """Supernova Rocketry Nero motor (KNDX, four BATES segments)."""
     grain = grain_models.Grain(spacing=10e-3)
     bates_segment = BatesSegmentFactory.build(
@@ -141,7 +145,7 @@ def build_nero_motor() -> tuple[motors.SolidMotor, InternalBallisticsSimulationP
         propellant=solid_propellants.KNDX,
         thrust_chamber=thrust_chamber,
     )
-    params = InternalBallisticsSimulationParams(
+    params = machwave_simulation.InternalBallisticsSimulationParams(
         d_t=0.01,
         igniter_pressure=1e6,
         external_pressure=1e5,
@@ -150,7 +154,9 @@ def build_nero_motor() -> tuple[motors.SolidMotor, InternalBallisticsSimulationP
     return motor, params
 
 
-def build_1kn_lre() -> tuple[motors.LiquidEngine, InternalBallisticsSimulationParams]:
+def build_1kn_lre() -> tuple[
+    motors_models.LiquidEngine, machwave_simulation.InternalBallisticsSimulationParams
+]:
     """1 kN-class N2O / Ethanol biliquid engine (HalfCat Sphinx-like)."""
     oxidizer = OxidizerComponentFactory.build(initial_temperature=300.0)
     fuel = FuelComponentFactory.build(initial_temperature=300.0)
@@ -203,7 +209,7 @@ def build_1kn_lre() -> tuple[motors.LiquidEngine, InternalBallisticsSimulationPa
         oxidizer_tank_cog=0.5,
         fuel_tank_cog=0.4,
     )
-    params = InternalBallisticsSimulationParams(
+    params = machwave_simulation.InternalBallisticsSimulationParams(
         d_t=1e-4,
         igniter_pressure=1e6,
         external_pressure=1e5,

--- a/tests/test_simulations/test_liquid_engine_simulation.py
+++ b/tests/test_simulations/test_liquid_engine_simulation.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from machwave.models import motors
-from machwave.simulation.liquid import LiquidEngineState, LiquidSimulationResult
+import machwave.models.motors as motors_models
+import machwave.simulation.liquid as liquid_simulation
 from tests.test_simulations import motor_builders
 from tests.test_simulations.conftest import (
     assert_recorded_arrays_aligned,
@@ -21,35 +21,39 @@ from tests.test_simulations.conftest import (
 
 
 @pytest.fixture(scope="module")
-def simulated_motor_and_result() -> tuple[motors.LiquidEngine, LiquidSimulationResult]:
+def simulated_motor_and_result() -> tuple[
+    motors_models.LiquidEngine, liquid_simulation.LiquidSimulationResult
+]:
     motor, params = motor_builders.build_1kn_lre()
     return motor, run_simulation(motor, params)
 
 
 @pytest.fixture(scope="module")
 def simulation_result(
-    simulated_motor_and_result: tuple[motors.LiquidEngine, LiquidSimulationResult],
-) -> LiquidSimulationResult:
+    simulated_motor_and_result: tuple[
+        motors_models.LiquidEngine, liquid_simulation.LiquidSimulationResult
+    ],
+) -> liquid_simulation.LiquidSimulationResult:
     return simulated_motor_and_result[1]
 
 
 def test_simulation_completes_with_terminal_state(
-    simulation_result: LiquidSimulationResult,
+    simulation_result: liquid_simulation.LiquidSimulationResult,
 ) -> None:
-    assert isinstance(simulation_result, LiquidSimulationResult)
+    assert isinstance(simulation_result, liquid_simulation.LiquidSimulationResult)
     assert simulation_result.end_thrust is True
     assert simulation_result.time.size > 1
 
 
 def test_thrust_time_is_finite_and_positive(
-    simulation_result: LiquidSimulationResult,
+    simulation_result: liquid_simulation.LiquidSimulationResult,
 ) -> None:
     assert np.isfinite(simulation_result.thrust_time)
     assert simulation_result.thrust_time > 0.0
 
 
 def test_propellant_masses_are_monotone_non_increasing(
-    simulation_result: LiquidSimulationResult,
+    simulation_result: liquid_simulation.LiquidSimulationResult,
 ) -> None:
     for series_name in ("fuel_mass", "oxidizer_mass", "propellant_mass"):
         series = getattr(simulation_result, series_name)
@@ -64,7 +68,7 @@ def test_propellant_masses_are_monotone_non_increasing(
 
 
 def test_chamber_pressure_and_thrust_are_physically_plausible(
-    simulation_result: LiquidSimulationResult,
+    simulation_result: liquid_simulation.LiquidSimulationResult,
 ) -> None:
     peak_pressure = float(np.max(simulation_result.chamber_pressure))
     peak_thrust = float(np.max(simulation_result.thrust))
@@ -79,14 +83,14 @@ def test_chamber_pressure_and_thrust_are_physically_plausible(
 
 
 def test_recorded_per_timestep_arrays_are_aligned(
-    simulation_result: LiquidSimulationResult,
+    simulation_result: liquid_simulation.LiquidSimulationResult,
 ) -> None:
     assert_recorded_arrays_aligned(simulation_result)
 
 
-def _build_state_for_burnout_test() -> LiquidEngineState:
+def _build_state_for_burnout_test() -> liquid_simulation.LiquidEngineState:
     motor, params = motor_builders.build_1kn_lre()
-    return LiquidEngineState(
+    return liquid_simulation.LiquidEngineState(
         motor=motor,
         igniter_pressure=params.igniter_pressure,
         external_pressure=params.external_pressure,
@@ -115,7 +119,9 @@ def test_run_timestep_sets_end_burn_when_oxidizer_exhausts() -> None:
 
 
 def test_live_mixture_ratio_drives_cea(
-    simulated_motor_and_result: tuple[motors.LiquidEngine, LiquidSimulationResult],
+    simulated_motor_and_result: tuple[
+        motors_models.LiquidEngine, liquid_simulation.LiquidSimulationResult
+    ],
 ) -> None:
     motor, simulation_result = simulated_motor_and_result
     propellant = motor.propellant
@@ -149,7 +155,7 @@ def test_live_mixture_ratio_drives_cea(
 
 
 def test_simulation_runs_through_burnout_without_crashing(
-    simulation_result: LiquidSimulationResult,
+    simulation_result: liquid_simulation.LiquidSimulationResult,
 ) -> None:
     assert simulation_result.end_thrust is True
     assert simulation_result.propellant_mass[-1] <= simulation_result.propellant_mass[0]

--- a/tests/test_simulations/test_solid_motor_simulation.py
+++ b/tests/test_simulations/test_solid_motor_simulation.py
@@ -12,9 +12,9 @@ from typing import Callable
 import numpy as np
 import pytest
 
-from machwave.models import motors
-from machwave.simulation import InternalBallisticsSimulationParams
-from machwave.simulation.solid import SolidSimulationResult
+import machwave.models.motors as motors_models
+import machwave.simulation as machwave_simulation
+import machwave.simulation.solid as solid_simulation
 from tests.test_simulations import motor_builders
 from tests.test_simulations.conftest import (
     assert_recorded_arrays_aligned,
@@ -22,7 +22,10 @@ from tests.test_simulations.conftest import (
 )
 
 SolidMotorBuilder = Callable[
-    [], tuple[motors.SolidMotor, InternalBallisticsSimulationParams]
+    [],
+    tuple[
+        motors_models.SolidMotor, machwave_simulation.InternalBallisticsSimulationParams
+    ],
 ]
 
 
@@ -38,22 +41,24 @@ SOLID_MOTOR_BUILDERS: tuple[SolidMotorBuilder, ...] = (
     params=SOLID_MOTOR_BUILDERS,
     ids=lambda builder: builder.__name__.removeprefix("build_"),
 )
-def simulation_result(request: pytest.FixtureRequest) -> SolidSimulationResult:
+def simulation_result(
+    request: pytest.FixtureRequest,
+) -> solid_simulation.SolidSimulationResult:
     motor, params = request.param()
     return run_simulation(motor, params)
 
 
 def test_simulation_completes_with_terminal_state(
-    simulation_result: SolidSimulationResult,
+    simulation_result: solid_simulation.SolidSimulationResult,
 ) -> None:
-    assert isinstance(simulation_result, SolidSimulationResult)
+    assert isinstance(simulation_result, solid_simulation.SolidSimulationResult)
     assert simulation_result.end_thrust is True
     assert simulation_result.end_burn is True
     assert simulation_result.time.size > 1
 
 
 def test_burn_time_and_thrust_time_are_finite_and_ordered(
-    simulation_result: SolidSimulationResult,
+    simulation_result: solid_simulation.SolidSimulationResult,
 ) -> None:
     assert np.isfinite(simulation_result.burn_time)
     assert np.isfinite(simulation_result.thrust_time)
@@ -65,7 +70,7 @@ def test_burn_time_and_thrust_time_are_finite_and_ordered(
 
 
 def test_propellant_mass_is_monotone_non_increasing(
-    simulation_result: SolidSimulationResult,
+    simulation_result: solid_simulation.SolidSimulationResult,
 ) -> None:
     propellant_mass = simulation_result.propellant_mass
     diffs = np.diff(propellant_mass)
@@ -77,7 +82,7 @@ def test_propellant_mass_is_monotone_non_increasing(
 
 
 def test_chamber_pressure_and_thrust_are_physically_plausible(
-    simulation_result: SolidSimulationResult,
+    simulation_result: solid_simulation.SolidSimulationResult,
 ) -> None:
     peak_pressure = float(np.max(simulation_result.chamber_pressure))
     peak_thrust = float(np.max(simulation_result.thrust))
@@ -94,6 +99,6 @@ def test_chamber_pressure_and_thrust_are_physically_plausible(
 
 
 def test_recorded_per_timestep_arrays_are_aligned(
-    simulation_result: SolidSimulationResult,
+    simulation_result: solid_simulation.SolidSimulationResult,
 ) -> None:
     assert_recorded_arrays_aligned(simulation_result)


### PR DESCRIPTION
## Summary

Converted every import to a namespace import.

## Linked issue

Closes #278 

## Test plan

- [x] `make check` passes (format, lint, typecheck)
- [x] `make test` passes
- [x] New or updated tests cover the change

## Documentation

- [ ] Public API or user-facing behaviour is documented in `docs/` or docstrings
- [x] Not applicable (internal change only)

## Additional notes

This makes imports cleaner and shorter.