### PR TITLE
Make Tank stateless and let the simulation own the propellant mass (#321)

### DIFF
--- a/machwave/models/feed_systems/base.py
+++ b/machwave/models/feed_systems/base.py
@@ -18,9 +18,9 @@ class FeedSystem(ABC):
         self.fuel_tank = fuel_tank
         self.oxidizer_tank = oxidizer_tank
 
-    def get_propellant_mass(self) -> float:
+    def get_initial_propellant_mass(self) -> float:
         """Compute and return the initial propellant mass in the system [kg]."""
-        return self.fuel_tank.fluid_mass + self.oxidizer_tank.fluid_mass
+        return self.fuel_tank.initial_fluid_mass + self.oxidizer_tank.initial_fluid_mass
 
     @abstractmethod
     def get_mass_flow_ox(
@@ -28,6 +28,7 @@ class FeedSystem(ABC):
         chamber_pressure: float,
         *,
         injector: injector_models.BipropellantInjector,
+        oxidizer_mass: float,
     ) -> float:
         """
         Compute and return the current oxidizer mass flow rate [kg/s].
@@ -35,6 +36,7 @@ class FeedSystem(ABC):
         Args:
             chamber_pressure: Chamber pressure [Pa].
             injector: Bipropellant injector handling the orifice dispatch.
+            oxidizer_mass: Current oxidizer mass in the tank [kg].
 
         Returns:
             Oxidizer mass flow rate [kg/s].
@@ -47,6 +49,8 @@ class FeedSystem(ABC):
         chamber_pressure: float,
         *,
         injector: injector_models.BipropellantInjector,
+        fuel_mass: float,
+        oxidizer_mass: float,
     ) -> float:
         """
         Compute and return the current fuel mass flow rate [kg/s].
@@ -54,6 +58,9 @@ class FeedSystem(ABC):
         Args:
             chamber_pressure: Chamber pressure [Pa].
             injector: Bipropellant injector handling the orifice dispatch.
+            fuel_mass: Current fuel mass in the tank [kg].
+            oxidizer_mass: Current oxidizer mass in the tank [kg]. Needed because
+                some feed systems pressurize the fuel from the oxidizer side.
 
         Returns:
             Fuel mass flow rate [kg/s].
@@ -61,11 +68,24 @@ class FeedSystem(ABC):
         pass
 
     @abstractmethod
-    def get_oxidizer_tank_pressure(self) -> float:
-        """Compute and return the current oxidizer tank pressure [Pa]."""
+    def get_oxidizer_tank_pressure(self, *, oxidizer_mass: float) -> float:
+        """
+        Compute and return the current oxidizer tank pressure [Pa].
+
+        Args:
+            oxidizer_mass: Current oxidizer mass in the tank [kg].
+        """
         pass
 
     @abstractmethod
-    def get_fuel_tank_pressure(self) -> float:
-        """Compute and return the current fuel tank pressure [Pa]."""
+    def get_fuel_tank_pressure(
+        self, *, oxidizer_mass: float, fuel_mass: float
+    ) -> float:
+        """
+        Compute and return the current fuel-side upstream pressure [Pa].
+
+        Args:
+            oxidizer_mass: Current oxidizer mass in the tank [kg].
+            fuel_mass: Current fuel mass in the tank [kg].
+        """
         pass

--- a/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
+++ b/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
@@ -51,6 +51,7 @@ class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
         chamber_pressure: float,
         *,
         injector: injector_models.BipropellantInjector,
+        oxidizer_mass: float,
     ) -> float:
         """
         Compute the current oxidizer mass flow rate by delegating to the injector.
@@ -58,14 +59,18 @@ class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
         Args:
             chamber_pressure: Chamber pressure [Pa].
             injector: Bipropellant injector handling the orifice dispatch.
+            oxidizer_mass: Current oxidizer mass in the tank [kg].
 
         Returns:
             Oxidizer mass flow rate [kg/s].
         """
         return injector.get_mass_flow_ox(
             tank=self.oxidizer_tank,
-            pressure_upstream=self.get_oxidizer_tank_pressure(),
+            pressure_upstream=self.get_oxidizer_tank_pressure(
+                oxidizer_mass=oxidizer_mass
+            ),
             chamber_pressure=chamber_pressure,
+            fluid_mass=oxidizer_mass,
         )
 
     def get_mass_flow_fuel(
@@ -73,6 +78,8 @@ class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
         chamber_pressure: float,
         *,
         injector: injector_models.BipropellantInjector,
+        fuel_mass: float,
+        oxidizer_mass: float,
     ) -> float:
         """
         Compute the current fuel mass flow rate by delegating to the injector.
@@ -83,26 +90,36 @@ class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
         Args:
             chamber_pressure: Chamber pressure [Pa].
             injector: Bipropellant injector handling the orifice dispatch.
+            fuel_mass: Current fuel mass in the tank [kg].
+            oxidizer_mass: Current oxidizer mass in the tank [kg].
 
         Returns:
             Fuel mass flow rate [kg/s].
         """
         return injector.get_mass_flow_fuel(
             tank=self.fuel_tank,
-            pressure_upstream=self.get_fuel_tank_pressure(),
+            pressure_upstream=self.get_fuel_tank_pressure(
+                oxidizer_mass=oxidizer_mass, fuel_mass=fuel_mass
+            ),
             chamber_pressure=chamber_pressure,
+            fluid_mass=fuel_mass,
         )
 
