### PR TITLE
Remove dead `_tank_density` properties from BiliquidPropellant

### DIFF
--- a/machwave/models/propellants/categories/biliquid.py
+++ b/machwave/models/propellants/categories/biliquid.py
@@ -41,8 +41,6 @@ class BiliquidPropellant(propellant_base.Propellant):
 
         self.properties: propellant_properties.ThermochemicalProperties | None = None
         self.oxidizer_to_fuel_ratio = oxidizer_to_fuel_ratio
-        self.oxidizer_tank_density: float = 0.0
-        self.fuel_tank_density: float = 0.0
         self._validate_components()
 
     def _validate_components(self):


### PR DESCRIPTION
Closes #300.

## Summary

- Deletes the unused `oxidizer_tank_density` and `fuel_tank_density` attributes from `BiliquidPropellant.__init__`. A repo-wide grep confirms nothing reads or writes them after construction.

## Test plan

- [x] CI passes