### PR TITLE
Validate solid propellant properties at construction

### DIFF
--- a/machwave/models/propellants/categories/base.py
+++ b/machwave/models/propellants/categories/base.py
@@ -1,5 +1,3 @@
-"""Base propellant class with shared functionality."""
-
 import abc
 import enum
 import functools
@@ -42,7 +40,7 @@ class Propellant(abc.ABC):
         combustion_efficiency: float = 0.95,
     ):
         """
-        Initialize propellant.
+        Initialize a propellant.
 
         Args:
             name: Propellant name.
@@ -50,7 +48,7 @@ class Propellant(abc.ABC):
             combustion_efficiency: Efficiency factor (0-1).
         """
         self.name = name
-        self.components = list(components) if components is not None else []
+        self.components = list(components or [])
         self.combustion_efficiency = combustion_efficiency
 
     @functools.cached_property
@@ -104,7 +102,6 @@ class Propellant(abc.ABC):
         Raises:
             ValueError: If evaluation fails.
         """
-        self._validate_components()
         service = self.thermochemical_service
 
         adiabatic_flame_temperature = service.get_adiabatic_flame_temperature(

--- a/machwave/models/propellants/categories/biliquid.py
+++ b/machwave/models/propellants/categories/biliquid.py
@@ -1,5 +1,3 @@
-"""Liquid propellant categories (biliquid)."""
-
 import machwave.services.cea as cea_service
 
 from .. import components as propellant_components
@@ -17,7 +15,6 @@ class BiliquidPropellant(propellant_base.Propellant):
         name: str,
         components: list[propellant_components.PropellantComponent] | None = None,
         combustion_efficiency: float = 0.95,
-        properties: propellant_properties.ThermochemicalProperties | None = None,
         oxidizer_to_fuel_ratio: float | None = None,
     ):
         """
@@ -27,21 +24,26 @@ class BiliquidPropellant(propellant_base.Propellant):
             name: Propellant name.
             components: Chemical components (should be exactly 2: oxidizer and fuel).
             combustion_efficiency: Efficiency factor (0-1).
-            properties: Pre-defined thermochemical properties (optional).
             oxidizer_to_fuel_ratio: Oxidizer-to-fuel mass ratio for this
                 formulation. Used as the default mixture_ratio at the
                 thermochemical service layer; callers can override per-call
                 via ``evaluate(mixture_ratio=...)``.
+
+        Raises:
+            PropellantValidationError: If components do not include exactly
+                one oxidizer and one fuel.
         """
         super().__init__(
             name=name,
             components=components,
             combustion_efficiency=combustion_efficiency,
         )
-        self.properties = properties
+
+        self.properties = None
         self.oxidizer_to_fuel_ratio = oxidizer_to_fuel_ratio
         self.oxidizer_tank_density: float = 0.0
         self.fuel_tank_density: float = 0.0
+        self._validate_components()
 
     def _validate_components(self):
         """

--- a/machwave/models/propellants/categories/biliquid.py
+++ b/machwave/models/propellants/categories/biliquid.py
@@ -39,7 +39,7 @@ class BiliquidPropellant(propellant_base.Propellant):
             combustion_efficiency=combustion_efficiency,
         )
 
-        self.properties = None
+        self.properties: propellant_properties.ThermochemicalProperties | None = None
         self.oxidizer_to_fuel_ratio = oxidizer_to_fuel_ratio
         self.oxidizer_tank_density: float = 0.0
         self.fuel_tank_density: float = 0.0

--- a/machwave/models/propellants/categories/solid.py
+++ b/machwave/models/propellants/categories/solid.py
@@ -1,5 +1,3 @@
-"""Solid propellant category."""
-
 import machwave.services.cea as cea_service
 
 from .. import components as propellant_components