-    def get_oxidizer_tank_pressure(self) -> float:
+    def get_oxidizer_tank_pressure(self, *, oxidizer_mass: float) -> float:
         """Returns the tank pressure [Pa]."""
-        return self.oxidizer_tank.get_pressure()
+        return self.oxidizer_tank.get_pressure(oxidizer_mass)
 
-    def get_fuel_tank_pressure(self) -> float:
+    def get_fuel_tank_pressure(
+        self, *, oxidizer_mass: float, fuel_mass: float
+    ) -> float:
         """
         Returns the fuel-side upstream pressure [Pa].
 
         In a stacked-tank system the fuel is pressurized by the oxidizer
         through the piston, so the fuel-side pressure is the oxidizer tank
-        pressure minus the piston pressure loss.
+        pressure minus the piston pressure loss; ``fuel_mass`` is unused here.
         """
-        return self.get_oxidizer_tank_pressure() - self.piston_loss
+        return (
+            self.get_oxidizer_tank_pressure(oxidizer_mass=oxidizer_mass)
+            - self.piston_loss
+        )

--- a/machwave/models/feed_systems/tank.py
+++ b/machwave/models/feed_systems/tank.py
@@ -7,6 +7,11 @@ class Tank:
     """
     A generic two-phase tank model for any single fluid recognized by CoolProp.
 
+    This is a static description of the tank: it carries no propellant-mass
+    state. Pressure and density are pure functions of a fluid mass passed in by
+    the caller, which lets the integrator own the mass and keeps the model
+    re-runnable.
+
     Assumptions:
       - Constant temperature (isothermal).
       - Two-phase equilibrium if there's enough mass to form liquid + vapor.
@@ -29,7 +34,8 @@ class Tank:
             fluid_name: Name of the fluid in the CoolProp database.
             volume: Internal volume of the tank [m^3] (>0).
             temperature: Absolute temperature [K], assumed constant (>0).
-            initial_fluid_mass: Initial total mass of fluid [kg] (>=0).
+            initial_fluid_mass: Initial total mass of fluid [kg] (>=0). This is
+                the tank's loading; the integrator owns the mass thereafter.
             overfill_tolerance: Allowed fraction over the saturated liquid
                 density, e.g. 0.01 = 1% (>=0).
 
@@ -41,7 +47,6 @@ class Tank:
         self.volume = volume
         self.temperature = temperature
         self.initial_fluid_mass = initial_fluid_mass
-        self.fluid_mass = initial_fluid_mass
         self.overfill_tolerance = overfill_tolerance
         self.molar_mass = CP.PropsSI("M", fluid_name)  # kg/mol
 
@@ -91,15 +96,18 @@ class Tank:
                 f"{self.temperature} K"
             )
 
-    def get_pressure(self) -> float:
+    def get_pressure(self, fluid_mass: float) -> float:
         """
-        Return the tank pressure [Pa].
+        Return the tank pressure [Pa] for a given fluid mass.
 
         1) Compute the saturation pressure at the given temperature.
         2) If the fluid mass is larger than the mass if all vapor at the saturation
             pressure, the tank is partially liquid and the pressure is the saturation
             pressure.
         3) Otherwise, the tank is all vapor and behaves like an ideal gas.
+
+        Args:
+            fluid_mass: Current total mass of fluid in the tank [kg].
 
         Returns:
             Tank pressure [Pa].
@@ -111,16 +119,16 @@ class Tank:
             saturation_pressure, self.volume, self.temperature, self.molar_mass
         )
 
-        if self.fluid_mass > max_vapor_mass:
+        if fluid_mass > max_vapor_mass:
             return saturation_pressure
         else:
             return ideal_gas.get_pressure(
-                self.fluid_mass, self.volume, self.temperature, self.molar_mass
+                fluid_mass, self.volume, self.temperature, self.molar_mass
             )
 
