### PR TITLE
Add per-segment variants to Grain aggregation methods (#313)

### DIFF
--- a/machwave/models/grain/base.py
+++ b/machwave/models/grain/base.py
@@ -345,20 +345,37 @@ class Grain:
         else:
             raise TypeError("Argument is not a GrainSegment class instance")
 
+    def get_propellant_mass_per_segment(
+        self, *, web_distance: float, ideal_density: float
+    ) -> np.typing.NDArray[np.float64]:
+        """
+        Return per-segment propellant mass at a given web distance.
+
+        Args:
+            web_distance: Web distance traveled [m].
+            ideal_density: Propellant ideal density [kg/m^3].
+
+        Returns:
+            Per-segment mass array of shape `(segment_count,)` [kg].
+        """
+        if ideal_density <= 0:
+            raise ValueError(f"ideal_density must be > 0 (got {ideal_density})")
+
+        volumes = self.get_propellant_volume_per_segment(web_distance)
+        density_ratios = self.get_density_ratio_per_segment()
+        return volumes * density_ratios * ideal_density
+
     def get_propellant_mass(
         self, *, web_distance: float, ideal_density: float
     ) -> float:
         """Return remaining propellant mass [kg] at a given web distance."""
-        if ideal_density <= 0:
-            raise ValueError(f"ideal_density must be > 0 (got {ideal_density})")
-
-        volumes = np.asarray(
-            [seg.get_volume(web_distance) for seg in self.segments], dtype=np.float64
+        return float(
+            np.sum(
+                self.get_propellant_mass_per_segment(
+                    web_distance=web_distance, ideal_density=ideal_density
+                )
+            )
         )
-        density_ratios = np.asarray(
-            [seg.density_ratio for seg in self.segments], dtype=np.float64
-        )
-        return float(np.sum(volumes * density_ratios) * ideal_density)
 
     @property
     def total_length(self) -> float:
@@ -423,12 +440,8 @@ class Grain:
         total_weighted_cogs = np.stack(weighted_cogs, axis=0).sum(
             axis=0, dtype=np.float64
         )
-        volumes = np.asarray(
-            [seg.get_volume(web_distance) for seg in self.segments], dtype=np.float64
-        )
-        density_ratios = np.asarray(
-            [seg.density_ratio for seg in self.segments], dtype=np.float64
-        )
+        volumes = self.get_propellant_volume_per_segment(web_distance)
+        density_ratios = self.get_density_ratio_per_segment()
         total_mass_normalized = float(np.sum(volumes * density_ratios))
 
         return (total_weighted_cogs / total_mass_normalized).astype(np.float64)
@@ -497,6 +510,35 @@ class Grain:
 
         return total_inertia.astype(np.float64)
 
+    def get_density_ratio_per_segment(self) -> np.typing.NDArray[np.float64]:
+        """
+        Return per-segment density ratios.
+
+        Returns:
+            Per-segment density-ratio array of shape `(segment_count,)`.
+        """
+        return np.asarray(
+            [segment.density_ratio for segment in self.segments],
+            dtype=np.float64,
+        )
+
+    def get_burn_area_per_segment(
+        self, web_distance: float
+    ) -> np.typing.NDArray[np.float64]:
+        """
+        Return per-segment burn area at a given web distance.
+
+        Args:
+            web_distance: Web distance traveled [m].
+
+        Returns:
+            Per-segment burn area array of shape `(segment_count,)` [m^2].
+        """
+        return np.asarray(
+            [segment.get_burn_area(web_distance) for segment in self.segments],
+            dtype=np.float64,
+        )
+
     def get_burn_area(self, web_distance: float) -> float:
         """
         Return the grain burn area at a given web distance.
@@ -507,8 +549,23 @@ class Grain:
         Returns:
             Total burn area summed across all segments [m^2].
         """
-        return np.sum(
-            [segment.get_burn_area(web_distance) for segment in self.segments]
+        return float(np.sum(self.get_burn_area_per_segment(web_distance)))
+
+    def get_propellant_volume_per_segment(
+        self, web_distance: float
+    ) -> np.typing.NDArray[np.float64]:
+        """
+        Return per-segment propellant volume at a given web distance.
+
+        Args:
+            web_distance: Web distance traveled [m].
+
+        Returns:
+            Per-segment volume array of shape `(segment_count,)` [m^3].
+        """
+        return np.asarray(
+            [segment.get_volume(web_distance) for segment in self.segments],
+            dtype=np.float64,
         )
 
     def get_propellant_volume(self, web_distance: float) -> float:
@@ -521,7 +578,7 @@ class Grain:
         Returns:
             Total propellant volume summed across all segments [m^3].
         """
-        return np.sum([segment.get_volume(web_distance) for segment in self.segments])
+        return float(np.sum(self.get_propellant_volume_per_segment(web_distance)))
 
     def get_mass_flux_per_segment(
         self,

--- a/machwave/simulation/solid/results.py
+++ b/machwave/simulation/solid/results.py
@@ -23,6 +23,9 @@ class SolidSimulationResult(
     web: simulation_results.SimulationResultArray
     burn_area: simulation_results.SimulationResultArray
     propellant_volume: simulation_results.SimulationResultArray
+    burn_area_per_segment: simulation_results.SimulationResultArray
+    propellant_volume_per_segment: simulation_results.SimulationResultArray
+    propellant_mass_per_segment: simulation_results.SimulationResultArray
     burn_rate: simulation_results.SimulationResultArray
     divergent_loss: simulation_results.SimulationResultArray
     kinetics_loss: simulation_results.SimulationResultArray
@@ -69,6 +72,11 @@ class SolidSimulationResult(
             "web": web,
             "burn_area": burn_area,
             "propellant_volume": propellant_volume,
+            "burn_area_per_segment": np.stack(state.burn_area_per_segment),
+            "propellant_volume_per_segment": np.stack(
+                state.propellant_volume_per_segment
+            ),
+            "propellant_mass_per_segment": np.stack(state.propellant_mass_per_segment),
             "burn_rate": burn_rate,
             "divergent_loss": np.asarray(state.divergent_loss),
             "kinetics_loss": np.asarray(state.kinetics_loss),
@@ -150,6 +158,15 @@ class SolidSimulationResult(
                 f" Propellant initial mass {self.propellant_mass[0] * 1e3:.3f} g",
                 file=file,
             )
+        print(
+            f" Initial propellant volume: {self.propellant_volume[0] * 1e6:.3f} cm^3",
+            file=file,
+        )
+        print(f" Initial burn area: {self.burn_area[0] * 1e4:.3f} cm^2", file=file)
+        print(
+            f" Peak burn area: {float(np.max(self.burn_area)) * 1e4:.3f} cm^2",
+            file=file,
+        )
         print(" Mean Kn: %.2f" % np.mean(self.klemmung), file=file)
         print(" Max Kn: %.2f" % np.max(self.klemmung), file=file)
         print(

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -57,11 +57,15 @@ class SolidMotorState(simulation_states.MotorState):
         )
 
         self.propellant_properties = propellant_properties
+        self.segment_density_ratios = motor.grain.get_density_ratio_per_segment()
 
         self.web: simulation_states.SimulationStateArray = [0.0]
 
         self.burn_area: simulation_states.SimulationStateArray = []
         self.propellant_volume: simulation_states.SimulationStateArray = []
+        self.burn_area_per_segment: list[npt.NDArray[np.float64]] = []
+        self.propellant_volume_per_segment: list[npt.NDArray[np.float64]] = []
+        self.propellant_mass_per_segment: list[npt.NDArray[np.float64]] = []
         self.burn_rate: simulation_states.SimulationStateArray = []
         self.free_chamber_volume: simulation_states.SimulationStateArray = []
         self.free_chamber_volume_rate: simulation_states.SimulationStateArray = []
@@ -101,9 +105,16 @@ class SolidMotorState(simulation_states.MotorState):
         web_distance = self.web[-1]
         chamber_pressure = self.chamber_pressure[-1]
 
-        burn_area = self.motor.grain.get_burn_area(web_distance)
+        burn_area_per_segment = self.motor.grain.get_burn_area_per_segment(web_distance)
+        self.burn_area_per_segment.append(burn_area_per_segment)
+        burn_area = float(np.sum(burn_area_per_segment))
         self.burn_area.append(burn_area)
-        propellant_volume = self.motor.grain.get_propellant_volume(web_distance)
+
+        propellant_volume_per_segment = (
+            self.motor.grain.get_propellant_volume_per_segment(web_distance)
+        )
+        self.propellant_volume_per_segment.append(propellant_volume_per_segment)
+        propellant_volume = float(np.sum(propellant_volume_per_segment))
         self.propellant_volume.append(propellant_volume)
 
         burn_rate = self.motor.propellant.get_burn_rate(chamber_pressure)
@@ -114,9 +125,13 @@ class SolidMotorState(simulation_states.MotorState):
         self.free_chamber_volume.append(free_chamber_volume)
         free_chamber_volume_rate = burn_rate * burn_area
         self.free_chamber_volume_rate.append(free_chamber_volume_rate)
-        propellant_mass = self.motor.grain.get_propellant_mass(
-            web_distance=web_distance, ideal_density=ideal_propellant_density
+        propellant_mass_per_segment = (
+            propellant_volume_per_segment
+            * self.segment_density_ratios
+            * ideal_propellant_density
         )
+        self.propellant_mass_per_segment.append(propellant_mass_per_segment)
+        propellant_mass = float(np.sum(propellant_mass_per_segment))
         self.propellant_mass.append(propellant_mass)
 
         propellant_cog = self.motor.grain.get_center_of_gravity(
@@ -131,12 +146,8 @@ class SolidMotorState(simulation_states.MotorState):
         grain_segment_mass_flow = (
             ideal_propellant_density
             * burn_rate
-            * np.asarray(
-                [
-                    segment.get_burn_area(web_distance) * segment.density_ratio
-                    for segment in self.motor.grain.segments
-                ]
-            )
+            * burn_area_per_segment
+            * self.segment_density_ratios
         )
         self.grain_segment_mass_flow.append(grain_segment_mass_flow)
 

--- a/tests/test_models/test_propulsion/test_grain/test_per_segment_aggregators.py
+++ b/tests/test_models/test_propulsion/test_grain/test_per_segment_aggregators.py
@@ -1,0 +1,130 @@
+"""Tests for Grain per-segment aggregation methods."""
+
+import numpy as np
+import pytest
+
+import machwave.models.grain as grain_models
+
+from tests.factories import BatesSegmentFactory
+
+
+@pytest.fixture
+def mixed_grain():
+    grain = grain_models.Grain(spacing=0.0)
+    grain.add_segment(
+        BatesSegmentFactory.build(
+            outer_diameter=0.10,
+            core_diameter=0.04,
+            length=0.20,
+            density_ratio=1.0,
+        )
+    )
+    grain.add_segment(
+        BatesSegmentFactory.build(
+            outer_diameter=0.10,
+            core_diameter=0.05,
+            length=0.18,
+            density_ratio=0.95,
+        )
+    )
+    grain.add_segment(
+        BatesSegmentFactory.build(
+            outer_diameter=0.10,
+            core_diameter=0.06,
+            length=0.16,
+            density_ratio=0.90,
+        )
+    )
+    return grain
+
+
+class TestDensityRatioPerSegment:
+    def test_returns_density_ratios_in_segment_order(self, mixed_grain):
+        ratios = mixed_grain.get_density_ratio_per_segment()
+        assert ratios.shape == (mixed_grain.segment_count,)
+        assert ratios.dtype == np.float64
+        np.testing.assert_allclose(ratios, [1.0, 0.95, 0.90])
+
+
+class TestBurnAreaPerSegment:
+    def test_shape(self, mixed_grain):
+        burn_area = mixed_grain.get_burn_area_per_segment(web_distance=0.0)
+        assert burn_area.shape == (mixed_grain.segment_count,)
+        assert burn_area.dtype == np.float64
+
+    def test_matches_segment_values(self, mixed_grain):
+        web = 0.005
+        per_segment = mixed_grain.get_burn_area_per_segment(web_distance=web)
+        expected = np.asarray([seg.get_burn_area(web) for seg in mixed_grain.segments])
+        np.testing.assert_allclose(per_segment, expected)
+
+    def test_sum_matches_aggregator(self, mixed_grain):
+        web = 0.003
+        total = mixed_grain.get_burn_area(web)
+        per_segment_sum = float(np.sum(mixed_grain.get_burn_area_per_segment(web)))
+        assert total == pytest.approx(per_segment_sum)
+
+
+class TestPropellantVolumePerSegment:
+    def test_shape(self, mixed_grain):
+        volume = mixed_grain.get_propellant_volume_per_segment(web_distance=0.0)
+        assert volume.shape == (mixed_grain.segment_count,)
+        assert volume.dtype == np.float64
+
+    def test_matches_segment_values(self, mixed_grain):
+        web = 0.002
+        per_segment = mixed_grain.get_propellant_volume_per_segment(web_distance=web)
+        expected = np.asarray([seg.get_volume(web) for seg in mixed_grain.segments])
+        np.testing.assert_allclose(per_segment, expected)
+
+    def test_sum_matches_aggregator(self, mixed_grain):
+        web = 0.004
+        total = mixed_grain.get_propellant_volume(web)
+        per_segment_sum = float(
+            np.sum(mixed_grain.get_propellant_volume_per_segment(web))
+        )
+        assert total == pytest.approx(per_segment_sum)
+
+
+class TestPropellantMassPerSegment:
+    def test_shape(self, mixed_grain):
+        mass = mixed_grain.get_propellant_mass_per_segment(
+            web_distance=0.0, ideal_density=1800.0
+        )
+        assert mass.shape == (mixed_grain.segment_count,)
+        assert mass.dtype == np.float64
+
+    def test_applies_density_ratio_and_density(self, mixed_grain):
+        web = 0.001
+        ideal_density = 1750.0
+        per_segment = mixed_grain.get_propellant_mass_per_segment(
+            web_distance=web, ideal_density=ideal_density
+        )
+        expected = np.asarray(
+            [
+                seg.get_mass(web_distance=web, ideal_density=ideal_density)
+                for seg in mixed_grain.segments
+            ]
+        )
+        np.testing.assert_allclose(per_segment, expected)
+
+    def test_sum_matches_aggregator(self, mixed_grain):
+        web = 0.005
+        ideal_density = 1800.0
+        total = mixed_grain.get_propellant_mass(
+            web_distance=web, ideal_density=ideal_density
+        )
+        per_segment_sum = float(
+            np.sum(
+                mixed_grain.get_propellant_mass_per_segment(
+                    web_distance=web, ideal_density=ideal_density
+                )
+            )
+        )
+        assert total == pytest.approx(per_segment_sum)
+
+    def test_rejects_non_positive_density(self, mixed_grain):
+        with pytest.raises(ValueError, match="ideal_density must be > 0"):
+            mixed_grain.get_propellant_mass_per_segment(
+                web_distance=0.0, ideal_density=0.0
+            )


### PR DESCRIPTION
Closes #313.

## Summary
- Surface per-segment data on `Grain`: `get_density_ratio_per_segment`, `get_burn_area_per_segment`, `get_propellant_volume_per_segment`, `get_propellant_mass_per_segment`. Existing aggregators (`get_burn_area`, `get_propellant_volume`, `get_propellant_mass`) reduced to one-line `float(np.sum(...))` delegates. `Grain.get_center_of_gravity` now reuses the new helpers.
- `SolidMotorState` caches `segment_density_ratios` once and stores per-segment arrays (`burn_area_per_segment`, `propellant_volume_per_segment`, `propellant_mass_per_segment`) alongside the scalar aggregates. `grain_segment_mass_flow` is now a single elementwise expression rather than an inline per-segment loop.
- `SolidSimulationResult` exposes the three new per-segment arrays (shape `[time_count, segment_count]`); `_report_body` prints initial propellant volume and initial/peak burn area.
- New unit tests in `tests/test_models/test_propulsion/test_grain/test_per_segment_aggregators.py` cover shape, per-segment-value parity, sum-equals-aggregator parity, and the `ideal_density > 0` guard.

## Test plan
- [x] `make check`
- [x] `pytest tests/test_models/test_propulsion/test_grain`
- [x] `pytest tests/test_simulations`