@@ -42,24 +40,31 @@ class SolidPropellant(propellant_base.Propellant):
         """
         Initialize a solid propellant.
 
-        Either `components` or `properties` must be provided.
-
         Args:
             name: Propellant name.
-            components: Chemical components (optional).
-            mass_fractions: Mass fractions for each component (optional).
+            components: Chemical components. Required; must contain at least
+                one oxidizer and one fuel.
+            mass_fractions: Mass fractions aligned with `components`. Must
+                sum to 1.0.
             combustion_efficiency: Efficiency factor in [0, 1].
-            properties: Pre-defined thermochemical properties (optional).
+            properties: Pre-defined thermochemical properties. Optional
+                override used by `evaluate()` to skip CEA when provided.
             burn_rate_map: Saint Robert's law coefficients by pressure range.
+
+        Raises:
+            PropellantValidationError: If components, mass_fractions, or
+                their relationship is invalid.
         """
         super().__init__(
             name=name,
             components=components,
             combustion_efficiency=combustion_efficiency,
         )
+
         self._properties = properties
-        self.burn_rate_map = burn_rate_map if burn_rate_map is not None else []
-        self.mass_fractions = mass_fractions if mass_fractions is not None else []
+        self.burn_rate_map = burn_rate_map or []
+        self.mass_fractions = mass_fractions or []
+        self._validate_components()
 
     @property
     def properties(self) -> propellant_properties.ThermochemicalProperties | None:
@@ -68,38 +73,34 @@ class SolidPropellant(propellant_base.Propellant):
 
     def _validate_components(self):
         """
-        Validate that the solid propellant has both an oxidizer and a fuel.
+        Validate solid propellant components and mass fractions.
 
         Raises:
             PropellantValidationError: If validation fails.
         """
-        # Allow empty components if properties are pre-defined (for formulations)
         if not self.components:
-            if self._properties is None:
-                raise propellant_base.PropellantValidationError(
-                    f"Solid propellant '{self.name}' has no components or pre-defined "
-                    "properties"
-                )
-            return
+            raise propellant_base.PropellantValidationError(
+                f"Solid propellant '{self.name}' requires `components`"
+            )
 
         if not self.mass_fractions:
             raise propellant_base.PropellantValidationError(
-                f"Solid propellant '{self.name}' requires mass_fractions for its "
+                f"Solid propellant '{self.name}' requires `mass_fractions` for its "
                 "components"
             )
         if len(self.mass_fractions) != len(self.components):
             raise propellant_base.PropellantValidationError(
-                f"Solid propellant '{self.name}' mass_fractions length must match "
+                f"Solid propellant '{self.name}' `mass_fractions` length must match "
                 "components length"
             )
         if any(mf < 0 for mf in self.mass_fractions):
             raise propellant_base.PropellantValidationError(
-                f"Solid propellant '{self.name}' mass_fractions must be non-negative"
+                f"Solid propellant '{self.name}' `mass_fractions` must be non-negative"
             )
         mf_sum = sum(self.mass_fractions)
         if abs(mf_sum - 1.0) > MASS_FRACTION_SUM_TOLERANCE:
             raise propellant_base.PropellantValidationError(
-                f"Solid propellant '{self.name}' mass_fractions must sum to 1.0 (got "
+                f"Solid propellant '{self.name}' `mass_fractions` must sum to 1.0 (got "
                 f"{mf_sum:.6f})"
             )
 
@@ -128,22 +129,15 @@ class SolidPropellant(propellant_base.Propellant):
         Returns:
             RocketCEAService instance.
         """
-        if self.components:
-            self._validate_components()
-            components_data = [
-                comp.to_cea_dict(weight_percent=mf * 100.0)
-                for comp, mf in zip(self.components, self.mass_fractions)
-            ]
-            card_string = cea_service.generate_card_string(components_data)
-            return cea_service.create_cea_service(
-                propellant_name=cea_service.normalize_custom_propellant_name(self.name),
-                card_string=card_string,
-            )
-        else:
-            raise propellant_base.PropellantValidationError(
-                f"Cannot create thermochemical service without components for "
-                f"propellant '{self.name}'"
-            )
+        components_data = [
+            comp.to_cea_dict(weight_percent=mf * 100.0)
+            for comp, mf in zip(self.components, self.mass_fractions)
+        ]
+        card_string = cea_service.generate_card_string(components_data)
+        return cea_service.create_cea_service(
+            propellant_name=cea_service.normalize_custom_propellant_name(self.name),
+            card_string=card_string,
+        )
 
     def evaluate(
         self,
@@ -180,7 +174,6 @@ class SolidPropellant(propellant_base.Propellant):
 
         Uses a harmonic mean based on solid mixture mass fractions.
         """
