### PR TITLE
Move biliquid live thermochemical properties off the propellant model

### DIFF
--- a/machwave/models/propellants/categories/biliquid.py
+++ b/machwave/models/propellants/categories/biliquid.py
@@ -1,7 +1,6 @@
 import machwave.services.cea as cea_service
 
 from .. import components as propellant_components
-from .. import properties as propellant_properties
 from . import base as propellant_base
 
 
@@ -39,7 +38,6 @@ class BiliquidPropellant(propellant_base.Propellant):
             combustion_efficiency=combustion_efficiency,
         )
 
-        self.properties: propellant_properties.ThermochemicalProperties | None = None
         self.oxidizer_to_fuel_ratio = oxidizer_to_fuel_ratio
         self._validate_components()
 

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -56,6 +56,12 @@ class BiliquidEngineState(simulation_states.MotorState):
             motor.feed_system.get_oxidizer_tank_pressure()
         ]
 
+        self.propellant_properties = motor.propellant.evaluate(
+            chamber_pressure=igniter_pressure,
+            expansion_ratio=motor.thrust_chamber.nozzle.expansion_ratio,
+            mixture_ratio=motor.propellant.oxidizer_to_fuel_ratio,
+        )
+
     def get_m_dot_in(self) -> float:
         """Return the total inlet mass flow (fuel + oxidizer) [kg/s]."""
         return self._m_dot_fuel + self._m_dot_ox
@@ -113,13 +119,12 @@ class BiliquidEngineState(simulation_states.MotorState):
                 instantaneous_oxidizer_to_fuel_ratio = m_dot_ox / m_dot_fuel
             else:
                 instantaneous_oxidizer_to_fuel_ratio = oxidizer_to_fuel_ratio
