### PR TITLE
Align state and derived arrays in solid and biliquid simulations

### DIFF
--- a/machwave/models/grain/base.py
+++ b/machwave/models/grain/base.py
@@ -345,33 +345,6 @@ class Grain:
         else:
             raise TypeError("Argument is not a GrainSegment class instance")
 
-    def get_effective_density_ratio(self, *, web_distance: float) -> float:
-        r"""
-        Return an effective (burn-area weighted) density ratio.
-
-        Used for gas generation terms where $\dot{m} \propto A_b r \rho_p$.
-        """
-        burn_areas = np.asarray(
-            [seg.get_burn_area(web_distance) for seg in self.segments],
-            dtype=np.float64,
-        )
-        total_burn_area = float(np.sum(burn_areas))
-        if total_burn_area <= 0:
-            return 0.0
-
-        density_ratios = np.asarray(
-            [seg.density_ratio for seg in self.segments], dtype=np.float64
-        )
-        return float(np.sum(burn_areas * density_ratios) / total_burn_area)
-
-    def get_real_density(self, *, web_distance: float, ideal_density: float) -> float:
-        """Return grain effective real propellant density [kg/m^3]."""
-        if ideal_density <= 0:
-            raise ValueError(f"ideal_density must be > 0 (got {ideal_density})")
-        return ideal_density * self.get_effective_density_ratio(
-            web_distance=web_distance
-        )
-
     def get_propellant_mass(
         self, *, web_distance: float, ideal_density: float
     ) -> float:

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -48,14 +48,10 @@ class BiliquidEngineState(simulation_states.MotorState):
         self.fuel_mass: simulation_states.SimulationStateArray = [
             motor.feed_system.fuel_tank.fluid_mass
         ]
-        self.nozzle_correction_factor: simulation_states.SimulationStateArray = [1.0]
 