-    def get_density(self, pressure: float | None = None) -> float:
+    def get_density(self, fluid_mass: float, pressure: float | None = None) -> float:
         """
-        Return fluid density [kg/m^3] at tank pressure and temperature.
+        Return fluid density [kg/m^3] for a given fluid mass.
 
         1) An empty tank has zero density.
         2) Away from saturation the single-phase density follows directly from
@@ -130,16 +138,17 @@ class Tank:
             from the bottom), otherwise it falls back to the bulk density.
 
         Args:
+            fluid_mass: Current total mass of fluid in the tank [kg].
             pressure: Tank pressure override [Pa], e.g. for a piston-pressurized
                 stacked-tank system. Defaults to the tank's own pressure.
 
         Returns:
             Fluid density [kg/m^3].
         """
-        if self.fluid_mass <= 0:
+        if fluid_mass <= 0:
             return 0.0
 
-        tank_pressure = self.get_pressure() if pressure is None else pressure
+        tank_pressure = self.get_pressure(fluid_mass) if pressure is None else pressure
 
         try:
             return CP.PropsSI(
@@ -149,25 +158,6 @@ class Tank:
             max_vapor_mass = ideal_gas.get_mass(
                 tank_pressure, self.volume, self.temperature, self.molar_mass
             )
-            if self.fluid_mass > max_vapor_mass:
+            if fluid_mass > max_vapor_mass:
                 return CP.PropsSI("D", "T", self.temperature, "Q", 0, self.fluid_name)
-            return self.fluid_mass / self.volume
-
-    def remove_propellant(self, mass: float) -> None:
-        """
-        Remove the specified mass of fluid [kg] from the tank.
-
-        If the requested mass exceeds what's in the tank, sets total mass to 0.
-
-        Args:
-            mass: Mass of fluid to remove [kg].
-
-        Raises:
-            ValueError: If `mass` is negative.
-        """
-        if mass < 0:
-            raise ValueError("Cannot remove a negative mass of propellant.")
-
-        self.fluid_mass -= mass
-        if self.fluid_mass < 0:
-            self.fluid_mass = 0.0
+            return fluid_mass / self.volume

--- a/machwave/models/motors/biliquid.py
+++ b/machwave/models/motors/biliquid.py
@@ -47,7 +47,7 @@ class BiliquidEngine(
     @property
     def initial_propellant_mass(self) -> float:
         """Return the initial propellant mass [kg]."""
-        return self.feed_system.get_propellant_mass()
+        return self.feed_system.get_initial_propellant_mass()
 
     def get_launch_mass(self) -> float:
         """Return the launch mass (dry mass + initial propellant) [kg]."""

--- a/machwave/models/thrust_chamber/injector.py
+++ b/machwave/models/thrust_chamber/injector.py
@@ -67,6 +67,7 @@ class BipropellantInjector:
         tank: tank_models.Tank,
         pressure_upstream: float,
         chamber_pressure: float,
+        fluid_mass: float,
     ) -> float:
         """
         Compute the fuel-side mass flow rate through this injector.
@@ -75,6 +76,7 @@ class BipropellantInjector:
             tank: Tank supplying the fuel.
             pressure_upstream: Upstream stagnation pressure [Pa].
             chamber_pressure: Chamber pressure [Pa].
+            fluid_mass: Current fuel mass in the tank [kg].
 
         Returns:
             Fuel mass flow rate [kg/s].
@@ -86,6 +88,7 @@ class BipropellantInjector:
             discharge_coefficient=self.discharge_coefficient_fuel,
             injector_area=self.area_fuel,
             mass_flow_model=self.mass_flow_model_fuel,
+            fluid_mass=fluid_mass,
         )
 
     def get_mass_flow_ox(
@@ -94,6 +97,7 @@ class BipropellantInjector:
         tank: tank_models.Tank,
         pressure_upstream: float,
         chamber_pressure: float,
+        fluid_mass: float,
     ) -> float:
         """
         Compute the oxidizer-side mass flow rate through this injector.
@@ -102,6 +106,7 @@ class BipropellantInjector:
             tank: Tank supplying the oxidizer.
             pressure_upstream: Upstream stagnation pressure [Pa].
             chamber_pressure: Chamber pressure [Pa].
+            fluid_mass: Current oxidizer mass in the tank [kg].
 
         Returns:
             Oxidizer mass flow rate [kg/s].
@@ -113,6 +118,7 @@ class BipropellantInjector:
             discharge_coefficient=self.discharge_coefficient_oxidizer,
             injector_area=self.area_ox,
             mass_flow_model=self.mass_flow_model_oxidizer,
+            fluid_mass=fluid_mass,
         )
 
     @staticmethod
