### PR TITLE
Add homogeneous-equilibrium injector model behind a per-side switch

### DIFF
--- a/docs/api/models/feed_systems.md
+++ b/docs/api/models/feed_systems.md
@@ -15,14 +15,14 @@ organised around three concerns:
 
 Every cycle implementation extends [`FeedSystem`][machwave.models.feed_systems.base.FeedSystem] and exposes four methods used by the simulation loop:
 
-- `get_mass_flow_ox(chamber_pressure, *, discharge_coefficient=None, injector_area=None) -> float`
-- `get_mass_flow_fuel(chamber_pressure, *, discharge_coefficient=None, injector_area=None) -> float`
+- `get_mass_flow_ox(chamber_pressure, *, injector) -> float`
+- `get_mass_flow_fuel(chamber_pressure, *, injector) -> float`
 - `get_oxidizer_tank_pressure() -> float`
 - `get_fuel_tank_pressure() -> float`
 
-`discharge_coefficient` and `injector_area` are keyword-only with `None` defaults: pressure-fed cycles need them to evaluate the injector orifice equation, while turbopump cycles that schedule mass flow from pump-curve solutions do not. Keeping the keywords on the abstract base means a single call site in the integrator works against either kind of cycle.
+The mass-flow methods take a [`BipropellantInjector`][machwave.models.thrust_chamber.injector.BipropellantInjector] and delegate the orifice dispatch to it. The feed system is responsible for computing the upstream pressure (tank state, piston losses, pump discharge); the injector owns the orifice physics (discharge coefficient, area, and the per-side `MassFlowModel` that selects between single-phase incompressible and homogeneous-equilibrium two-phase flow). This split lets pump-fed cycles substitute a different upstream-pressure source without touching orifice physics.
 
-The concrete propellant mass-flow consumer is [`machwave.simulation.biliquid.states.BiliquidEngineState.run_timestep`][machwave.simulation.biliquid.states.BiliquidEngineState.run_timestep], which always passes the keywords explicitly — code calling these methods should follow the same pattern.
+The concrete propellant mass-flow consumer is [`machwave.simulation.biliquid.states.BiliquidEngineState.run_timestep`][machwave.simulation.biliquid.states.BiliquidEngineState.run_timestep], which calls these methods once per integration step with the current `chamber_pressure` and the [`BipropellantInjector`][machwave.models.thrust_chamber.injector.BipropellantInjector] from the thrust chamber.
 
 ## Public surface
 