-        self.fuel_tank_pressure: simulation_states.SimulationStateArray = [
-            motor.feed_system.get_fuel_tank_pressure()
-        ]
-        self.oxidizer_tank_pressure: simulation_states.SimulationStateArray = [
-            motor.feed_system.get_oxidizer_tank_pressure()
-        ]
+        self.nozzle_correction_factor: simulation_states.SimulationStateArray = []
+        self.fuel_tank_pressure: simulation_states.SimulationStateArray = []
+        self.oxidizer_tank_pressure: simulation_states.SimulationStateArray = []
 
         self.propellant_properties = self._evaluate_propellant_properties(
             chamber_pressure=igniter_pressure,
@@ -94,69 +90,57 @@ class BiliquidEngineState(simulation_states.MotorState):
         injector = self.motor.thrust_chamber.injector
         feed_system = self.motor.feed_system
 
-        self.time.append(self.time[-1] + d_t)
+        time = self.time[-1]
+        chamber_pressure = self.chamber_pressure[-1]
+        fuel_mass = self.fuel_mass[-1]
+        oxidizer_mass = self.oxidizer_mass[-1]
 
-        if self.propellant_mass[-1] > 0:
+        propellant_mass = fuel_mass + oxidizer_mass
+        self.propellant_mass.append(propellant_mass)
+        self.fuel_tank_pressure.append(feed_system.get_fuel_tank_pressure())
+        self.oxidizer_tank_pressure.append(feed_system.get_oxidizer_tank_pressure())
+
+        if propellant_mass > 0:
             m_dot_fuel = feed_system.get_mass_flow_fuel(
-                chamber_pressure=self.chamber_pressure[-1],
+                chamber_pressure=chamber_pressure,
                 injector=injector,
             )
             m_dot_ox = feed_system.get_mass_flow_ox(
-                chamber_pressure=self.chamber_pressure[-1],
+                chamber_pressure=chamber_pressure,
                 injector=injector,
             )
         else:
             m_dot_fuel = m_dot_ox = 0.0
 
-        m_dot_fuel = min(m_dot_fuel, self.fuel_mass[-1] / d_t)
-        m_dot_ox = min(m_dot_ox, self.oxidizer_mass[-1] / d_t)
+        m_dot_fuel = min(m_dot_fuel, fuel_mass / d_t)
+        m_dot_ox = min(m_dot_ox, oxidizer_mass / d_t)
+        self._m_dot_fuel = m_dot_fuel
+        self._m_dot_ox = m_dot_ox
 
         oxidizer_to_fuel_ratio = self.motor.propellant.oxidizer_to_fuel_ratio
         assert oxidizer_to_fuel_ratio is not None
         fuel_consumed = m_dot_fuel * d_t
         oxidizer_consumed = m_dot_ox * d_t
-        if (
-            fuel_consumed >= self.fuel_mass[-1]
-            or oxidizer_consumed >= self.oxidizer_mass[-1]
-        ):
-            self.end_burn = True
-            self._burn_time = self.time[-1]
-        self._m_dot_fuel = m_dot_fuel
-        self._m_dot_ox = m_dot_ox
 
-        if self.propellant_mass[-1] > 0:
+        if propellant_mass > 0:
             if m_dot_fuel > 0.0:
                 instantaneous_oxidizer_to_fuel_ratio = m_dot_ox / m_dot_fuel
             else:
                 instantaneous_oxidizer_to_fuel_ratio = oxidizer_to_fuel_ratio
             self.propellant_properties = self._evaluate_propellant_properties(
-                chamber_pressure=self.chamber_pressure[-1],
+                chamber_pressure=chamber_pressure,
                 mixture_ratio=instantaneous_oxidizer_to_fuel_ratio,
             )
         propellant_properties = self.propellant_properties
 
-        new_chamber_pressure = rk4.rk4th_ode_solver(
-            variables={"chamber_pressure": self.chamber_pressure[-1]},
-            equation=mass_balance.compute_chamber_pressure_mass_balance,
-            d_t=d_t,
-            external_pressure=external_pressure,
-            mass_flow_in=self.get_m_dot_in(),
-            free_chamber_volume=self.motor.thrust_chamber.combustion_chamber.internal_volume,
-            throat_area=nozzle.get_throat_area(),
-            k=propellant_properties.k_chamber,
-            R=propellant_properties.R_chamber,
-            flame_temperature=propellant_properties.adiabatic_flame_temperature,
-            nozzle_discharge_coefficient=nozzle.discharge_coefficient,
-        )[0]
-        self.chamber_pressure.append(new_chamber_pressure)
         exit_pressure = isentropic.get_exit_pressure(
             propellant_properties.k_exhaust,
             nozzle.expansion_ratio,
-            new_chamber_pressure,
+            chamber_pressure,
         )
         self.exit_pressure.append(exit_pressure)
 
-        chamber_pressure_psi = conversions.convert_pa_to_psi(new_chamber_pressure)
+        chamber_pressure_psi = conversions.convert_pa_to_psi(chamber_pressure)
         divergent_loss = losses.get_nozzle_divergent_loss_fraction(
             divergent_angle=nozzle.divergent_angle,
         )
@@ -174,43 +158,58 @@ class BiliquidEngineState(simulation_states.MotorState):
         self.nozzle_correction_factor.append(nozzle_correction_factor)
 
         ideal_thrust_coefficient = nozzle_core.get_ideal_thrust_coefficient(
-            new_chamber_pressure,
+            chamber_pressure,
             exit_pressure,
             external_pressure,
             nozzle.expansion_ratio,
             propellant_properties.k_exhaust,
         )
+        self.ideal_thrust_coefficient.append(ideal_thrust_coefficient)
         thrust_coefficient = nozzle_core.apply_thrust_coefficient_correction(
             ideal_thrust_coefficient, nozzle_correction_factor
         )
         self.thrust_coefficient.append(thrust_coefficient)
-        self.ideal_thrust_coefficient.append(ideal_thrust_coefficient)
         self.thrust.append(
             nozzle_core.get_thrust_from_thrust_coefficient(
-                thrust_coefficient, new_chamber_pressure, nozzle.get_throat_area()
+                thrust_coefficient, chamber_pressure, nozzle.get_throat_area()
             )
         )
 
-        feed_system.fuel_tank.remove_propellant(fuel_consumed)
-        feed_system.oxidizer_tank.remove_propellant(oxidizer_consumed)
-        new_fuel = self.fuel_mass[-1] - fuel_consumed
-        new_ox = self.oxidizer_mass[-1] - oxidizer_consumed
-        self.fuel_mass.append(new_fuel)
-        self.oxidizer_mass.append(new_ox)
-        self.propellant_mass.append(new_fuel + new_ox)
-
-        self.fuel_tank_pressure.append(feed_system.get_fuel_tank_pressure())
-        self.oxidizer_tank_pressure.append(feed_system.get_oxidizer_tank_pressure())
-
-        if self.propellant_mass[-1] <= 0 and not self.end_burn:
+        new_time = time + d_t
+        if (
+            fuel_consumed >= fuel_mass or oxidizer_consumed >= oxidizer_mass
+        ) and not self.end_burn:
             self.end_burn = True
-            self._burn_time = self.time[-1]
+            self._burn_time = new_time
+
         if not isentropic.is_flow_choked(
-            new_chamber_pressure,
+            chamber_pressure,
             external_pressure,
             isentropic.get_critical_pressure_ratio(propellant_properties.k_chamber),
         ):
             if self._burn_time is None:
-                self._burn_time = self.time[-1]
-            self._thrust_time = self.time[-1]
+                self._burn_time = time
+            self._thrust_time = time
             self.end_thrust = True
+            return
+
+        feed_system.fuel_tank.remove_propellant(fuel_consumed)
+        feed_system.oxidizer_tank.remove_propellant(oxidizer_consumed)
+        self.fuel_mass.append(fuel_mass - fuel_consumed)
+        self.oxidizer_mass.append(oxidizer_mass - oxidizer_consumed)
+
+        new_chamber_pressure = rk4.rk4th_ode_solver(
+            variables={"chamber_pressure": chamber_pressure},
+            equation=mass_balance.compute_chamber_pressure_mass_balance,
+            d_t=d_t,
+            external_pressure=external_pressure,
+            mass_flow_in=self.get_m_dot_in(),
+            free_chamber_volume=self.motor.thrust_chamber.combustion_chamber.internal_volume,
+            throat_area=nozzle.get_throat_area(),
+            k=propellant_properties.k_chamber,
+            R=propellant_properties.R_chamber,
+            flame_temperature=propellant_properties.adiabatic_flame_temperature,
+            nozzle_discharge_coefficient=nozzle.discharge_coefficient,
+        )[0]
+        self.chamber_pressure.append(new_chamber_pressure)
+        self.time.append(new_time)

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -17,6 +17,7 @@ import machwave.simulation.states as simulation_states
 class SolidMotorState(simulation_states.MotorState):
     """State for a Solid Rocket Motor."""
 
+    motor: motors.SolidMotor
     result_class = solid_results.SolidSimulationResult
 
     def __init__(

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -55,46 +55,30 @@ class SolidMotorState(simulation_states.MotorState):
             other_losses=other_losses,
         )
 
-        self.motor: motors.SolidMotor = motor
         self.propellant_properties = propellant_properties
 
-        self.free_chamber_volume: simulation_states.SimulationStateArray = [
-            motor.thrust_chamber.combustion_chamber.internal_volume
-        ]
         self.web: simulation_states.SimulationStateArray = [0.0]
-        self.burn_area: simulation_states.SimulationStateArray = [
-            self.motor.grain.get_burn_area(0.0)
-        ]
-        self.propellant_volume: simulation_states.SimulationStateArray = [
-            self.motor.grain.get_propellant_volume(0.0)
-        ]
-        self.burn_rate: simulation_states.SimulationStateArray = [0.0]
-        self.free_chamber_volume_rate: simulation_states.SimulationStateArray = [0.0]
 
-        initial_cog = motor.grain.get_center_of_gravity(
-            web_distance=0.0,
-        )
-        initial_moi = motor.grain.get_moment_of_inertia(
-            ideal_density=motor.propellant.ideal_density,
-            web_distance=0.0,
-        )
-        self.propellant_cog: list[npt.NDArray[np.float64]] = [initial_cog]
-        self.propellant_moi: list[npt.NDArray[np.float64]] = [initial_moi]
+        self.burn_area: simulation_states.SimulationStateArray = []
+        self.propellant_volume: simulation_states.SimulationStateArray = []
+        self.burn_rate: simulation_states.SimulationStateArray = []
+        self.free_chamber_volume: simulation_states.SimulationStateArray = []
+        self.free_chamber_volume_rate: simulation_states.SimulationStateArray = []
+        self.grain_segment_mass_flow: list[npt.NDArray[np.float64]] = []
 
-        self.divergent_loss: simulation_states.SimulationStateArray = [0.0]
-        self.kinetics_loss: simulation_states.SimulationStateArray = [0.0]
-        self.boundary_layer_loss: simulation_states.SimulationStateArray = [0.0]
-        self.two_phase_loss: simulation_states.SimulationStateArray = [0.0]
-        self.nozzle_efficiency: simulation_states.SimulationStateArray = [0.0]
-        self.overall_efficiency: simulation_states.SimulationStateArray = [0.0]
+        self.propellant_cog: list[npt.NDArray[np.float64]] = []
+        self.propellant_moi: list[npt.NDArray[np.float64]] = []
+
+        self.divergent_loss: simulation_states.SimulationStateArray = []
+        self.kinetics_loss: simulation_states.SimulationStateArray = []
+        self.boundary_layer_loss: simulation_states.SimulationStateArray = []
+        self.two_phase_loss: simulation_states.SimulationStateArray = []
+        self.nozzle_efficiency: simulation_states.SimulationStateArray = []
+        self.overall_efficiency: simulation_states.SimulationStateArray = []
 
     def get_m_dot_in(self) -> float:
         """Return the propellant mass generation rate from the grain [kg/s]."""
-        propellant_density = self.motor.grain.get_real_density(
-            web_distance=self.web[-1],
-            ideal_density=self.motor.propellant.ideal_density,
-        )
-        return propellant_density * self.burn_rate[-1] * self.burn_area[-1]
+        return float(np.sum(self.grain_segment_mass_flow[-1]))
 
     def run_timestep(
         self,
@@ -112,18 +96,18 @@ class SolidMotorState(simulation_states.MotorState):
         nozzle = self.motor.thrust_chamber.nozzle
         ideal_propellant_density = self.motor.propellant.ideal_density
 
-        time = self.time[-1] + d_t
-        self.time.append(time)
-
+        time = self.time[-1]
         web_distance = self.web[-1]
+        chamber_pressure = self.chamber_pressure[-1]
+
         burn_area = self.motor.grain.get_burn_area(web_distance)
         self.burn_area.append(burn_area)
         propellant_volume = self.motor.grain.get_propellant_volume(web_distance)
         self.propellant_volume.append(propellant_volume)
-        burn_rate = self.motor.propellant.get_burn_rate(self.chamber_pressure[-1])
+
+        burn_rate = self.motor.propellant.get_burn_rate(chamber_pressure)
         self.burn_rate.append(burn_rate)
         web_consumed = burn_rate * d_t
-        self.web.append(web_distance + web_consumed)
 
         free_chamber_volume = self.motor.get_free_chamber_volume(propellant_volume)
         self.free_chamber_volume.append(free_chamber_volume)
@@ -143,21 +127,18 @@ class SolidMotorState(simulation_states.MotorState):
         )
         self.propellant_moi.append(propellant_moi)
 
-        chamber_pressure = rk4.rk4th_ode_solver(
-            variables={"chamber_pressure": self.chamber_pressure[-1]},
-            equation=mass_balance.compute_chamber_pressure_mass_balance,
-            d_t=d_t,
-            external_pressure=external_pressure,
-            mass_flow_in=self.get_m_dot_in(),
-            free_chamber_volume=free_chamber_volume,
-            throat_area=nozzle.get_throat_area(),
-            k=propellant_properties.k_chamber,
-            R=propellant_properties.R_chamber,
-            flame_temperature=propellant_properties.adiabatic_flame_temperature,
-            nozzle_discharge_coefficient=nozzle.discharge_coefficient,
-            free_chamber_volume_rate=free_chamber_volume_rate,
-        )[0]
-        self.chamber_pressure.append(chamber_pressure)
+        grain_segment_mass_flow = (
+            ideal_propellant_density
+            * burn_rate
+            * np.asarray(
+                [
+                    segment.get_burn_area(web_distance) * segment.density_ratio
+                    for segment in self.motor.grain.segments
+                ]
+            )
+        )
+        self.grain_segment_mass_flow.append(grain_segment_mass_flow)
+
         exit_pressure = isentropic.get_exit_pressure(
             propellant_properties.k_exhaust,
             nozzle.expansion_ratio,
@@ -230,6 +211,7 @@ class SolidMotorState(simulation_states.MotorState):
         if propellant_mass <= 0 and not self.end_burn:
             self._burn_time = time
             self.end_burn = True
+
         if not isentropic.is_flow_choked(
             chamber_pressure,
             external_pressure,
@@ -239,3 +221,24 @@ class SolidMotorState(simulation_states.MotorState):
                 self._burn_time = time
             self._thrust_time = time
             self.end_thrust = True
+            return
+
+        new_time = time + d_t
+        self.time.append(new_time)
+        new_web_distance = web_distance + web_consumed
+        self.web.append(new_web_distance)
+        new_chamber_pressure = rk4.rk4th_ode_solver(
+            variables={"chamber_pressure": self.chamber_pressure[-1]},
+            equation=mass_balance.compute_chamber_pressure_mass_balance,
+            d_t=d_t,
+            external_pressure=external_pressure,
+            mass_flow_in=self.get_m_dot_in(),
+            free_chamber_volume=free_chamber_volume,
+            throat_area=nozzle.get_throat_area(),
+            k=propellant_properties.k_chamber,
+            R=propellant_properties.R_chamber,
+            flame_temperature=propellant_properties.adiabatic_flame_temperature,
+            nozzle_discharge_coefficient=nozzle.discharge_coefficient,
+            free_chamber_volume_rate=free_chamber_volume_rate,
+        )[0]
+        self.chamber_pressure.append(new_chamber_pressure)

--- a/machwave/simulation/states.py
+++ b/machwave/simulation/states.py
@@ -34,17 +34,17 @@ class MotorState(ABC):
                 mechanisms, in [0, 1].
         """
         self.motor = motor
+        self.external_pressure = external_pressure
         self.other_losses = other_losses
 
         self.time: SimulationStateArray = [0.0]
-
-        self.propellant_mass: SimulationStateArray = [motor.initial_propellant_mass]
         self.chamber_pressure: SimulationStateArray = [igniter_pressure]
-        self.exit_pressure: SimulationStateArray = [external_pressure]
 
-        self.thrust_coefficient: SimulationStateArray = [0.0]
-        self.ideal_thrust_coefficient: SimulationStateArray = [0.0]
-        self.thrust: SimulationStateArray = [0.0]
+        self.propellant_mass: SimulationStateArray = []
+        self.exit_pressure: SimulationStateArray = []
+        self.ideal_thrust_coefficient: SimulationStateArray = []
+        self.thrust_coefficient: SimulationStateArray = []
+        self.thrust: SimulationStateArray = []
 
         self._thrust_time: float | None = None
         self._burn_time: float | None = None


### PR DESCRIPTION
## Summary
- Restructure `run_timestep` in both [solid](machwave/simulation/solid/states.py) and [biliquid](machwave/simulation/biliquid/states.py) to compute derived quantities from start-of-step state first, then advance state. An early `return` after `end_thrust = True` skips the final step's state advancement so every per-timestep array ends at length `N`.
- Move `propellant_mass`, `exit_pressure`, `ideal_thrust_coefficient`, `thrust_coefficient`, `thrust` to the derived side in the parent [`MotorState`](machwave/simulation/states.py) (`[]` in `__init__`). Move simulation-specific derived arrays (`free_chamber_volume`, `burn_area`, `burn_rate`, losses, etc. for solid; `nozzle_correction_factor`, `fuel_tank_pressure`, `oxidizer_tank_pressure` for biliquid) to the same pattern.
- Add `grain_segment_mass_flow` derived array in solid (per-segment mass generation rate); simplify `get_m_dot_in` to `np.sum(self.grain_segment_mass_flow[-1])`. Delete now-unused `Grain.get_real_density` and `Grain.get_effective_density_ratio`.

Closes #314.

## Test plan
- [x] `pytest tests/test_simulations/test_solid_motor_simulation.py` — 15 passed
- [x] `pytest tests/test_simulations/test_biliquid_engine_simulation.py` — 9 passed
- [x] `pytest` full suite — 639 passed, 2 skipped