@@ -124,6 +130,7 @@ class BipropellantInjector:
         discharge_coefficient: float,
         injector_area: float,
         mass_flow_model: MassFlowModel,
+        fluid_mass: float,
     ) -> float:
         """
         Dispatch a mass flow calculation through the requested model.
@@ -135,6 +142,7 @@ class BipropellantInjector:
             discharge_coefficient: Discharge coefficient (dimensionless).
             injector_area: Effective flow area [m^2].
             mass_flow_model: Mass flow model for this side.
+            fluid_mass: Current mass of fluid in the tank [kg].
 
         Returns:
             Mass flow rate [kg/s].
@@ -151,7 +159,7 @@ class BipropellantInjector:
             return incompressible_flow.get_mass_flow_orifice(
                 discharge_coefficient=discharge_coefficient,
                 area=injector_area,
-                density=tank.get_density(),
+                density=tank.get_density(fluid_mass),
                 pressure_upstream=pressure_upstream,
                 pressure_downstream=chamber_pressure,
             )

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -105,9 +105,6 @@ class BiliquidEngineState(simulation_states.MotorState):
         )
         self.oxidizer_tank_pressure.append(oxidizer_tank_pressure)
 
-        # A tank can only feed the chamber while its pressure exceeds the
-        # chamber pressure. Once a tank is (nearly) empty its pressure collapses
-        # below the chamber and the engine can no longer be fed.
         can_feed = (
             propellant_mass > 0
             and fuel_tank_pressure > chamber_pressure

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -43,10 +43,10 @@ class BiliquidEngineState(simulation_states.MotorState):
         )
 
         self.oxidizer_mass: simulation_states.SimulationStateArray = [
-            motor.feed_system.oxidizer_tank.fluid_mass
+            motor.feed_system.oxidizer_tank.initial_fluid_mass
         ]
         self.fuel_mass: simulation_states.SimulationStateArray = [
-            motor.feed_system.fuel_tank.fluid_mass
+            motor.feed_system.fuel_tank.initial_fluid_mass
         ]
 
         self.fuel_mass_flow_rate: simulation_states.SimulationStateArray = []
@@ -95,17 +95,35 @@ class BiliquidEngineState(simulation_states.MotorState):
 
         propellant_mass = fuel_mass + oxidizer_mass
         self.propellant_mass.append(propellant_mass)
-        self.fuel_tank_pressure.append(feed_system.get_fuel_tank_pressure())
-        self.oxidizer_tank_pressure.append(feed_system.get_oxidizer_tank_pressure())
 
-        if propellant_mass > 0:
+        fuel_tank_pressure = feed_system.get_fuel_tank_pressure(
+            oxidizer_mass=oxidizer_mass, fuel_mass=fuel_mass
+        )
+        self.fuel_tank_pressure.append(fuel_tank_pressure)
+        oxidizer_tank_pressure = feed_system.get_oxidizer_tank_pressure(
+            oxidizer_mass=oxidizer_mass
+        )
+        self.oxidizer_tank_pressure.append(oxidizer_tank_pressure)
+
+        # A tank can only feed the chamber while its pressure exceeds the
+        # chamber pressure. Once a tank is (nearly) empty its pressure collapses
+        # below the chamber and the engine can no longer be fed.
+        can_feed = (
+            propellant_mass > 0
+            and fuel_tank_pressure > chamber_pressure
+            and oxidizer_tank_pressure > chamber_pressure
+        )
+        if can_feed:
             m_dot_fuel = feed_system.get_mass_flow_fuel(
                 chamber_pressure=chamber_pressure,
                 injector=injector,
+                fuel_mass=fuel_mass,
+                oxidizer_mass=oxidizer_mass,
             )
             m_dot_ox = feed_system.get_mass_flow_ox(
                 chamber_pressure=chamber_pressure,
                 injector=injector,
+                oxidizer_mass=oxidizer_mass,
             )
         else:
             m_dot_fuel = m_dot_ox = 0.0
@@ -172,7 +190,9 @@ class BiliquidEngineState(simulation_states.MotorState):
         self.thrust.append(thrust)
 
         if (
-            fuel_consumed >= fuel_mass or oxidizer_consumed >= oxidizer_mass
+            not can_feed
+            or fuel_consumed >= fuel_mass
+            or oxidizer_consumed >= oxidizer_mass
         ) and not self.end_burn:
             self.end_burn = True
             self._burn_time = time + d_t
@@ -190,8 +210,6 @@ class BiliquidEngineState(simulation_states.MotorState):
 
         new_time = time + d_t
         self.time.append(new_time)
-        feed_system.fuel_tank.remove_propellant(fuel_consumed)
-        feed_system.oxidizer_tank.remove_propellant(oxidizer_consumed)
         self.fuel_mass.append(fuel_mass - fuel_consumed)
         self.oxidizer_mass.append(oxidizer_mass - oxidizer_consumed)
         new_chamber_pressure = rk4.rk4th_ode_solver(

--- a/tests/test_models/test_propulsion/test_feed_systems/test_stacked_tank_pressure_fed.py
+++ b/tests/test_models/test_propulsion/test_feed_systems/test_stacked_tank_pressure_fed.py
@@ -10,8 +10,12 @@ from tests.factories import (
 
 def test_get_mass_flow_ox_delegates_to_injector_dispatch():
     """Feed-system call equals the injector's own dispatch on the ox tank."""
