### PR TITLE
295: Add spike issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/spike.md
+++ b/.github/ISSUE_TEMPLATE/spike.md
@@ -1,0 +1,21 @@
+---
+name: Spike
+about: Investigation to answer a question before committing to work
+title: ""
+labels: spike
+assignees: ""
+---
+
+## Question
+
+The specific question this spike needs to answer.
+
+## Why
+
+Why we need an answer before doing the real work, and what decision depends on
+it.
+
+## Scope
+
+What is in scope for the investigation, and what is explicitly out of scope.
+Spikes should not turn into implementation.


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/spike.md` for time-bounded investigation
  tickets, with sections for Question, Why, and Scope.
- Labelled `spike` so investigation tickets are distinguishable from features
  and tech debt at a glance.

Closes #295.

## Test plan

- [x] Open "New issue" on GitHub and confirm "Spike" appears alongside the
      existing templates with the expected sections pre-filled.