-        self._validate_components()
         reciprocal_sum = sum(
             mf / comp.density for comp, mf in zip(self.components, self.mass_fractions)
         )

--- a/machwave/models/propellants/formulations/base.py
+++ b/machwave/models/propellants/formulations/base.py
@@ -166,7 +166,6 @@ def _create_propellant(
             name=data["name"],
             components=components,
             combustion_efficiency=data.get("combustion_efficiency", 0.98),
-            properties=properties,
             oxidizer_to_fuel_ratio=data.get("oxidizer_to_fuel_ratio"),
         )
     else:

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -42,7 +42,8 @@ class SolidMotorState(simulation_states.MotorState):
                 entire run, so a missing value is a configuration error and
                 the simulation refuses to start.
         """
-        if motor.propellant.properties is None:
+        propellant_properties = motor.propellant.properties
+        if propellant_properties is None:
             raise ValueError(
                 "Propellant properties must be defined to run the simulation."
             )
@@ -55,6 +56,7 @@ class SolidMotorState(simulation_states.MotorState):
         )
 
         self.motor: motors.SolidMotor = motor
+        self.propellant_properties = propellant_properties
 
         self.free_chamber_volume: simulation_states.SimulationStateArray = [
             motor.thrust_chamber.combustion_chamber.internal_volume
@@ -105,7 +107,7 @@ class SolidMotorState(simulation_states.MotorState):
             d_t: Time increment [s].
             external_pressure: External pressure [Pa].
         """
-        propellant_properties = self.motor.propellant.properties
+        propellant_properties = self.propellant_properties
         nozzle = self.motor.thrust_chamber.nozzle
         ideal_propellant_density = self.motor.propellant.ideal_density
 

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -35,7 +35,18 @@ class SolidMotorState(simulation_states.MotorState):
             external_pressure: Ambient pressure [Pa].
             other_losses: Fractional losses not covered by specific
                 mechanisms, in [0, 1].
+
+        Raises:
+            ValueError: If the motor's propellant has no thermochemical
+                properties. Solid propellant properties are fixed for the
+                entire run, so a missing value is a configuration error and
+                the simulation refuses to start.
         """
+        if motor.propellant.properties is None:
+            raise ValueError(
+                "Propellant properties must be defined to run the simulation."
+            )
+
         super().__init__(
             motor=motor,
             igniter_pressure=igniter_pressure,
@@ -95,11 +106,6 @@ class SolidMotorState(simulation_states.MotorState):
             external_pressure: External pressure [Pa].
         """
         propellant_properties = self.motor.propellant.properties
-        if propellant_properties is None:
-            raise ValueError(
-                "Propellant properties must be defined to run the simulation."
-            )
-
         nozzle = self.motor.thrust_chamber.nozzle
         ideal_propellant_density = self.motor.propellant.ideal_density
 

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_base.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_base.py
@@ -246,8 +246,23 @@ class TestCreatePropellant:
             "combustion_efficiency": 0.95,
             "burn_rate_map": [{"min": 0, "max": 1e7, "a": 5.0, "n": 0.5}],
         }
-        components = []
-        mass_fractions = []
+        components = [
+            propellant_components.PropellantComponent(
+                name="KNO3",
+                role=propellant_components.ComponentRole.OXIDIZER,
+                density=2109.0,
+                chemical_formula={"K": 1, "N": 1, "O": 3},
+                enthalpy=-494600.0,
+            ),
+            propellant_components.PropellantComponent(
+                name="Sucrose",
+                role=propellant_components.ComponentRole.FUEL,
+                density=1587.0,
+                chemical_formula={"C": 12, "H": 22, "O": 11},
+                enthalpy=-2226100.0,
+            ),
+        ]
+        mass_fractions = [0.65, 0.35]
         properties = None
 
         result = formulations_base._create_propellant(
@@ -269,7 +284,22 @@ class TestCreatePropellant:
             "combustion_efficiency": 0.98,
             "oxidizer_to_fuel_ratio": 2.5,
         }