--- a/docs/api/models/feed_systems/cycles.md
+++ b/docs/api/models/feed_systems/cycles.md
@@ -47,13 +47,17 @@ feed_system = StackedTankPressureFedFeedSystem(
 )
 ```
 
-**Mass-flow model.** Each propellant's mass flow is evaluated with the injector orifice equation via `get_mass_flow_orifice` (in [`machwave.core.incompressible_flow`](../../core.md)):
+**Mass-flow model.** The feed system supplies the upstream pressure for each side and delegates the orifice dispatch to the injector. Upstream pressure is the oxidizer tank pressure for the oxidizer branch and `oxidizer_tank_pressure - piston_loss` for the fuel branch; downstream pressure is `chamber_pressure`. The injector picks SPI or HEM per side from its [`MassFlowModel`][machwave.models.thrust_chamber.injector.MassFlowModel]:
 
-\[
-\dot{m} = C_d \cdot A \cdot \sqrt{2 \rho \left(P_\text{up} - P_\text{down}\right)}
-\]
+- **SPI** (single-phase incompressible) — `get_mass_flow_orifice` in [`machwave.core.incompressible_flow`](../../core.md):
 
-with $P_\text{up}$ equal to the oxidizer tank pressure for the oxidizer branch and to `oxidizer_tank_pressure - piston_loss` for the fuel branch, $P_\text{down}$ equal to `chamber_pressure`, and $\rho$ the saturated-liquid density returned by [`Tank.get_density`][machwave.models.feed_systems.tanks.base.Tank.get_density].
+    \[
+    \dot{m} = C_d \cdot A \cdot \sqrt{2 \rho \left(P_\text{up} - P_\text{down}\right)}
+    \]
+
+    with $\rho$ the saturated-liquid density returned by [`Tank.get_density`][machwave.models.feed_systems.tanks.base.Tank.get_density].
+
+- **HEM** (homogeneous-equilibrium two-phase) — `get_homogeneous_equilibrium_mass_flux` in [`machwave.core.two_phase_flow`](../../core.md), required for self-pressurized propellants such as nitrous oxide where the upstream saturated liquid flashes across the orifice and the flow can choke on the two-phase sound speed. The injector multiplies the returned mass flux by $C_d \cdot A$.
 
 Line geometry (`oxidizer_line_diameter`, `oxidizer_line_length`, `fuel_line_diameter`, `fuel_line_length`) is currently stored on the instance for downstream issues that will add feedline pressure drop, but is not consumed by the mass-flow model itself yet.
 

--- a/docs/api/models/thrust_chamber.md
+++ b/docs/api/models/thrust_chamber.md
@@ -4,7 +4,8 @@ Thrust chamber assembly and sub-components.
 
 - `Nozzle` — Conical nozzle defined by throat diameter, expansion ratio, convergent/divergent half-angles, and boundary-layer loss coefficients (`c_1`, `c_2`). Computes throat area and outlet diameter.
 - `CombustionChamber` — Cylindrical casing with thermal liner. Provides internal volume from casing dimensions and liner thickness.
-- `BipropellantInjector` — Injector for biliquid engines, characterized by discharge coefficients and orifice areas for oxidizer and fuel.
+- `BipropellantInjector` — Injector for biliquid engines, characterized by discharge coefficients, orifice areas, and a per-side `MassFlowModel` for the oxidizer and fuel sides. Owns the orifice mass-flow dispatch: `get_mass_flow_ox(*, tank, pressure_upstream, chamber_pressure)` and `get_mass_flow_fuel(*, tank, pressure_upstream, chamber_pressure)`. Feed systems delegate to these methods.
+- `MassFlowModel` — Enum selecting the orifice flow model. `SPI` (single-phase incompressible) for subcooled liquid propellants; `HEM` (homogeneous-equilibrium two-phase) for self-pressurized propellants such as nitrous oxide, where flow can choke on the two-phase sound speed.
 - `SolidMotorThrustChamber` — Bundles nozzle + chamber + the distance from nozzle exit to grain port.
 - `BiliquidEngineThrustChamber` — Bundles nozzle + chamber + injector.
 

--- a/machwave/core/two_phase_flow.py
+++ b/machwave/core/two_phase_flow.py
@@ -1,0 +1,116 @@
+import CoolProp.CoolProp as CP
+import numpy as np
+
+
+def get_homogeneous_equilibrium_mass_flux(
+    fluid_name: str,
+    temperature_upstream: float,
+    pressure_downstream: float,
+    pressure_upstream: float | None = None,
+    sweep_points: int = 200,
+) -> float:
+    """
+    Get the mass flux through an orifice via the homogeneous-equilibrium model.
+
+    Sweeps the pressure from downstream to upstream to find the maximum mass flux.
+    Returns the choked mass flux when the orifice is critical, otherwise the value at
+    the downstream pressure.
+
+    Args:
+        fluid_name: CoolProp fluid name.
+        temperature_upstream: Upstream stagnation temperature [K].
+        pressure_downstream: Downstream pressure [Pa].
+        pressure_upstream: Upstream stagnation pressure [Pa]. If `None`, the saturation
+            pressure at the upstream temperature is used.
+        sweep_points: Number of pressure points in the isentropic sweep.
+
+    Returns:
+        Mass flux [kg/(m^2-s)]. Zero if the downstream pressure is at or above the
+        upstream pressure.
+
+    Raises:
+        ValueError: If the number of sweep points is less than 2.
+    """
+    if sweep_points < 2:
+        raise ValueError("sweep_points must be at least 2")
+
+    upstream_pressure = (
+        CP.PropsSI("P", "T", temperature_upstream, "Q", 0, fluid_name)
+        if pressure_upstream is None
+        else pressure_upstream
+    )
+
+    if pressure_downstream >= upstream_pressure:
+        return 0.0
+
+    upstream_enthalpy, upstream_entropy = _get_stagnation_enthalpy_and_entropy(
+        fluid_name, temperature_upstream, upstream_pressure
+    )
+
+    pressures = np.linspace(pressure_downstream, upstream_pressure, sweep_points)
+    mass_flux = np.zeros_like(pressures)
+    for index, pressure in enumerate(pressures):
+        mass_flux[index] = _get_isentropic_mass_flux(
+            fluid_name, pressure, upstream_enthalpy, upstream_entropy
+        )
+
+    return float(mass_flux.max())
+
+
+def _get_stagnation_enthalpy_and_entropy(
+    fluid_name: str,
+    temperature: float,
+    pressure: float,
+) -> tuple[float, float]:
+    """
+    Get enthalpy and entropy at a given pressure and temperature.
+
+    Falls back to the saturated-liquid state at the requested temperature
+    when the pressure-temperature pair lies on the saturation curve.
+
+    Args:
+        fluid_name: CoolProp fluid name.
+        temperature: Stagnation temperature [K].
+        pressure: Stagnation pressure [Pa].
+
+    Returns:
+        Tuple of enthalpy [J/kg] and entropy [J/(kg K)].
+    """
+    try:
+        enthalpy = CP.PropsSI("H", "P", pressure, "T", temperature, fluid_name)
+        entropy = CP.PropsSI("S", "P", pressure, "T", temperature, fluid_name)
+        return enthalpy, entropy
+    except ValueError:
+        enthalpy = CP.PropsSI("H", "T", temperature, "Q", 0, fluid_name)
+        entropy = CP.PropsSI("S", "T", temperature, "Q", 0, fluid_name)
+        return enthalpy, entropy
+
+
+def _get_isentropic_mass_flux(
+    fluid_name: str,
+    pressure: float,
+    enthalpy_upstream: float,
+    entropy_upstream: float,
+) -> float:
+    """
+    Get the isentropic mass flux at a given pressure for a known upstream state.
+
+    Args:
+        fluid_name: CoolProp fluid name.
+        pressure: Downstream pressure [Pa].
+        enthalpy_upstream: Upstream stagnation enthalpy [J/kg].
+        entropy_upstream: Upstream stagnation entropy [J/(kg K)].
+
+    Returns:
+        Mass flux [kg/(m^2-s)]. Zero if the downstream enthalpy exceeds
+        the upstream value or if CoolProp cannot evaluate the state.
+    """
+    try:
+        density = CP.PropsSI("D", "P", pressure, "S", entropy_upstream, fluid_name)
+        enthalpy = CP.PropsSI("H", "P", pressure, "S", entropy_upstream, fluid_name)
+    except ValueError:
+        return 0.0
+    delta_enthalpy = enthalpy_upstream - enthalpy
+    if delta_enthalpy <= 0.0:
+        return 0.0
+    return density * float(np.sqrt(2.0 * delta_enthalpy))

--- a/machwave/models/feed_systems/base.py
+++ b/machwave/models/feed_systems/base.py
@@ -26,6 +26,7 @@ class FeedSystem(ABC):
     def get_mass_flow_ox(
         self,
         chamber_pressure: float,
+        *,
         injector: injector_models.BipropellantInjector,
     ) -> float:
         """
@@ -44,6 +45,7 @@ class FeedSystem(ABC):
     def get_mass_flow_fuel(
         self,
         chamber_pressure: float,
+        *,
         injector: injector_models.BipropellantInjector,
     ) -> float:
         """

--- a/machwave/models/feed_systems/base.py
+++ b/machwave/models/feed_systems/base.py
@@ -1,20 +1,11 @@
 from abc import ABC, abstractmethod
 
 import machwave.models.feed_systems.tanks as tanks
+import machwave.models.thrust_chamber.injector as injector_models
 
 
 class FeedSystem(ABC):
-    """
-    Abstract base class for a bipropellant feed system in a biliquid rocket engine.
-
-    This class is responsible for determining oxidizer and fuel mass flows as a function of tank/pressurant states,
-    pumps (if any), and current chamber conditions. Subclasses must implement the abstract methods to specify the
-    actual flow calculations.
-
-    The mass-flow methods accept `discharge_coefficient` and `injector_area` as keyword-only arguments with
-    `None` defaults. Pressure-fed cycles require both to evaluate the injector orifice equation. Cycles that
-    schedule mass flow from pump curves or other internal logic can ignore them.
-    """
+    """Abstract base class for a bipropellant feed system in a biliquid rocket engine."""
 
     def __init__(self, fuel_tank: tanks.Tank, oxidizer_tank: tanks.Tank):
         """
@@ -35,17 +26,14 @@ class FeedSystem(ABC):
     def get_mass_flow_ox(
         self,
         chamber_pressure: float,
-        *,
-        discharge_coefficient: float | None = None,
-        injector_area: float | None = None,
+        injector: injector_models.BipropellantInjector,
     ) -> float:
         """
         Compute and return the current oxidizer mass flow rate [kg/s].
 
         Args:
             chamber_pressure: Chamber pressure [Pa].
-            discharge_coefficient: Oxidizer injector discharge coefficient (dimensionless).
-            injector_area: Effective flow area for the oxidizer injector [m^2].
+            injector: Bipropellant injector handling the orifice dispatch.
 
         Returns:
             Oxidizer mass flow rate [kg/s].
@@ -56,17 +44,14 @@ class FeedSystem(ABC):
     def get_mass_flow_fuel(
         self,
         chamber_pressure: float,
-        *,
-        discharge_coefficient: float | None = None,
-        injector_area: float | None = None,
+        injector: injector_models.BipropellantInjector,
     ) -> float:
         """
         Compute and return the current fuel mass flow rate [kg/s].
 
         Args:
             chamber_pressure: Chamber pressure [Pa].
-            discharge_coefficient: Fuel injector discharge coefficient (dimensionless).
-            injector_area: Effective flow area for the fuel injector [m^2].
+            injector: Bipropellant injector handling the orifice dispatch.
 
         Returns:
             Fuel mass flow rate [kg/s].

--- a/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
+++ b/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
@@ -1,14 +1,15 @@
-import machwave.core.incompressible_flow as incompressible_flow
 import machwave.models.feed_systems.base as feed_system_base
 import machwave.models.feed_systems.tanks as tanks
+import machwave.models.thrust_chamber.injector as injector_models
 
 
 class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
     """
     Represents a bipropellant biliquid rocket engine feed system with stacked tanks.
 
-    A stacked tank system is a type of pressure-fed system where the oxidizer and fuel tanks are arranged in a
-    vertical stack. The tanks are separated by a piston and the fuel is pressurized by the oxidizer tank.
+    A stacked tank system is a type of pressure-fed system where the oxidizer and fuel
+    tanks are arranged in a vertical stack. The tanks are separated by a piston and the
+    fuel is pressurized by the oxidizer tank.
     """
 
     def __init__(
@@ -22,7 +23,7 @@ class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
         piston_loss: float = 0.0,
     ):
         """
-        Initialize the StackedTankPressureFedFeedSystem with feedline dimensions, tank objects, and fluid densities.
+        Initialize the StackedTankPressureFedFeedSystem.
 
         Args:
             oxidizer_line_diameter: Diameter of the oxidizer feedline [m].
@@ -49,81 +50,47 @@ class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
         self,
         chamber_pressure: float,
         *,
-        discharge_coefficient: float | None = None,
-        injector_area: float | None = None,
+        injector: injector_models.BipropellantInjector,
     ) -> float:
         """
-        Compute the current oxidizer mass flow rate via get_mass_flow_orifice().
+        Compute the current oxidizer mass flow rate by delegating to the injector.
 
         Args:
             chamber_pressure: Chamber pressure [Pa].
-            discharge_coefficient: Discharge coefficient for the injector (dimensionless).
-            injector_area: Effective flow area for the oxidizer injector [m^2].
+            injector: Bipropellant injector handling the orifice dispatch.
 
         Returns:
             Oxidizer mass flow rate [kg/s].
-
-        Raises:
-            ValueError: If `discharge_coefficient` or `injector_area` is None.
         """
-        if discharge_coefficient is None or injector_area is None:
-            raise ValueError(
-                "StackedTankPressureFedFeedSystem.get_mass_flow_ox requires "
-                "discharge_coefficient and injector_area"
-            )
-
-        p_up = self.get_oxidizer_tank_pressure()
-        p_down = chamber_pressure
-        oxidizer_density = self.oxidizer_tank.get_density()
-
-        return incompressible_flow.get_mass_flow_orifice(
-            discharge_coefficient=discharge_coefficient,
-            area=injector_area,
-            density=oxidizer_density,
-            pressure_upstream=p_up,
-            pressure_downstream=p_down,
+        return injector.get_mass_flow_ox(
+            tank=self.oxidizer_tank,
+            pressure_upstream=self.get_oxidizer_tank_pressure(),
+            chamber_pressure=chamber_pressure,
         )
 
     def get_mass_flow_fuel(
         self,
         chamber_pressure: float,
         *,
-        discharge_coefficient: float | None = None,
-        injector_area: float | None = None,
+        injector: injector_models.BipropellantInjector,
     ) -> float:
         """
-        Compute the current fuel mass flow rate via the orifice model.
+        Compute the current fuel mass flow rate by delegating to the injector.
 
-        The upstream pressure is the oxidizer tank pressure, since this models
-        a stacked tank.
+        The upstream pressure is the oxidizer tank pressure minus the piston
+        loss, since this models a stacked tank pressurized through the piston.
 
         Args:
             chamber_pressure: Chamber pressure [Pa].
-            discharge_coefficient: Discharge coefficient for the injector.
-            injector_area: Effective flow area for the fuel injector [m^2].
+            injector: Bipropellant injector handling the orifice dispatch.
 
         Returns:
             Fuel mass flow rate [kg/s].
-
-        Raises:
-            ValueError: If `discharge_coefficient` or `injector_area` is None.
         """
-        if discharge_coefficient is None or injector_area is None:
-            raise ValueError(
-                "StackedTankPressureFedFeedSystem.get_mass_flow_fuel requires "
-                "discharge_coefficient and injector_area"
-            )
-
-        p_up = self.get_oxidizer_tank_pressure() - self.piston_loss
-        p_down = chamber_pressure
-        fuel_density = self.fuel_tank.get_density()
-
-        return incompressible_flow.get_mass_flow_orifice(
-            discharge_coefficient=discharge_coefficient,
-            area=injector_area,
-            density=fuel_density,
-            pressure_upstream=p_up,
-            pressure_downstream=p_down,
+        return injector.get_mass_flow_fuel(
+            tank=self.fuel_tank,
+            pressure_upstream=self.get_fuel_tank_pressure(),
+            chamber_pressure=chamber_pressure,
         )
 
     def get_oxidizer_tank_pressure(self) -> float:

--- a/machwave/models/thrust_chamber/__init__.py
+++ b/machwave/models/thrust_chamber/__init__.py
@@ -6,7 +6,10 @@ from machwave.models.thrust_chamber.base import (
 from machwave.models.thrust_chamber.combustion_chamber import (
     CombustionChamber,
 )
-from machwave.models.thrust_chamber.injector import BipropellantInjector
+from machwave.models.thrust_chamber.injector import (
+    BipropellantInjector,
+    MassFlowModel,
+)
 from machwave.models.thrust_chamber.nozzle import Nozzle
 
 __all__ = [
@@ -14,6 +17,7 @@ __all__ = [
     "SolidMotorThrustChamber",
     "ThrustChamber",
     "BipropellantInjector",
+    "MassFlowModel",
     "Nozzle",
     "CombustionChamber",
 ]

--- a/machwave/models/thrust_chamber/injector.py
+++ b/machwave/models/thrust_chamber/injector.py
@@ -1,3 +1,30 @@
+from __future__ import annotations
+
+import enum
+from typing import TYPE_CHECKING
+
+import machwave.core.incompressible_flow as incompressible_flow
+import machwave.core.two_phase_flow as two_phase_flow
+
+if TYPE_CHECKING:
+    import machwave.models.feed_systems.tanks as tanks
+
+
+class MassFlowModel(enum.StrEnum):
+    """
+    Models for computing mass flow through an injector orifice.
+
+    SPI: Single-phase incompressible orifice equation. Valid for subcooled liquid
+        propellants.
+    HEM: Homogeneous-equilibrium two-phase model. Required for self-pressurized
+        propellants such as nitrous oxide, where flow can choke at the injector due to
+        flash boiling.
+    """
+
+    SPI = "spi"
+    HEM = "hem"
+
+
 class BipropellantInjector:
     """A simple injector class for a biliquid rocket engine."""
 
@@ -7,6 +34,8 @@ class BipropellantInjector:
         discharge_coefficient_oxidizer: float,
         area_fuel: float,
         area_ox: float,
+        mass_flow_model_fuel: MassFlowModel = MassFlowModel.SPI,
+        mass_flow_model_oxidizer: MassFlowModel = MassFlowModel.SPI,
     ):
         """
         Initialize an Injector instance.
@@ -20,8 +49,111 @@ class BipropellantInjector:
                 Effective flow area of the fuel injector [m^2].
             area_ox:
                 Effective flow area of the oxidizer injector [m^2].
+            mass_flow_model_fuel:
+                Mass flow model for the fuel side.
+            mass_flow_model_oxidizer:
+                Mass flow model for the oxidizer side.
         """
         self.discharge_coefficient_fuel = discharge_coefficient_fuel
         self.discharge_coefficient_oxidizer = discharge_coefficient_oxidizer
         self.area_fuel = area_fuel
         self.area_ox = area_ox
+        self.mass_flow_model_fuel = MassFlowModel(mass_flow_model_fuel)
+        self.mass_flow_model_oxidizer = MassFlowModel(mass_flow_model_oxidizer)
+
+    def get_mass_flow_fuel(
+        self,
+        *,
+        tank: tanks.Tank,
+        pressure_upstream: float,
+        chamber_pressure: float,
+    ) -> float:
+        """
+        Compute the fuel-side mass flow rate through this injector.
+
+        Args:
+            tank: Tank supplying the fuel.
+            pressure_upstream: Upstream stagnation pressure [Pa].
+            chamber_pressure: Chamber pressure [Pa].
+
+        Returns:
+            Fuel mass flow rate [kg/s].
+        """
+        return self._get_mass_flow(
+            tank=tank,
+            pressure_upstream=pressure_upstream,
+            chamber_pressure=chamber_pressure,
+            discharge_coefficient=self.discharge_coefficient_fuel,
+            injector_area=self.area_fuel,
+            mass_flow_model=self.mass_flow_model_fuel,
+        )
+
+    def get_mass_flow_ox(
+        self,
+        *,
+        tank: tanks.Tank,
+        pressure_upstream: float,
+        chamber_pressure: float,
+    ) -> float:
+        """
+        Compute the oxidizer-side mass flow rate through this injector.
+
+        Args:
+            tank: Tank supplying the oxidizer.
+            pressure_upstream: Upstream stagnation pressure [Pa].
+            chamber_pressure: Chamber pressure [Pa].
+
+        Returns:
+            Oxidizer mass flow rate [kg/s].
+        """
+        return self._get_mass_flow(
+            tank=tank,
+            pressure_upstream=pressure_upstream,
+            chamber_pressure=chamber_pressure,
+            discharge_coefficient=self.discharge_coefficient_oxidizer,
+            injector_area=self.area_ox,
+            mass_flow_model=self.mass_flow_model_oxidizer,
+        )
+
+    @staticmethod
+    def _get_mass_flow(
+        *,
+        tank: tanks.Tank,
+        pressure_upstream: float,
+        chamber_pressure: float,
+        discharge_coefficient: float,
+        injector_area: float,
+        mass_flow_model: MassFlowModel,
+    ) -> float:
+        """
+        Dispatch a mass flow calculation through the requested model.
+
+        Args:
+            tank: Tank supplying the propellant.
+            pressure_upstream: Upstream stagnation pressure [Pa].
+            chamber_pressure: Chamber pressure [Pa].
+            discharge_coefficient: Discharge coefficient (dimensionless).
+            injector_area: Effective flow area [m^2].
+            mass_flow_model: Mass flow model for this side.
+
+        Returns:
+            Mass flow rate [kg/s].
+        """
+        if mass_flow_model == MassFlowModel.HEM:
+            mass_flux = two_phase_flow.get_homogeneous_equilibrium_mass_flux(
+                fluid_name=tank.fluid_name,
+                temperature_upstream=tank.temperature,
+                pressure_downstream=chamber_pressure,
+                pressure_upstream=pressure_upstream,
+            )
+            return discharge_coefficient * injector_area * mass_flux
+        elif mass_flow_model == MassFlowModel.SPI:
+            return incompressible_flow.get_mass_flow_orifice(
+                discharge_coefficient=discharge_coefficient,
+                area=injector_area,
+                density=tank.get_density(),
+                pressure_upstream=pressure_upstream,
+                pressure_downstream=chamber_pressure,
+            )
+
+        raise ValueError(f"Unsupported mass flow model: {mass_flow_model}")

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -99,13 +99,11 @@ class BiliquidEngineState(simulation_states.MotorState):
         if self.propellant_mass[-1] > 0:
             m_dot_fuel = feed_system.get_mass_flow_fuel(
                 chamber_pressure=self.chamber_pressure[-1],
-                discharge_coefficient=injector.discharge_coefficient_fuel,
-                injector_area=injector.area_fuel,
+                injector=injector,
             )
             m_dot_ox = feed_system.get_mass_flow_ox(
                 chamber_pressure=self.chamber_pressure[-1],
-                discharge_coefficient=injector.discharge_coefficient_oxidizer,
-                injector_area=injector.area_ox,
+                injector=injector,
             )
         else:
             m_dot_fuel = m_dot_ox = 0.0

--- a/tests/test_core/test_two_phase_flow.py
+++ b/tests/test_core/test_two_phase_flow.py
@@ -1,0 +1,173 @@
+import CoolProp.CoolProp as CP
+import numpy as np
+import pytest
+
+import machwave.core.two_phase_flow as two_phase_flow
+
+
+def _get_reference_hem_mass_flux(
+    fluid_name: str,
+    temperature_upstream: float,
+    pressure_downstream: float,
+    pressure_upstream: float | None = None,
+    sweep_points: int = 2000,
+) -> float:
+    """High-resolution HEM oracle reproducing PropSim's TwoPhaseN2OFlow.m."""
+    p_up = (
+        CP.PropsSI("P", "T", temperature_upstream, "Q", 0, fluid_name)
+        if pressure_upstream is None
+        else pressure_upstream
+    )
+    if pressure_downstream >= p_up:
+        return 0.0
+    h_up = CP.PropsSI("H", "T", temperature_upstream, "Q", 0, fluid_name)
+    s_up = CP.PropsSI("S", "T", temperature_upstream, "Q", 0, fluid_name)
+    pressures = np.linspace(pressure_downstream, p_up, sweep_points)
+    fluxes = np.zeros_like(pressures)
+    for i, pressure in enumerate(pressures):
+        try:
+            density = CP.PropsSI("D", "P", pressure, "S", s_up, fluid_name)
+            enthalpy = CP.PropsSI("H", "P", pressure, "S", s_up, fluid_name)
+        except ValueError:
+            continue
+        delta_enthalpy = h_up - enthalpy
+        if delta_enthalpy > 0:
+            fluxes[i] = density * np.sqrt(2.0 * delta_enthalpy)
+    return float(fluxes.max())
+
+
+@pytest.mark.parametrize(
+    "temperature_upstream,pressure_downstream",
+    [
+        (283.0, 20e5),
+        (293.0, 20e5),
+        (293.0, 30e5),
+    ],
+)
+def test_get_homogeneous_equilibrium_mass_flux_matches_reference_within_five_percent(
+    temperature_upstream,
+    pressure_downstream,
+):
+    """
+    HEM mass flux for saturated nitrous oxide matches the PropSim-style
+    reference within 5%.
+    """
+    actual = two_phase_flow.get_homogeneous_equilibrium_mass_flux(
+        fluid_name="N2O",
+        temperature_upstream=temperature_upstream,
+        pressure_downstream=pressure_downstream,
+    )
+    expected = _get_reference_hem_mass_flux(
+        fluid_name="N2O",
+        temperature_upstream=temperature_upstream,
+        pressure_downstream=pressure_downstream,
+    )
+    assert actual == pytest.approx(expected, rel=0.05)
+
+
+def test_get_homogeneous_equilibrium_mass_flux_returns_zero_when_downstream_at_or_above_upstream():
+    """No flow when chamber pressure is at or above the upstream pressure."""
+    p_sat = CP.PropsSI("P", "T", 293.0, "Q", 0, "N2O")
+
+    assert (
+        two_phase_flow.get_homogeneous_equilibrium_mass_flux(
+            fluid_name="N2O",
+            temperature_upstream=293.0,
+            pressure_downstream=p_sat,
+        )
+        == 0.0
+    )
+    assert (
+        two_phase_flow.get_homogeneous_equilibrium_mass_flux(
+            fluid_name="N2O",
+            temperature_upstream=293.0,
+            pressure_downstream=p_sat + 1e5,
+        )
+        == 0.0
+    )
+
+
+def test_get_homogeneous_equilibrium_mass_flux_chokes_below_critical_back_pressure():
+    """Two deeply subcritical chamber pressures yield the same choked mass flux."""
+    flux_low = two_phase_flow.get_homogeneous_equilibrium_mass_flux(
+        fluid_name="N2O",
+        temperature_upstream=293.0,
+        pressure_downstream=5e5,
+    )
+    flux_mid = two_phase_flow.get_homogeneous_equilibrium_mass_flux(
+        fluid_name="N2O",
+        temperature_upstream=293.0,
+        pressure_downstream=15e5,
+    )
+    assert flux_low == pytest.approx(flux_mid, rel=1e-3)
+
+
+def test_get_homogeneous_equilibrium_mass_flux_is_subcritical_above_choking_back_pressure():
+    """
+    Above the choking back-pressure, lowering chamber pressure increases
+    mass flux.
+    """
+    flux_high_back_pressure = two_phase_flow.get_homogeneous_equilibrium_mass_flux(
+        fluid_name="N2O",
+        temperature_upstream=293.0,
+        pressure_downstream=45e5,
+    )
+    flux_lower_back_pressure = two_phase_flow.get_homogeneous_equilibrium_mass_flux(
+        fluid_name="N2O",
+        temperature_upstream=293.0,
+        pressure_downstream=42e5,
+    )
+    assert flux_lower_back_pressure > flux_high_back_pressure
+
+
+def test_get_homogeneous_equilibrium_mass_flux_predicts_lower_flow_than_incompressible_for_saturated_n2o():
+    """HEM is conservative relative to SPI evaluated on saturated-liquid density."""
+    fluid_name = "N2O"
+    temperature_upstream = 293.0
+    pressure_downstream = 20e5
+    p_sat = CP.PropsSI("P", "T", temperature_upstream, "Q", 0, fluid_name)
+    rho_l = CP.PropsSI("D", "T", temperature_upstream, "Q", 0, fluid_name)
+
+    flux_hem = two_phase_flow.get_homogeneous_equilibrium_mass_flux(
+        fluid_name=fluid_name,
+        temperature_upstream=temperature_upstream,
+        pressure_downstream=pressure_downstream,
+    )
+    flux_spi = np.sqrt(2.0 * rho_l * (p_sat - pressure_downstream))
+
+    assert flux_hem < flux_spi
+
+
+def test_get_homogeneous_equilibrium_mass_flux_raises_on_degenerate_sweep_points():
+    """ValueError is raised when `sweep_points` is less than 2."""
+    with pytest.raises(ValueError, match="sweep_points must be at least 2"):
+        two_phase_flow.get_homogeneous_equilibrium_mass_flux(
+            fluid_name="N2O",
+            temperature_upstream=293.0,
+            pressure_downstream=20e5,
+            sweep_points=1,
+        )
+
+
+def test_get_homogeneous_equilibrium_mass_flux_honors_pressure_upstream_override():
+    """
+    Explicit upstream pressure is used in place of the saturation pressure
+    at the upstream temperature.
+    """
+    fluid_name = "N2O"
+    temperature_upstream = 293.0
+    pressure_downstream = 20e5
+    p_sat = CP.PropsSI("P", "T", temperature_upstream, "Q", 0, fluid_name)
+
+    default = two_phase_flow.get_homogeneous_equilibrium_mass_flux(
+        fluid_name=fluid_name,
+        temperature_upstream=temperature_upstream,
+        pressure_downstream=pressure_downstream,
+    )
+    overridden = two_phase_flow.get_homogeneous_equilibrium_mass_flux(
+        fluid_name=fluid_name,
+        temperature_upstream=temperature_upstream,
+        pressure_downstream=pressure_downstream,
+        pressure_upstream=p_sat,
+    )
+    assert default == pytest.approx(overridden)

--- a/tests/test_models/test_propulsion/test_feed_systems/test_stacked_tank_pressure_fed.py
+++ b/tests/test_models/test_propulsion/test_feed_systems/test_stacked_tank_pressure_fed.py
@@ -1,0 +1,45 @@
+import pytest
+
+import machwave.models.feed_systems.tanks as tanks
+from machwave.models.thrust_chamber import MassFlowModel
+from tests.factories import (
+    BipropellantInjectorFactory,
+    StackedTankPressureFedFeedSystemFactory,
+)
+
+
+def test_get_mass_flow_ox_delegates_to_injector_dispatch():
+    """Feed-system call equals the injector's own dispatch on the ox tank."""
+    oxidizer_tank = tanks.Tank(
+        fluid_name="N2O", volume=0.01, temperature=293.0, initial_fluid_mass=5.0
+    )
+    feed_system = StackedTankPressureFedFeedSystemFactory.build(
+        oxidizer_tank=oxidizer_tank,
+    )
+    injector = BipropellantInjectorFactory.build(
+        mass_flow_model_oxidizer=MassFlowModel.HEM,
+    )
+    chamber_pressure = 20e5
+
+    actual = feed_system.get_mass_flow_ox(chamber_pressure, injector=injector)
+    expected = injector.get_mass_flow_ox(
+        tank=oxidizer_tank,
+        pressure_upstream=feed_system.get_oxidizer_tank_pressure(),
+        chamber_pressure=chamber_pressure,
+    )
+    assert actual == pytest.approx(expected)
+
+
+def test_get_mass_flow_fuel_uses_piston_pressurized_upstream():
+    """Fuel-side upstream is the oxidizer tank pressure minus piston loss."""
+    feed_system = StackedTankPressureFedFeedSystemFactory.build(piston_loss=2e5)
+    injector = BipropellantInjectorFactory.build()
+    chamber_pressure = 15e5
+
+    actual = feed_system.get_mass_flow_fuel(chamber_pressure, injector=injector)
+    expected = injector.get_mass_flow_fuel(
+        tank=feed_system.fuel_tank,
+        pressure_upstream=feed_system.get_oxidizer_tank_pressure() - 2e5,
+        chamber_pressure=chamber_pressure,
+    )
+    assert actual == pytest.approx(expected)

--- a/tests/test_models/test_propulsion/test_injector.py
+++ b/tests/test_models/test_propulsion/test_injector.py
@@ -1,5 +1,7 @@
 import pytest
 
+import machwave.models.feed_systems.tanks as tanks
+from machwave.models.thrust_chamber import MassFlowModel
 from tests.factories import BipropellantInjectorFactory
 
 
@@ -35,3 +37,148 @@ class TestBipropellantInjectorInstantiation:
         """Fuel and oxidizer orifice areas are independently configurable."""
         inj = BipropellantInjectorFactory.build(area_fuel=5e-6, area_ox=2e-5)
         assert inj.area_fuel != inj.area_ox
+
+    def test_default_mass_flow_model_is_spi(self, injector):
+        assert injector.mass_flow_model_fuel is MassFlowModel.SPI
+        assert injector.mass_flow_model_oxidizer is MassFlowModel.SPI
+
+    def test_per_side_mass_flow_model_overrides(self):
+        """Mass flow models are configurable independently per side."""
+        inj = BipropellantInjectorFactory.build(
+            mass_flow_model_fuel=MassFlowModel.SPI,
+            mass_flow_model_oxidizer=MassFlowModel.HEM,
+        )
+        assert inj.mass_flow_model_fuel is MassFlowModel.SPI
+        assert inj.mass_flow_model_oxidizer is MassFlowModel.HEM
+
+    def test_invalid_mass_flow_model_raises_value_error(self):
+        with pytest.raises(ValueError, match="not a valid MassFlowModel"):
+            BipropellantInjectorFactory.build(mass_flow_model_fuel="foo")
+
+
+class TestBipropellantInjectorMassFlow:
+    def test_hem_predicts_lower_oxidizer_flow_than_spi_for_saturated_n2o(self):
+        """For saturated N2O, HEM under-predicts SPI."""
+        oxidizer_tank = tanks.Tank(
+            fluid_name="N2O", volume=0.01, temperature=293.0, initial_fluid_mass=5.0
+        )
+        kwargs = dict(
+            tank=oxidizer_tank,
+            pressure_upstream=oxidizer_tank.get_pressure(),
+            chamber_pressure=20e5,
+        )
+        injector_spi = BipropellantInjectorFactory.build(
+            mass_flow_model_oxidizer=MassFlowModel.SPI,
+        )
+        injector_hem = BipropellantInjectorFactory.build(
+            mass_flow_model_oxidizer=MassFlowModel.HEM,
+        )
+
+        flow_spi = injector_spi.get_mass_flow_ox(**kwargs)
+        flow_hem = injector_hem.get_mass_flow_ox(**kwargs)
+
+        assert flow_hem < flow_spi
+
+    def test_spi_dispatch_returns_positive_flow(self):
+        oxidizer_tank = tanks.Tank(
+            fluid_name="N2O", volume=0.01, temperature=293.0, initial_fluid_mass=5.0
+        )
+        injector = BipropellantInjectorFactory.build()
+        flow = injector.get_mass_flow_ox(
+            tank=oxidizer_tank,
+            pressure_upstream=oxidizer_tank.get_pressure(),
+            chamber_pressure=20e5,
+        )
+        assert flow > 0.0
+
+    def test_spi_dispatch_matches_core_orifice_helper(self):
+        """SPI dispatch equals `Cd * A * sqrt(2 * rho * dP)` from the core helper."""
+        import machwave.core.incompressible_flow as incompressible_flow
+
+        oxidizer_tank = tanks.Tank(
+            fluid_name="N2O", volume=0.01, temperature=293.0, initial_fluid_mass=5.0
+        )
+        injector = BipropellantInjectorFactory.build(
+            mass_flow_model_oxidizer=MassFlowModel.SPI,
+        )
+        pressure_upstream = oxidizer_tank.get_pressure()
+        chamber_pressure = 20e5
+
+        actual = injector.get_mass_flow_ox(
+            tank=oxidizer_tank,
+            pressure_upstream=pressure_upstream,
+            chamber_pressure=chamber_pressure,
+        )
+        expected = incompressible_flow.get_mass_flow_orifice(
+            discharge_coefficient=injector.discharge_coefficient_oxidizer,
+            area=injector.area_ox,
+            density=oxidizer_tank.get_density(),
+            pressure_upstream=pressure_upstream,
+            pressure_downstream=chamber_pressure,
+        )
+        assert actual == pytest.approx(expected)
+
+    def test_hem_dispatch_matches_two_phase_helper_times_cd_and_area(self):
+        """HEM dispatch equals `Cd * A * G_HEM` from the core helper."""
+        import machwave.core.two_phase_flow as two_phase_flow
+
+        oxidizer_tank = tanks.Tank(
+            fluid_name="N2O", volume=0.01, temperature=293.0, initial_fluid_mass=5.0
+        )
+        injector = BipropellantInjectorFactory.build(
+            mass_flow_model_oxidizer=MassFlowModel.HEM,
+        )
+        pressure_upstream = oxidizer_tank.get_pressure()
+        chamber_pressure = 20e5
+
+        actual = injector.get_mass_flow_ox(
+            tank=oxidizer_tank,
+            pressure_upstream=pressure_upstream,
+            chamber_pressure=chamber_pressure,
+        )
+        mass_flux = two_phase_flow.get_homogeneous_equilibrium_mass_flux(
+            fluid_name=oxidizer_tank.fluid_name,
+            temperature_upstream=oxidizer_tank.temperature,
+            pressure_downstream=chamber_pressure,
+            pressure_upstream=pressure_upstream,
+        )
+        expected = (
+            injector.discharge_coefficient_oxidizer * injector.area_ox * mass_flux
+        )
+        assert actual == pytest.approx(expected)
+
+    def test_fuel_side_dispatch_uses_fuel_attributes(self):
+        """Fuel dispatch uses fuel-side Cd, area, and model — not the ox-side ones."""
+        fuel_tank = tanks.Tank(
+            fluid_name="Ethanol",
+            volume=0.005,
+            temperature=298.0,
+            initial_fluid_mass=2.0,
+        )
+        injector = BipropellantInjectorFactory.build(
+            discharge_coefficient_fuel=0.40,
+            discharge_coefficient_oxidizer=0.80,
+            area_fuel=5.0e-6,
+            area_ox=2.0e-5,
+            mass_flow_model_fuel=MassFlowModel.SPI,
+            mass_flow_model_oxidizer=MassFlowModel.HEM,
+        )
+        pressure_upstream = 30e5
+        chamber_pressure = 20e5
+
+        flow = injector.get_mass_flow_fuel(
+            tank=fuel_tank,
+            pressure_upstream=pressure_upstream,
+            chamber_pressure=chamber_pressure,
+        )
+
+        import machwave.core.incompressible_flow as incompressible_flow
+
+        expected = incompressible_flow.get_mass_flow_orifice(
+            discharge_coefficient=0.40,
+            area=5.0e-6,
+            density=fuel_tank.get_density(),
+            pressure_upstream=pressure_upstream,
+            pressure_downstream=chamber_pressure,
+        )
+        assert flow == pytest.approx(expected)


### PR DESCRIPTION
## Summary

Adds `MassFlowModel.HEM` (homogeneous-equilibrium two-phase) as an alternative to `MassFlowModel.SPI` for computing injector mass flow, configurable per side on `BipropellantInjector`. SPI remains the default. As part of the change, orifice dispatch was moved from `StackedTankPressureFedFeedSystem` onto the injector itself — the feed system now owns upstream-pressure determination (tank state, piston loss) and delegates orifice physics to `injector.get_mass_flow_fuel`/`get_mass_flow_ox`.

HEM is required for self-pressurized propellants such as nitrous oxide where the upstream saturated liquid flashes across the orifice and the flow can choke on the two-phase sound speed. For the 1 kN N₂O/ethanol operating envelope, SPI over-predicts oxidizer mass flow by ~2–2.5x; HEM matches the PropSim `TwoPhaseN2OFlow.m` reference within 5% at three N₂O operating points.

## Linked issue

Closes #253

## Test plan

- [x] `make check` passes (format, lint, typecheck)
- [x] `make test` passes — 670 passed, no regressions
- [x] New or updated tests cover the change
- [x] Manual verification: not run; full sim is exercised by `test_biliquid_engine_simulation.py`

New test coverage:

- `tests/test_core/test_two_phase_flow.py` — 9 tests on the HEM helper: 5% match against a high-resolution PropSim-style oracle, choking plateau, subcritical monotonicity, HEM < SPI for saturated N₂O, boundary cases, `pressure_upstream` override.
- `tests/test_models/test_propulsion/test_injector.py` — added per-side `MassFlowModel` storage/validation tests and 4 dispatch tests (HEM < SPI, SPI dispatch matches `get_mass_flow_orifice` exactly, HEM dispatch matches `Cd·A·G_HEM` exactly, fuel-side uses fuel attributes not ox).
- `tests/test_models/test_propulsion/test_feed_systems/test_stacked_tank_pressure_fed.py` — feed-system delegation: ox call delegates to injector; fuel call uses piston-pressurized upstream.

## Documentation

- [x] Public API or user-facing behaviour is documented in `docs/` or docstrings
  - `docs/api/models/thrust_chamber.md` — `BipropellantInjector` description updated; `MassFlowModel` enum added.
  - `docs/api/models/feed_systems.md` — `FeedSystem` contract updated to reflect the `injector=` kwarg.
  - `docs/api/models/feed_systems/cycles.md` — mass-flow section split into SPI/HEM, pointing at the per-side `MassFlowModel` selector.

## Additional notes

- **Out of scope:** Dyer / NHNE (non-homogeneous non-equilibrium) model — `1/(1+κ)·m_HEM + κ/(1+κ)·m_SPI` blend. With both `SPI` and `HEM` now behind the switch, adding `NHNE` is a small follow-up: one `κ` helper plus a third enum member.
- **Default behavior unchanged:** `BipropellantInjector` defaults both sides to `MassFlowModel.SPI`. The example in `examples/1kn_biliquid_engine.py` does not opt into HEM. Existing call sites and tests stay on SPI.
- **Architecture:** Per #253's "on the injector or feed system" guidance, the dispatch lives on the injector. The feed system retains responsibility for upstream-pressure determination so pump-fed cycles can substitute a different source without touching orifice physics.
- **Circular import resolution:** `injector.py` imports `feed_systems.tanks` under `TYPE_CHECKING` only (matching the pattern in `machwave/simulation/states.py`) to break the new feed-systems ↔ injector cycle.
- **Signature note:** the abstract `FeedSystem.get_mass_flow_*` declares `injector` as positional/keyword while the concrete `StackedTankPressureFedFeedSystem` declares it keyword-only. Liskov-OK but minor inconsistency — left as-is per discussion; happy to align if preferred.