### PR TITLE
290: Deduplicate motor-state construction in InternalBallisticsSimulation

### DIFF
--- a/machwave/simulation/base.py
+++ b/machwave/simulation/base.py
@@ -35,6 +35,11 @@ class InternalBallisticsSimulation:
         params: Simulation parameters.
     """
 
+    _STATE_CLASS_BY_MOTOR_TYPE = (
+        (motors.SolidMotor, solid_states.SolidMotorState),
+        (motors.LiquidEngine, liquid_states.LiquidEngineState),
+    )
+
     def __init__(
         self,
         motor: motors.Motor,
@@ -52,21 +57,16 @@ class InternalBallisticsSimulation:
 
     def _build_motor_state(self) -> simulation_states.MotorState:
         """Build the motor state matching the configured motor type."""
-        if isinstance(self.motor, motors.SolidMotor):
-            return solid_states.SolidMotorState(
-                motor=self.motor,
-                igniter_pressure=self.params.igniter_pressure,
-                external_pressure=self.params.external_pressure,
-                other_losses=self.params.other_losses,
-            )
-        if isinstance(self.motor, motors.LiquidEngine):
-            return liquid_states.LiquidEngineState(
-                motor=self.motor,
-                igniter_pressure=self.params.igniter_pressure,
-                external_pressure=self.params.external_pressure,
-                other_losses=self.params.other_losses,
-            )
-        raise ValueError("Unsupported motor type.")
+        state_kwargs = {
+            "motor": self.motor,
+            "igniter_pressure": self.params.igniter_pressure,
+            "external_pressure": self.params.external_pressure,
+            "other_losses": self.params.other_losses,
+        }
+        for motor_type, state_class in self._STATE_CLASS_BY_MOTOR_TYPE:
+            if isinstance(self.motor, motor_type):
+                return state_class(**state_kwargs)
+        raise ValueError(f"Unsupported motor type: {type(self.motor).__name__}.")
 
     def run(self) -> simulation_results.SimulationResult:
         """Run the simulation to thrust termination and return its result."""


### PR DESCRIPTION
Closes #290.

## Summary

`InternalBallisticsSimulation._build_motor_state` used to repeat the same four constructor arguments (`motor`, `igniter_pressure`, `external_pressure`, `other_losses`) for every supported motor type. With a hybrid engine on the way, that pattern would force another copy.

This change builds the shared kwargs once and dispatches through a `(motor type, state class)` registry. Adding a new engine type is now a one-line tuple entry. The unsupported-type error message also now names the offending class.

Public behaviour is unchanged.

## Test plan

- [x] `python -m pytest tests/test_simulations -x -q` (24 passed locally)