-        components = []
+        components = [
+            propellant_components.PropellantComponent(
+                name="LOX",
+                role=propellant_components.ComponentRole.OXIDIZER,
+                density=1141.0,
+                chemical_formula={"O": 2},
+                enthalpy=0.0,
+            ),
+            propellant_components.PropellantComponent(
+                name="LH2",
+                role=propellant_components.ComponentRole.FUEL,
+                density=70.8,
+                chemical_formula={"H": 2},
+                enthalpy=0.0,
+            ),
+        ]
         mass_fractions = None
         properties = None
 
@@ -288,8 +318,28 @@ class TestCreatePropellant:
 
     def test_create_solid_with_default_efficiency(self):
         data = {"name": "Test"}
+        components = [
+            propellant_components.PropellantComponent(
+                name="KNO3",
+                role=propellant_components.ComponentRole.OXIDIZER,
+                density=2109.0,
+                chemical_formula={"K": 1, "N": 1, "O": 3},
+                enthalpy=-494600.0,
+            ),
+            propellant_components.PropellantComponent(
+                name="Sucrose",
+                role=propellant_components.ComponentRole.FUEL,
+                density=1587.0,
+                chemical_formula={"C": 12, "H": 22, "O": 11},
+                enthalpy=-2226100.0,
+            ),
+        ]
         result = formulations_base._create_propellant(
-            propellant_categories.MixtureType.SOLID, data, [], [], None
+            propellant_categories.MixtureType.SOLID,
+            data,
+            components,
+            [0.65, 0.35],
+            None,
         )
 
         assert isinstance(result, propellant_categories.SolidPropellant)
@@ -297,8 +347,24 @@ class TestCreatePropellant:
 
     def test_create_biliquid_with_default_efficiency(self):
         data = {"name": "Test"}
+        components = [
+            propellant_components.PropellantComponent(
+                name="LOX",
+                role=propellant_components.ComponentRole.OXIDIZER,
+                density=1141.0,
+                chemical_formula={"O": 2},
+                enthalpy=0.0,
+            ),
+            propellant_components.PropellantComponent(
+                name="LH2",
+                role=propellant_components.ComponentRole.FUEL,
+                density=70.8,
+                chemical_formula={"H": 2},
+                enthalpy=0.0,
+            ),
+        ]
         result = formulations_base._create_propellant(
-            propellant_categories.MixtureType.BILIQUID, data, [], None, None
+            propellant_categories.MixtureType.BILIQUID, data, components, None, None
         )
 
         assert isinstance(result, propellant_categories.BiliquidPropellant)

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_solid.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_solid.py
@@ -9,6 +9,8 @@ to the module will automatically be tested.
 import pytest
 
 import machwave.models.propellants as propellants_models
+import machwave.models.propellants.categories as propellant_categories
+import machwave.models.propellants.categories.base as propellant_base
 import machwave.models.propellants.categories.solid as solid_propellant_category
 import machwave.models.propellants.formulations.solid as solid_formulations
 
@@ -132,6 +134,15 @@ class TestFixedSolidPropellantSpecifics:
             assert propellant.properties is not None, (
                 f"{name} should have immediate properties"
             )
+
+
+class TestSolidPropellantConstruction:
+    """Test construction-time validation of SolidPropellant."""
+
+    def test_missing_components_raises(self):
+        """Reject a solid propellant built without components."""
+        with pytest.raises(propellant_base.PropellantValidationError):
+            propellant_categories.SolidPropellant(name="Empty")
 
 
 class TestBurnRateBehavior:


### PR DESCRIPTION
## Summary

Changed the validation structure in `propellants`.

## Linked issue

Closes #282