-            self.motor.propellant.properties = self.motor.propellant.evaluate(
+            self.propellant_properties = self.motor.propellant.evaluate(
                 chamber_pressure=self.chamber_pressure[-1],
                 expansion_ratio=nozzle.expansion_ratio,
                 mixture_ratio=instantaneous_oxidizer_to_fuel_ratio,
             )
-        propellant_properties = self.motor.propellant.properties
-        assert propellant_properties is not None
+        propellant_properties = self.propellant_properties
 
         new_chamber_pressure = rk4.rk4th_ode_solver(
             variables={"chamber_pressure": self.chamber_pressure[-1]},

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -7,6 +7,7 @@ import machwave.core.conversions as conversions
 import machwave.core.mass_balance as mass_balance
 import machwave.core.solvers.rk4 as rk4
 import machwave.models.motors as motors
+import machwave.models.propellants.properties as propellant_properties_models
 import machwave.simulation.biliquid.results as biliquid_results
 import machwave.simulation.states as simulation_states
 
@@ -56,15 +57,26 @@ class BiliquidEngineState(simulation_states.MotorState):
             motor.feed_system.get_oxidizer_tank_pressure()
         ]
 
-        self.propellant_properties = motor.propellant.evaluate(
+        self.propellant_properties = self._evaluate_propellant_properties(
             chamber_pressure=igniter_pressure,
-            expansion_ratio=motor.thrust_chamber.nozzle.expansion_ratio,
             mixture_ratio=motor.propellant.oxidizer_to_fuel_ratio,
         )
 
     def get_m_dot_in(self) -> float:
         """Return the total inlet mass flow (fuel + oxidizer) [kg/s]."""
         return self._m_dot_fuel + self._m_dot_ox
+
+    def _evaluate_propellant_properties(
+        self,
+        chamber_pressure: float,
+        mixture_ratio: float | None,
+    ) -> propellant_properties_models.ThermochemicalProperties:
+        """Evaluate the propellant at the chamber pressure and mixture ratio."""
+        return self.motor.propellant.evaluate(
+            chamber_pressure=chamber_pressure,
+            expansion_ratio=self.motor.thrust_chamber.nozzle.expansion_ratio,
+            mixture_ratio=mixture_ratio,
+        )
 
     def run_timestep(
         self,
@@ -119,9 +131,8 @@ class BiliquidEngineState(simulation_states.MotorState):
                 instantaneous_oxidizer_to_fuel_ratio = m_dot_ox / m_dot_fuel
             else:
                 instantaneous_oxidizer_to_fuel_ratio = oxidizer_to_fuel_ratio
-            self.propellant_properties = self.motor.propellant.evaluate(
+            self.propellant_properties = self._evaluate_propellant_properties(
                 chamber_pressure=self.chamber_pressure[-1],
-                expansion_ratio=nozzle.expansion_ratio,
                 mixture_ratio=instantaneous_oxidizer_to_fuel_ratio,
             )
         propellant_properties = self.propellant_properties

--- a/tests/test_simulations/test_biliquid_engine_simulation.py
+++ b/tests/test_simulations/test_biliquid_engine_simulation.py
@@ -8,10 +8,13 @@ it can be reused by benchmarks under tests/benchmarks/.
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pytest
 
 import machwave.models.motors as motors_models
+import machwave.models.propellants.properties as propellant_properties
 import machwave.simulation.biliquid as biliquid_simulation
 from tests.test_simulations import motor_builders
 from tests.test_simulations.conftest import (
@@ -118,38 +121,46 @@ def test_run_timestep_sets_end_burn_when_oxidizer_exhausts() -> None:
     assert state.burn_time == pytest.approx(state.time[-1])
 
 
-def test_live_mixture_ratio_drives_cea(
-    simulated_motor_and_result: tuple[
-        motors_models.BiliquidEngine, biliquid_simulation.BiliquidSimulationResult
-    ],
-) -> None:
-    motor, simulation_result = simulated_motor_and_result
-    propellant = motor.propellant
+def test_live_mixture_ratio_drives_cea() -> None:
+    motor, params = motor_builders.build_1kn_biliquid_engine()
+    state = biliquid_simulation.BiliquidEngineState(
+        motor=motor,
+        igniter_pressure=params.igniter_pressure,
+        external_pressure=params.external_pressure,
+        other_losses=params.other_losses,
+    )
 
-    design_ratio = propellant.oxidizer_to_fuel_ratio
+    design_ratio = motor.propellant.oxidizer_to_fuel_ratio
     assert design_ratio is not None
 
-    fuel_consumed = -np.diff(simulation_result.fuel_mass)
-    oxidizer_consumed = -np.diff(simulation_result.oxidizer_mass)
-    valid = fuel_consumed > 0
-    live_ratios = oxidizer_consumed[valid] / fuel_consumed[valid]
-    assert np.any(np.abs(live_ratios - design_ratio) > 1e-6), (
-        "Live oxidizer/fuel mass deltas never deviated from the design ratio"
-    )
+    deviation_sample: (
+        tuple[propellant_properties.ThermochemicalProperties, float] | None
+    ) = None
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        while not state.end_thrust:
+            state.run_timestep(params.d_t, params.external_pressure)
+            if state._m_dot_fuel <= 0.0:
+                continue
+            live_ratio = state._m_dot_ox / state._m_dot_fuel
+            if abs(live_ratio - design_ratio) > 1e-6:
+                deviation_sample = (
+                    state.propellant_properties,
+                    state.chamber_pressure[-1],
+                )
 
-    chamber_pressure = simulation_result.chamber_pressure[
-        len(simulation_result.chamber_pressure) // 2
-    ]
-    expansion_ratio = motor.thrust_chamber.nozzle.expansion_ratio
-    design_props = propellant.evaluate(
-        chamber_pressure=chamber_pressure,
-        expansion_ratio=expansion_ratio,
+    assert deviation_sample is not None, (
+        "Live oxidizer/fuel mass flow ratio never deviated from the design ratio"
+    )
+    live_properties, live_chamber_pressure = deviation_sample
+
+    design_props = motor.propellant.evaluate(
+        chamber_pressure=live_chamber_pressure,
+        expansion_ratio=motor.thrust_chamber.nozzle.expansion_ratio,
         mixture_ratio=design_ratio,
     )
-    live_props = propellant.properties
-    assert live_props is not None
     assert (
-        live_props.adiabatic_flame_temperature
+        live_properties.adiabatic_flame_temperature
         != design_props.adiabatic_flame_temperature
     )
 


### PR DESCRIPTION
## Summary

- Drop the `properties` attribute from `BiliquidPropellant` so the propellant model is no longer reassigned during simulation.
- `BiliquidEngineState` now owns `propellant_properties` (matches `SolidMotorState`): initialised from the design point in `__init__`, reassigned each `run_timestep` based on the live mixture ratio.
- Rewrite `test_live_mixture_ratio_drives_cea` to drive the state directly and read `state.propellant_properties` at the last step whose live O/F ratio actually diverges from design.

Closes #299.

## Test plan
- [x] `pytest tests/test_simulations/test_biliquid_engine_simulation.py` passes (9 tests, locally green).
- [x] `pytest tests/test_simulations/ tests/test_models/test_propulsion/test_propellants/` passes (160 tests, locally green).