### PR TITLE
286: Remove redundant end_thrust guard from run_timestep

### DIFF
--- a/machwave/simulation/liquid/states.py
+++ b/machwave/simulation/liquid/states.py
@@ -72,9 +72,6 @@ class LiquidEngineState(simulation_states.MotorState):
             d_t: Time step.
             external_pressure: External pressure.
         """
-        if self.end_thrust:
-            return
-
         nozzle = self.motor.thrust_chamber.nozzle
         injector = self.motor.thrust_chamber.injector
         feed_system = self.motor.feed_system

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -94,9 +94,6 @@ class SolidMotorState(simulation_states.MotorState):
             d_t: Time increment [s].
             external_pressure: External pressure [Pa].
         """
-        if self.end_thrust:
-            return
-
         propellant_properties = self.motor.propellant.properties
         if propellant_properties is None:
             raise ValueError(


### PR DESCRIPTION
Closes #286.

## Summary
- Drop the unreachable `if self.end_thrust: return` from `SolidMotorState.run_timestep` and `LiquidMotorState.run_timestep` — the only caller, `Simulation.run`, already loops `while not motor_state.end_thrust`.

## Test plan
- [x] `pytest`