### PR TITLE
288: Add tech-debt / refactor issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tech_debt.md
+++ b/.github/ISSUE_TEMPLATE/tech_debt.md
@@ -1,5 +1,5 @@
 ---
-name: Tech debt / refactor
+name: Tech debt/refactor
 about: Propose a cleanup, refactor, or other internal improvement
 title: ""
 labels: tech-debt

--- a/.github/ISSUE_TEMPLATE/tech_debt.md
+++ b/.github/ISSUE_TEMPLATE/tech_debt.md
@@ -1,0 +1,19 @@
+---
+name: Tech debt / refactor
+about: Propose a cleanup, refactor, or other internal improvement
+title: ""
+labels: tech-debt
+assignees: ""
+---
+
+## What
+
+The code or area that needs work.
+
+## Why
+
+Why it is worth doing now.
+
+## Proposed change
+
+What the cleanup would look like.


### PR DESCRIPTION
Closes #288.

## Summary

Adds a third issue template, `.github/ISSUE_TEMPLATE/tech_debt.md`, for cleanup and refactor work. Uses the `tech-debt` label and a minimal What / Why / Proposed change body to keep filing friction low.

## Test plan

- [ ] On GitHub, "New issue" shows three options: Bug report, Feature request, Tech debt/refactor.
- [ ] Selecting the new template pre-fills the three sections and applies the `tech-debt` label.