### PR TITLE
Add free-chamber-volume rate term to chamber pressure ODE

### DIFF
--- a/machwave/core/mass_balance.py
+++ b/machwave/core/mass_balance.py
@@ -10,7 +10,8 @@ def compute_chamber_pressure_mass_balance(
     k: float,
     R: float,
     flame_temperature: float,
-    discharge_coefficient: float = 1.0,
+    nozzle_discharge_coefficient: float = 1.0,
+    free_chamber_volume_rate: float = 0.0,
 ) -> tuple[float]:
     """
     Right-hand side of the chamber pressure ODE from a control-volume mass balance.
@@ -26,7 +27,9 @@ def compute_chamber_pressure_mass_balance(
         k: Isentropic exponent of the mix.
         R: Gas constant per molecular weight [J/(kg-K)].
         flame_temperature: Flame temperature [K].
-        discharge_coefficient: Discharge coefficient.
+        nozzle_discharge_coefficient: Nozzle discharge coefficient.
+        free_chamber_volume_rate: Rate of change of chamber free volume [m^3/s].
+            Defaults to 0, i.e. constant free volume.
 
     Returns:
         Derivative of chamber pressure with respect to time, as a one-tuple.
@@ -35,23 +38,25 @@ def compute_chamber_pressure_mass_balance(
     pressure_ratio = external_pressure / chamber_pressure
 
     if pressure_ratio <= critical_pressure_ratio:  # choked
-        H = (k**0.5) * (2 / (k + 1)) ** ((k + 1) / (2 * (k - 1)))
+        isentropic_flow_function = (k**0.5) * (2 / (k + 1)) ** (
+            (k + 1) / (2 * (k - 1))
+        )  # Vandenkerckhove function
     else:
-        H = (
+        isentropic_flow_function = (
             ((2 * k / (k - 1)) ** 0.5)
             * pressure_ratio ** (1 / k)
             * (1 - pressure_ratio ** ((k - 1) / k)) ** 0.5
         )
 
     mass_flow_out = (
-        discharge_coefficient
+        nozzle_discharge_coefficient
         * chamber_pressure
         * throat_area
-        * H
+        * isentropic_flow_function
         / (R * flame_temperature) ** 0.5
     )
 
     chamber_pressure_derivative = (R * flame_temperature / free_chamber_volume) * (
         mass_flow_in - mass_flow_out
-    )
+    ) - chamber_pressure * free_chamber_volume_rate / free_chamber_volume
     return (chamber_pressure_derivative,)

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -146,7 +146,7 @@ class BiliquidEngineState(simulation_states.MotorState):
             k=propellant_properties.k_chamber,
             R=propellant_properties.R_chamber,
             flame_temperature=propellant_properties.adiabatic_flame_temperature,
-            discharge_coefficient=nozzle.discharge_coefficient,
+            nozzle_discharge_coefficient=nozzle.discharge_coefficient,
         )[0]
         self.chamber_pressure.append(new_chamber_pressure)
         exit_pressure = isentropic.get_exit_pressure(

--- a/machwave/simulation/solid/results.py
+++ b/machwave/simulation/solid/results.py
@@ -19,6 +19,7 @@ class SolidSimulationResult(
     """Simulation result for a solid motor run."""
 
     free_chamber_volume: simulation_results.SimulationResultArray
+    free_chamber_volume_rate: simulation_results.SimulationResultArray
     web: simulation_results.SimulationResultArray
     burn_area: simulation_results.SimulationResultArray
     propellant_volume: simulation_results.SimulationResultArray
@@ -64,6 +65,7 @@ class SolidSimulationResult(
 
         return {
             "free_chamber_volume": np.asarray(state.free_chamber_volume),
+            "free_chamber_volume_rate": np.asarray(state.free_chamber_volume_rate),
             "web": web,
             "burn_area": burn_area,
             "propellant_volume": propellant_volume,

--- a/machwave/simulation/solid/results.py
+++ b/machwave/simulation/solid/results.py
@@ -19,7 +19,6 @@ class SolidSimulationResult(
     """Simulation result for a solid motor run."""
 
     free_chamber_volume: simulation_results.SimulationResultArray
-    free_chamber_volume_rate: simulation_results.SimulationResultArray
     web: simulation_results.SimulationResultArray
     burn_area: simulation_results.SimulationResultArray
     propellant_volume: simulation_results.SimulationResultArray
@@ -65,7 +64,6 @@ class SolidSimulationResult(
 
         return {
             "free_chamber_volume": np.asarray(state.free_chamber_volume),
-            "free_chamber_volume_rate": np.asarray(state.free_chamber_volume_rate),
             "web": web,
             "burn_area": burn_area,
             "propellant_volume": propellant_volume,

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -69,6 +69,7 @@ class SolidMotorState(simulation_states.MotorState):
             self.motor.grain.get_propellant_volume(0.0)
         ]
         self.burn_rate: simulation_states.SimulationStateArray = [0.0]
+        self.free_chamber_volume_rate: simulation_states.SimulationStateArray = [0.0]
 
         initial_cog = motor.grain.get_center_of_gravity(
             web_distance=0.0,
@@ -126,6 +127,8 @@ class SolidMotorState(simulation_states.MotorState):
 
         free_chamber_volume = self.motor.get_free_chamber_volume(propellant_volume)
         self.free_chamber_volume.append(free_chamber_volume)
+        free_chamber_volume_rate = burn_rate * burn_area
+        self.free_chamber_volume_rate.append(free_chamber_volume_rate)
         propellant_mass = self.motor.grain.get_propellant_mass(
             web_distance=web_distance, ideal_density=ideal_propellant_density
         )
@@ -152,7 +155,7 @@ class SolidMotorState(simulation_states.MotorState):
             R=propellant_properties.R_chamber,
             flame_temperature=propellant_properties.adiabatic_flame_temperature,
             nozzle_discharge_coefficient=nozzle.discharge_coefficient,
-            free_chamber_volume_rate=burn_rate * burn_area,
+            free_chamber_volume_rate=free_chamber_volume_rate,
         )[0]
         self.chamber_pressure.append(chamber_pressure)
         exit_pressure = isentropic.get_exit_pressure(

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -69,6 +69,7 @@ class SolidMotorState(simulation_states.MotorState):
             self.motor.grain.get_propellant_volume(0.0)
         ]
         self.burn_rate: simulation_states.SimulationStateArray = [0.0]
+        self.free_chamber_volume_rate: simulation_states.SimulationStateArray = [0.0]
 
         initial_cog = motor.grain.get_center_of_gravity(
             web_distance=0.0,
@@ -127,6 +128,7 @@ class SolidMotorState(simulation_states.MotorState):
         free_chamber_volume = self.motor.get_free_chamber_volume(propellant_volume)
         self.free_chamber_volume.append(free_chamber_volume)
         free_chamber_volume_rate = burn_rate * burn_area
+        self.free_chamber_volume_rate.append(free_chamber_volume_rate)
         propellant_mass = self.motor.grain.get_propellant_mass(
             web_distance=web_distance, ideal_density=ideal_propellant_density
         )

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -69,7 +69,6 @@ class SolidMotorState(simulation_states.MotorState):
             self.motor.grain.get_propellant_volume(0.0)
         ]
         self.burn_rate: simulation_states.SimulationStateArray = [0.0]
-        self.free_chamber_volume_rate: simulation_states.SimulationStateArray = [0.0]
 
         initial_cog = motor.grain.get_center_of_gravity(
             web_distance=0.0,
@@ -128,7 +127,6 @@ class SolidMotorState(simulation_states.MotorState):
         free_chamber_volume = self.motor.get_free_chamber_volume(propellant_volume)
         self.free_chamber_volume.append(free_chamber_volume)
         free_chamber_volume_rate = burn_rate * burn_area
-        self.free_chamber_volume_rate.append(free_chamber_volume_rate)
         propellant_mass = self.motor.grain.get_propellant_mass(
             web_distance=web_distance, ideal_density=ideal_propellant_density
         )

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -151,7 +151,7 @@ class SolidMotorState(simulation_states.MotorState):
             k=propellant_properties.k_chamber,
             R=propellant_properties.R_chamber,
             flame_temperature=propellant_properties.adiabatic_flame_temperature,
-            discharge_coefficient=nozzle.discharge_coefficient,
+            nozzle_discharge_coefficient=nozzle.discharge_coefficient,
         )[0]
         self.chamber_pressure.append(chamber_pressure)
         exit_pressure = isentropic.get_exit_pressure(

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -152,6 +152,7 @@ class SolidMotorState(simulation_states.MotorState):
             R=propellant_properties.R_chamber,
             flame_temperature=propellant_properties.adiabatic_flame_temperature,
             nozzle_discharge_coefficient=nozzle.discharge_coefficient,
+            free_chamber_volume_rate=burn_rate * burn_area,
         )[0]
         self.chamber_pressure.append(chamber_pressure)
         exit_pressure = isentropic.get_exit_pressure(

--- a/tests/test_core/test_mass_balance.py
+++ b/tests/test_core/test_mass_balance.py
@@ -1,0 +1,103 @@
+import pytest
+
+import machwave.core.mass_balance as mass_balance
+
+
+BASE_KWARGS = {
+    "external_pressure": 101_325.0,
+    "free_chamber_volume": 1.0e-3,
+    "throat_area": 1.0e-4,
+    "k": 1.18,
+    "R": 320.0,
+    "flame_temperature": 2_800.0,
+    "nozzle_discharge_coefficient": 0.95,
+}
+
+
+@pytest.mark.parametrize(
+    "chamber_pressure, mass_flow_in",
+    [
+        (5.0e6, 0.5),  # choked
+        (
+            1.5e5,
+            0.05,
+        ),  # sub-critical: external_pressure/chamber_pressure above critical
+    ],
+)
+def test_zero_volume_rate_matches_rigid_form(chamber_pressure, mass_flow_in):
+    """With V_dot = 0 (default), output must equal the rigid-volume form."""
+    explicit = mass_balance.compute_chamber_pressure_mass_balance(
+        chamber_pressure=chamber_pressure,
+        mass_flow_in=mass_flow_in,
+        free_chamber_volume_rate=0.0,
+        **BASE_KWARGS,
+    )
+    default = mass_balance.compute_chamber_pressure_mass_balance(
+        chamber_pressure=chamber_pressure,
+        mass_flow_in=mass_flow_in,
+        **BASE_KWARGS,
+    )
+    assert explicit == default
+
+
+def test_balanced_mass_flow_isolates_volume_term():
+    """With m_dot_in = m_dot_out, dP/dt collapses to -P V_dot / V exactly."""
+    chamber_pressure = 4.0e6
+    (baseline,) = mass_balance.compute_chamber_pressure_mass_balance(
+        chamber_pressure=chamber_pressure,
+        mass_flow_in=0.0,
+        **BASE_KWARGS,
+    )
+    mass_flow_out = (
+        -baseline
+        * BASE_KWARGS["free_chamber_volume"]
+        / (BASE_KWARGS["R"] * BASE_KWARGS["flame_temperature"])
+    )
+
+    free_chamber_volume_rate = 2.5e-5
+    (derivative,) = mass_balance.compute_chamber_pressure_mass_balance(
+        chamber_pressure=chamber_pressure,
+        mass_flow_in=mass_flow_out,
+        free_chamber_volume_rate=free_chamber_volume_rate,
+        **BASE_KWARGS,
+    )
+
+    expected = (
+        -chamber_pressure
+        * free_chamber_volume_rate
+        / BASE_KWARGS["free_chamber_volume"]
+    )
+    assert derivative == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+@pytest.mark.parametrize(
+    "chamber_pressure, mass_flow_in, free_chamber_volume_rate",
+    [
+        (5.0e6, 0.5, 2.5e-5),
+        (5.0e6, 0.5, -1.0e-5),
+        (1.5e5, 0.05, 1.0e-6),
+    ],
+)
+def test_volume_term_is_linear_addition(
+    chamber_pressure, mass_flow_in, free_chamber_volume_rate
+):
+    """dP/dt(V_dot) = dP/dt(0) + (-P V_dot / V) to machine precision."""
+    (baseline,) = mass_balance.compute_chamber_pressure_mass_balance(
+        chamber_pressure=chamber_pressure,
+        mass_flow_in=mass_flow_in,
+        free_chamber_volume_rate=0.0,
+        **BASE_KWARGS,
+    )
+    (with_rate,) = mass_balance.compute_chamber_pressure_mass_balance(
+        chamber_pressure=chamber_pressure,
+        mass_flow_in=mass_flow_in,
+        free_chamber_volume_rate=free_chamber_volume_rate,
+        **BASE_KWARGS,
+    )
+    expected = (
+        baseline
+        - chamber_pressure
+        * free_chamber_volume_rate
+        / BASE_KWARGS["free_chamber_volume"]
+    )
+    assert with_rate == pytest.approx(expected, rel=1e-12, abs=1e-12)


### PR DESCRIPTION
Closes #235.

## Summary

- Adds optional `free_chamber_volume_rate: float = 0.0` to `compute_chamber_pressure_mass_balance`, extending the ODE to `dP/dt = (R·T/V)(ṁ_in − ṁ_out) − P·V̇/V`.
- Wires `SolidMotorState` to pass `burn_rate · burn_area` (port expansion as the burn progresses).
- Biliquid keeps the default `0.0` — the bipropellant chamber is rigid.
- Renames `discharge_coefficient` to `nozzle_discharge_coefficient` on the function signature (the injector also has discharge coefficients, so the unqualified name was ambiguous at call sites).
- Renames `H` to `isentropic_flow_function` (Vandenkerckhove form in the choked branch; general isentropic flow function in the sub-critical branch).

## Effect on solid simulations

Measured against the three configured BATES motors:

| Motor | Peak Pc Δ | Total impulse Δ |
|---|---|---|
| apcp_motor (4.5 s) | −0.50 % | −0.50 % |
| kappa_rnakka (1.4 s) | −1.13 % | −1.25 % |
| nero_motor (1.0 s) | −1.05 % | −1.07 % |

Direction is physical (port growth acts as an effective leak, lowering steady-state Pc) and roughly 10× larger than the issue's "~10⁻³" estimate, though still below other modeling uncertainties (c\* efficiency, two-phase loss).

## Tests

New `tests/test_core/test_mass_balance.py` covers:

- Zero volume rate matches the rigid-volume form exactly (choked and sub-critical regimes).
- Balanced mass flows with non-zero `V̇` collapse to `dP/dt = −P·V̇/V` to machine precision.
- The volume-rate term adds linearly to the baseline derivative.

## Test plan

- [x] `pytest tests/test_core/test_mass_balance.py` — 6 passed.
- [x] `pytest tests/test_simulations/test_solid_motor_simulation.py` — 15 passed (peak Pc, thrust, burn time all stay in physical-plausibility ranges with the term wired in).
- [x] Full `pytest` suite — 639 passed.