+    oxidizer_mass = 5.0
     oxidizer_tank = tank_models.Tank(
-        fluid_name="N2O", volume=0.01, temperature=293.0, initial_fluid_mass=5.0
+        fluid_name="N2O",
+        volume=0.01,
+        temperature=293.0,
+        initial_fluid_mass=oxidizer_mass,
     )
     feed_system = StackedTankPressureFedFeedSystemFactory.build(
         oxidizer_tank=oxidizer_tank,
@@ -21,11 +25,16 @@ def test_get_mass_flow_ox_delegates_to_injector_dispatch():
     )
     chamber_pressure = 20e5
 
-    actual = feed_system.get_mass_flow_ox(chamber_pressure, injector=injector)
+    actual = feed_system.get_mass_flow_ox(
+        chamber_pressure, injector=injector, oxidizer_mass=oxidizer_mass
+    )
     expected = injector.get_mass_flow_ox(
         tank=oxidizer_tank,
-        pressure_upstream=feed_system.get_oxidizer_tank_pressure(),
+        pressure_upstream=feed_system.get_oxidizer_tank_pressure(
+            oxidizer_mass=oxidizer_mass
+        ),
         chamber_pressure=chamber_pressure,
+        fluid_mass=oxidizer_mass,
     )
     assert actual == pytest.approx(expected)
 
@@ -35,11 +44,22 @@ def test_get_mass_flow_fuel_uses_piston_pressurized_upstream():
     feed_system = StackedTankPressureFedFeedSystemFactory.build(piston_loss=2e5)
     injector = BipropellantInjectorFactory.build()
     chamber_pressure = 15e5
+    oxidizer_mass = feed_system.oxidizer_tank.initial_fluid_mass
+    fuel_mass = feed_system.fuel_tank.initial_fluid_mass
 
-    actual = feed_system.get_mass_flow_fuel(chamber_pressure, injector=injector)
+    actual = feed_system.get_mass_flow_fuel(
+        chamber_pressure,
+        injector=injector,
+        fuel_mass=fuel_mass,
+        oxidizer_mass=oxidizer_mass,
+    )
     expected = injector.get_mass_flow_fuel(
         tank=feed_system.fuel_tank,
-        pressure_upstream=feed_system.get_oxidizer_tank_pressure() - 2e5,
+        pressure_upstream=feed_system.get_oxidizer_tank_pressure(
+            oxidizer_mass=oxidizer_mass
+        )
+        - 2e5,
         chamber_pressure=chamber_pressure,
+        fluid_mass=fuel_mass,
     )
     assert actual == pytest.approx(expected)

--- a/tests/test_models/test_propulsion/test_feed_systems/test_tank.py
+++ b/tests/test_models/test_propulsion/test_feed_systems/test_tank.py
@@ -36,15 +36,16 @@ def test_saturated_condition(fluid_name, temperature):
     m_vap = (p_sat * volume * molar_mass) / (R_universal * temperature)
 
     # 3) Put more mass than m_vap => ensures there's liquid
+    fluid_mass = 2.0 * m_vap  # definitely more than needed for vapor only
     tank = tank_models.Tank(
         fluid_name=fluid_name,
         volume=volume,
         temperature=temperature,
-        initial_fluid_mass=2.0 * m_vap,  # definitely more than needed for vapor only
+        initial_fluid_mass=fluid_mass,
     )
 
     # 4) Check the tank pressure ~ saturation
