### PR TITLE
Align BiliquidEngineState.run_timestep with SolidMotorState

### DIFF
--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -49,18 +49,16 @@ class BiliquidEngineState(simulation_states.MotorState):
             motor.feed_system.fuel_tank.fluid_mass
         ]
 
-        self.nozzle_correction_factor: simulation_states.SimulationStateArray = []
+        self.fuel_mass_flow_rate: simulation_states.SimulationStateArray = []
+        self.oxidizer_mass_flow_rate: simulation_states.SimulationStateArray = []
+        self.oxidizer_to_fuel_ratio: simulation_states.SimulationStateArray = []
         self.fuel_tank_pressure: simulation_states.SimulationStateArray = []
         self.oxidizer_tank_pressure: simulation_states.SimulationStateArray = []
-
-        self.propellant_properties = self._evaluate_propellant_properties(
-            chamber_pressure=igniter_pressure,
-            mixture_ratio=motor.propellant.oxidizer_to_fuel_ratio,
-        )
+        self.nozzle_correction_factor: simulation_states.SimulationStateArray = []
 
     def get_m_dot_in(self) -> float:
         """Return the total inlet mass flow (fuel + oxidizer) [kg/s]."""
-        return self._m_dot_fuel + self._m_dot_ox
+        return self.fuel_mass_flow_rate[-1] + self.oxidizer_mass_flow_rate[-1]
 
     def _evaluate_propellant_properties(
         self,
@@ -114,24 +112,23 @@ class BiliquidEngineState(simulation_states.MotorState):
 
         m_dot_fuel = min(m_dot_fuel, fuel_mass / d_t)
         m_dot_ox = min(m_dot_ox, oxidizer_mass / d_t)
-        self._m_dot_fuel = m_dot_fuel
-        self._m_dot_ox = m_dot_ox
-
-        oxidizer_to_fuel_ratio = self.motor.propellant.oxidizer_to_fuel_ratio
-        assert oxidizer_to_fuel_ratio is not None
+        self.fuel_mass_flow_rate.append(m_dot_fuel)
+        self.oxidizer_mass_flow_rate.append(m_dot_ox)
         fuel_consumed = m_dot_fuel * d_t
         oxidizer_consumed = m_dot_ox * d_t
 
-        if propellant_mass > 0:
-            if m_dot_fuel > 0.0:
-                instantaneous_oxidizer_to_fuel_ratio = m_dot_ox / m_dot_fuel
-            else:
-                instantaneous_oxidizer_to_fuel_ratio = oxidizer_to_fuel_ratio
-            self.propellant_properties = self._evaluate_propellant_properties(
-                chamber_pressure=chamber_pressure,
-                mixture_ratio=instantaneous_oxidizer_to_fuel_ratio,
-            )
-        propellant_properties = self.propellant_properties
+        if m_dot_fuel > 0.0:
+            oxidizer_to_fuel_ratio = m_dot_ox / m_dot_fuel
+        else:
+            design_ratio = self.motor.propellant.oxidizer_to_fuel_ratio
+            assert design_ratio is not None
+            oxidizer_to_fuel_ratio = design_ratio
+        self.oxidizer_to_fuel_ratio.append(oxidizer_to_fuel_ratio)
+
+        propellant_properties = self._evaluate_propellant_properties(
+            chamber_pressure=chamber_pressure,
+            mixture_ratio=oxidizer_to_fuel_ratio,
+        )
 
         exit_pressure = isentropic.get_exit_pressure(
             propellant_properties.k_exhaust,
@@ -169,18 +166,16 @@ class BiliquidEngineState(simulation_states.MotorState):
             ideal_thrust_coefficient, nozzle_correction_factor
         )
         self.thrust_coefficient.append(thrust_coefficient)
-        self.thrust.append(
-            nozzle_core.get_thrust_from_thrust_coefficient(
-                thrust_coefficient, chamber_pressure, nozzle.get_throat_area()
-            )
+        thrust = nozzle_core.get_thrust_from_thrust_coefficient(
+            thrust_coefficient, chamber_pressure, nozzle.get_throat_area()
         )
+        self.thrust.append(thrust)
 
-        new_time = time + d_t
         if (
             fuel_consumed >= fuel_mass or oxidizer_consumed >= oxidizer_mass
         ) and not self.end_burn:
             self.end_burn = True
-            self._burn_time = new_time
+            self._burn_time = time + d_t
 
         if not isentropic.is_flow_choked(
             chamber_pressure,
@@ -193,11 +188,12 @@ class BiliquidEngineState(simulation_states.MotorState):
             self.end_thrust = True
             return
 
+        new_time = time + d_t
+        self.time.append(new_time)
         feed_system.fuel_tank.remove_propellant(fuel_consumed)
         feed_system.oxidizer_tank.remove_propellant(oxidizer_consumed)
         self.fuel_mass.append(fuel_mass - fuel_consumed)
         self.oxidizer_mass.append(oxidizer_mass - oxidizer_consumed)
-
         new_chamber_pressure = rk4.rk4th_ode_solver(
             variables={"chamber_pressure": chamber_pressure},
             equation=mass_balance.compute_chamber_pressure_mass_balance,
@@ -210,6 +206,6 @@ class BiliquidEngineState(simulation_states.MotorState):
             R=propellant_properties.R_chamber,
             flame_temperature=propellant_properties.adiabatic_flame_temperature,
             nozzle_discharge_coefficient=nozzle.discharge_coefficient,
+            free_chamber_volume_rate=0.0,
         )[0]
         self.chamber_pressure.append(new_chamber_pressure)
-        self.time.append(new_time)

--- a/tests/test_simulations/test_biliquid_engine_simulation.py
+++ b/tests/test_simulations/test_biliquid_engine_simulation.py
@@ -14,7 +14,6 @@ import numpy as np
 import pytest
 
 import machwave.models.motors as motors_models
-import machwave.models.propellants.properties as propellant_properties
 import machwave.simulation.biliquid as biliquid_simulation
 from tests.test_simulations import motor_builders
 from tests.test_simulations.conftest import (
@@ -133,34 +132,34 @@ def test_live_mixture_ratio_drives_cea() -> None:
     design_ratio = motor.propellant.oxidizer_to_fuel_ratio
     assert design_ratio is not None
 
-    deviation_sample: (
-        tuple[propellant_properties.ThermochemicalProperties, float] | None
-    ) = None
+    deviation_sample: tuple[float, float] | None = None
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
         while not state.end_thrust:
             state.run_timestep(params.d_t, params.external_pressure)
-            if state._m_dot_fuel <= 0.0:
+            if state.fuel_mass_flow_rate[-1] <= 0.0:
                 continue
-            live_ratio = state._m_dot_ox / state._m_dot_fuel
+            live_ratio = state.oxidizer_to_fuel_ratio[-1]
             if abs(live_ratio - design_ratio) > 1e-6:
-                deviation_sample = (
-                    state.propellant_properties,
-                    state.chamber_pressure[-1],
-                )
+                deviation_sample = (live_ratio, state.chamber_pressure[-1])
 
     assert deviation_sample is not None, (
         "Live oxidizer/fuel mass flow ratio never deviated from the design ratio"
     )
-    live_properties, live_chamber_pressure = deviation_sample
+    live_ratio, live_chamber_pressure = deviation_sample
 
+    live_props = motor.propellant.evaluate(
+        chamber_pressure=live_chamber_pressure,
+        expansion_ratio=motor.thrust_chamber.nozzle.expansion_ratio,
+        mixture_ratio=live_ratio,
+    )
     design_props = motor.propellant.evaluate(
         chamber_pressure=live_chamber_pressure,
         expansion_ratio=motor.thrust_chamber.nozzle.expansion_ratio,
         mixture_ratio=design_ratio,
     )
     assert (
-        live_properties.adiabatic_flame_temperature
+        live_props.adiabatic_flame_temperature
         != design_props.adiabatic_flame_temperature
     )
 


### PR DESCRIPTION
Closes #317. Follow-up to #315 and #309.

## Summary
- Only append advance-state arrays (`time`, `fuel_mass`, `oxidizer_mass`, `chamber_pressure`) past the choked-flow early return, matching `SolidMotorState`.
- Pass `free_chamber_volume_rate=0.0` explicitly to `compute_chamber_pressure_mass_balance` for call-site symmetry with the solid version.
- Expose per-step `fuel_mass_flow_rate`, `oxidizer_mass_flow_rate`, and `oxidizer_to_fuel_ratio` as public `SimulationStateArray`s; drop the `_m_dot_fuel` / `_m_dot_ox` private stashes and the cached `propellant_properties` attribute. `get_m_dot_in()` now reads from `fuel_mass_flow_rate[-1] + oxidizer_mass_flow_rate[-1]`, mirroring solid's `grain_segment_mass_flow[-1]` access pattern.
- Replace the fragile `m_dot_ox / m_dot_fuel` ratio computation with a single `if m_dot_fuel > 0.0` guard (fall back to the design ratio otherwise), preventing divide-by-zero and unbound-variable paths.
- Update `test_live_mixture_ratio_drives_cea` to read live ratios from the new public arrays and recompute live propellant properties inside the test.

End-burn detection is left as "either tank depleted" (biliquid-specific), only the time recorded for `_burn_time` is inlined as `time + d_t` to avoid computing `new_time` before the early-return guard.

## Test plan
- [x] `make check`
- [x] `make test` (650 passed, 2 skipped)