-    assert tank.get_pressure() == pytest.approx(p_sat, rel=1e-3), (
+    assert tank.get_pressure(fluid_mass) == pytest.approx(p_sat, rel=1e-3), (
         f"Expected saturation pressure for {fluid_name} at T={temperature} K."
     )
 
@@ -76,41 +77,25 @@ def test_all_vapor_condition(fluid_name, temperature):
     n_moles = mass / molar_mass
     p_ideal = (n_moles * R_universal * temperature) / volume
 
-    assert tank.get_pressure() == pytest.approx(p_ideal, rel=1e-3), (
+    assert tank.get_pressure(mass) == pytest.approx(p_ideal, rel=1e-3), (
         f"Expected ideal-gas pressure for {fluid_name} at T={temperature} K with insufficient mass."
     )
 
 
 @pytest.mark.parametrize("fluid_name, temperature", TEST_FLUIDS)
-def test_remove_propellant(fluid_name, temperature):
+def test_empty_tank_pressure_and_density(fluid_name, temperature):
     """
-    Removing propellant must decrement fluid_mass, and removing more than
-    is present must empty the tank cleanly.
+    An empty tank (zero fluid mass) must report ~zero pressure and density.
     """
-    volume = 0.02
-    initial_mass = 1.0
-
     tank = tank_models.Tank(
         fluid_name=fluid_name,
-        volume=volume,
+        volume=0.02,
         temperature=temperature,
-        initial_fluid_mass=initial_mass,
+        initial_fluid_mass=1.0,
     )
 
-    # 1) Remove some fraction of fluid
-    remove_mass_1 = 0.2
-    tank.remove_propellant(remove_mass_1)
-
-    assert tank.fluid_mass == pytest.approx(initial_mass - remove_mass_1, abs=1e-9)
-
-    # 2) Remove more mass than is left => tank empties
-    tank.remove_propellant(5.0)  # definitely more than remains
-    assert tank.fluid_mass == 0.0, "Tank should be fully emptied."
-    assert tank.get_density() == 0.0, "Density should be zero when empty."
-
-    # Depending on your model, if fluid_mass=0 => get_pressure() might be 0 or very small
-    empty_pressure = tank.get_pressure()
-    assert empty_pressure == pytest.approx(0.0, abs=1e-9), (
+    assert tank.get_density(0.0) == 0.0, "Density should be zero when empty."
+    assert tank.get_pressure(0.0) == pytest.approx(0.0, abs=1e-9), (
         f"Pressure should be ~0 for an empty tank of {fluid_name}."
     )
 
@@ -129,22 +114,23 @@ def test_two_phase_density_returns_saturated_liquid(fluid_name, temperature):
     R_universal = scipy.constants.R
     m_vap_sat = (p_sat * volume * molar_mass) / (R_universal * temperature)
 
+    fluid_mass = 2.0 * m_vap_sat
     tank = tank_models.Tank(
         fluid_name=fluid_name,
         volume=volume,
         temperature=temperature,
-        initial_fluid_mass=2.0 * m_vap_sat,
+        initial_fluid_mass=fluid_mass,
     )
 
     rho_liquid = CP.PropsSI("D", "T", temperature, "Q", 0, fluid_name)
-    assert tank.get_density() == pytest.approx(rho_liquid, rel=1e-3)
+    assert tank.get_density(fluid_mass) == pytest.approx(rho_liquid, rel=1e-3)
 
 
 @pytest.mark.parametrize("fluid_name, temperature", TEST_FLUIDS)
 def test_two_phase_density_constant_while_two_phase(fluid_name, temperature):
     """
     While the tank remains two-phase, ``get_density()`` must be invariant
-    under mass removal — it tracks the saturated liquid density, not the
+    under mass change — it tracks the saturated liquid density, not the
     bulk mixture.
     """
     volume = 0.01
@@ -160,17 +146,13 @@ def test_two_phase_density_constant_while_two_phase(fluid_name, temperature):
         initial_fluid_mass=5.0 * m_vap_sat,
     )
 
-    density_before = tank.get_density()
-    tank.remove_propellant(m_vap_sat)  # still leaves > m_vap_sat in the tank
-    assert tank.fluid_mass > m_vap_sat
-    assert tank.get_density() == pytest.approx(density_before, rel=1e-6)
-
-
-def test_remove_negative_mass():
-    """Removing negative mass should raise ValueError."""
-    tank = tank_models.Tank("Water", 0.01, 300.0, 1.0)
-    with pytest.raises(ValueError):
-        tank.remove_propellant(-0.5)
+    # Both masses leave the tank two-phase (> m_vap_sat), so density is invariant.
+    higher_mass = 5.0 * m_vap_sat
+    lower_mass = 4.0 * m_vap_sat
+    assert lower_mass > m_vap_sat
+    assert tank.get_density(lower_mass) == pytest.approx(
+        tank.get_density(higher_mass), rel=1e-6
+    )
 
 
 @pytest.mark.parametrize("fluid_name, temperature", TEST_FLUIDS)

--- a/tests/test_models/test_propulsion/test_injector.py
+++ b/tests/test_models/test_propulsion/test_injector.py
@@ -59,13 +59,18 @@ class TestBipropellantInjectorInstantiation:
 class TestBipropellantInjectorMassFlow:
     def test_hem_predicts_lower_oxidizer_flow_than_spi_for_saturated_n2o(self):
         """For saturated N2O, HEM under-predicts SPI."""
+        oxidizer_mass = 5.0
         oxidizer_tank = tank_models.Tank(
-            fluid_name="N2O", volume=0.01, temperature=293.0, initial_fluid_mass=5.0
+            fluid_name="N2O",
+            volume=0.01,
+            temperature=293.0,
+            initial_fluid_mass=oxidizer_mass,
         )
         kwargs = dict(
             tank=oxidizer_tank,
-            pressure_upstream=oxidizer_tank.get_pressure(),
+            pressure_upstream=oxidizer_tank.get_pressure(oxidizer_mass),
             chamber_pressure=20e5,
+            fluid_mass=oxidizer_mass,
         )
         injector_spi = BipropellantInjectorFactory.build(
             mass_flow_model_oxidizer=MassFlowModel.SPI,
@@ -80,14 +85,19 @@ class TestBipropellantInjectorMassFlow:
         assert flow_hem < flow_spi
 
     def test_spi_dispatch_returns_positive_flow(self):
+        oxidizer_mass = 5.0
         oxidizer_tank = tank_models.Tank(
-            fluid_name="N2O", volume=0.01, temperature=293.0, initial_fluid_mass=5.0
+            fluid_name="N2O",
+            volume=0.01,
+            temperature=293.0,
+            initial_fluid_mass=oxidizer_mass,
         )
         injector = BipropellantInjectorFactory.build()
         flow = injector.get_mass_flow_ox(
             tank=oxidizer_tank,
-            pressure_upstream=oxidizer_tank.get_pressure(),
+            pressure_upstream=oxidizer_tank.get_pressure(oxidizer_mass),
             chamber_pressure=20e5,
+            fluid_mass=oxidizer_mass,
         )
         assert flow > 0.0
 
@@ -95,24 +105,29 @@ class TestBipropellantInjectorMassFlow:
         """SPI dispatch equals `Cd * A * sqrt(2 * rho * dP)` from the core helper."""
         import machwave.core.incompressible_flow as incompressible_flow
 
+        oxidizer_mass = 5.0
         oxidizer_tank = tank_models.Tank(
-            fluid_name="N2O", volume=0.01, temperature=293.0, initial_fluid_mass=5.0
+            fluid_name="N2O",
+            volume=0.01,
+            temperature=293.0,
+            initial_fluid_mass=oxidizer_mass,
         )
         injector = BipropellantInjectorFactory.build(
             mass_flow_model_oxidizer=MassFlowModel.SPI,
         )
-        pressure_upstream = oxidizer_tank.get_pressure()
+        pressure_upstream = oxidizer_tank.get_pressure(oxidizer_mass)
         chamber_pressure = 20e5
 
         actual = injector.get_mass_flow_ox(
             tank=oxidizer_tank,
             pressure_upstream=pressure_upstream,
             chamber_pressure=chamber_pressure,
+            fluid_mass=oxidizer_mass,
         )
         expected = incompressible_flow.get_mass_flow_orifice(
             discharge_coefficient=injector.discharge_coefficient_oxidizer,
             area=injector.area_ox,
-            density=oxidizer_tank.get_density(),
+            density=oxidizer_tank.get_density(oxidizer_mass),
             pressure_upstream=pressure_upstream,
             pressure_downstream=chamber_pressure,
         )
@@ -122,19 +137,24 @@ class TestBipropellantInjectorMassFlow:
         """HEM dispatch equals `Cd * A * G_HEM` from the core helper."""
         import machwave.core.two_phase_flow as two_phase_flow
 
+        oxidizer_mass = 5.0
         oxidizer_tank = tank_models.Tank(
-            fluid_name="N2O", volume=0.01, temperature=293.0, initial_fluid_mass=5.0
+            fluid_name="N2O",
+            volume=0.01,
+            temperature=293.0,
+            initial_fluid_mass=oxidizer_mass,
         )
         injector = BipropellantInjectorFactory.build(
             mass_flow_model_oxidizer=MassFlowModel.HEM,
         )
-        pressure_upstream = oxidizer_tank.get_pressure()
+        pressure_upstream = oxidizer_tank.get_pressure(oxidizer_mass)
         chamber_pressure = 20e5
 
         actual = injector.get_mass_flow_ox(
             tank=oxidizer_tank,
             pressure_upstream=pressure_upstream,
             chamber_pressure=chamber_pressure,
+            fluid_mass=oxidizer_mass,
         )
         mass_flux = two_phase_flow.get_homogeneous_equilibrium_mass_flux(
             fluid_name=oxidizer_tank.fluid_name,
@@ -149,11 +169,12 @@ class TestBipropellantInjectorMassFlow:
 
     def test_fuel_side_dispatch_uses_fuel_attributes(self):
         """Fuel dispatch uses fuel-side Cd, area, and model — not the ox-side ones."""
+        fuel_mass = 2.0
         fuel_tank = tank_models.Tank(
             fluid_name="Ethanol",
             volume=0.005,
             temperature=298.0,
-            initial_fluid_mass=2.0,
+            initial_fluid_mass=fuel_mass,
         )
         injector = BipropellantInjectorFactory.build(
             discharge_coefficient_fuel=0.40,
@@ -170,6 +191,7 @@ class TestBipropellantInjectorMassFlow:
             tank=fuel_tank,
             pressure_upstream=pressure_upstream,
             chamber_pressure=chamber_pressure,
+            fluid_mass=fuel_mass,
         )
 
         import machwave.core.incompressible_flow as incompressible_flow
@@ -177,7 +199,7 @@ class TestBipropellantInjectorMassFlow:
         expected = incompressible_flow.get_mass_flow_orifice(
             discharge_coefficient=0.40,
             area=5.0e-6,
-            density=fuel_tank.get_density(),
+            density=fuel_tank.get_density(fuel_mass),
             pressure_upstream=pressure_upstream,
             pressure_downstream=chamber_pressure,
         )

--- a/tests/test_simulations/test_biliquid_engine_simulation.py
+++ b/tests/test_simulations/test_biliquid_engine_simulation.py
@@ -54,6 +54,24 @@ def test_thrust_time_is_finite_and_positive(
     assert simulation_result.thrust_time > 0.0
 
 
+def test_motor_is_re_runnable() -> None:
+    """A motor must produce identical results when simulated twice.
+
+    Regression test for #321: the tank used to be drained in place during a
+    run, so a second run started from an empty tank. With the tank stateless and
+    the mass owned by the simulation state, re-running is reproducible.
+    """
+    motor, params = motor_builders.build_1kn_biliquid_engine()
+
+    first = run_simulation(motor, params)
+    second = run_simulation(motor, params)
+
+    assert first.time.size == second.time.size
+    np.testing.assert_array_equal(first.oxidizer_mass, second.oxidizer_mass)
+    np.testing.assert_array_equal(first.fuel_mass, second.fuel_mass)
+    np.testing.assert_array_equal(first.thrust, second.thrust)
+
+
 def test_propellant_masses_are_monotone_non_increasing(
     simulation_result: biliquid_simulation.BiliquidSimulationResult,
 ) -> None:


### PR DESCRIPTION
Closes #321.

`Tank` no longer carries or mutates a fluid mass. `get_pressure` and `get_density` now take the current mass as an argument, and the feed system, injector, and `BiliquidEngineState` thread through the mass that the integrator owns. A motor is therefore re-runnable instead of staying drained after a run (the root cause behind #267 and #223).

## Changes
- **Tank**: drop the `fluid_mass` attribute and `remove_propellant`; `get_pressure(fluid_mass)` and `get_density(fluid_mass, ...)` are pure functions of a passed-in mass.
- **Feed system / stacked cycle**: pressure and mass-flow methods take the relevant tank mass(es); `get_propellant_mass` renamed to `get_initial_propellant_mass`, since it returns the initial loading.
- **Injector**: mass-flow methods take `fluid_mass`, threaded into `get_density`.
- **BiliquidEngineState**: seeds its mass arrays from `initial_fluid_mass`, threads the current mass into feed-system calls, and no longer mutates the tank.

## Behaviour note (slightly beyond a pure refactor)
Making the tank reflect its true depleted state surfaced a latent crash: the simulation asked the injector to flow against a collapsed tank pressure once a tank emptied. Added a `can_feed` guard so a tank whose pressure has fallen to the chamber pressure stops feeding and ends the burn. This does not change normal-run numbers (tank pressures sit far above the chamber pressure until depletion).

## Tests
- Added a re-runnability regression test: simulating the same motor twice now yields identical mass and thrust series.
- Updated the tank, injector, and stacked-feed-system unit tests for the new signatures.
- 67 unit tests and 10 simulation tests pass.

## Follow-up
A non-isothermal tank (#327) will add internal energy as a second integrated state; it will extend these method signatures rather than slot in unchanged.