### PR TITLE
Review and revise documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo/machwave-icon-white.svg">
+    <img src="docs/assets/logo/machwave-icon-color.svg" alt="Machwave" width="120">
+  </picture>
+</p>
+
 # Machwave
 
 Machwave is a Python library for chemical propulsion simulation. The library makes it

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -5,7 +5,9 @@ The engineering math layer. Contains unit conversions, geometric primitives (cir
 Submodules:
 
 - [compressible_flow](core/compressible_flow.md) — Isentropic relations, thrust coefficients, nozzle loss models
-- [mass_balance](core/mass_balance.md) — Chamber-pressure ODE shared by SRM and LRE
+- [interpolation](core/interpolation.md) — Non-extrapolating bounded cubic spline for tabulated curves
+- [mass_balance](core/mass_balance.md) — Chamber-pressure ODE shared by solid motors and biliquid engines
+- [performance](core/performance.md) — Total and specific impulse
 - [solvers](core/solvers.md) — RK4 ODE solver
 
 ::: machwave.core

--- a/docs/api/core/compressible_flow.md
+++ b/docs/api/core/compressible_flow.md
@@ -4,8 +4,8 @@ Compressible flow relations for convergent-divergent nozzle analysis.
 
 - **Isentropic flow** — Critical pressure ratio, exit Mach from expansion ratio, exit pressure, choked-flow detection.
 - **Nozzle performance** — Ideal and corrected thrust coefficient (Cf), optimal expansion ratio for a given altitude, thrust from Cf.
-- **Loss models** — Percentage-based correction factors for divergent angle, finite-rate kinetics, boundary layer, and two-phase flow losses. These combine into an overall nozzle efficiency applied to the ideal Cf.
+- **Loss models** — Fractional correction factors for divergent angle, finite-rate kinetics, boundary layer, and two-phase flow losses. These combine into an overall nozzle efficiency applied to the ideal Cf.
 
-All loss functions return values in the 0–100% range and follow standard empirical correlations from Humble, Henry & Larson.
+All loss functions return a loss as a fraction in [0, 1] and follow the empirical correlations of Coats et al. (AFRPL-TR-75-36, 1975).
 
 ::: machwave.core.compressible_flow

--- a/docs/api/core/mass_balance.md
+++ b/docs/api/core/mass_balance.md
@@ -2,8 +2,9 @@
 
 Right-hand side of the chamber-pressure ODE solved during internal-ballistics
 simulation. A single control-volume mass balance covers both choked and
-sub-critical nozzle flow (Seidel 1965, Eq. 35), and is shared by the SRM and
-LRE state integrations — the caller supplies the appropriate \(\dot{m}_{in}\)
-(propellant regression for SRM, summed injector flows for LRE).
+sub-critical nozzle flow (Seidel 1965, Eq. 35), and is shared by the solid-motor
+and biliquid-engine state integrations — the caller supplies the appropriate
+\(\dot{m}_{in}\) (propellant regression for a solid motor, summed injector flows
+for a biliquid engine).
 
 ::: machwave.core.mass_balance

--- a/docs/api/core/performance.md
+++ b/docs/api/core/performance.md
@@ -1,0 +1,6 @@
+# core.performance
+
+Scalar performance metrics derived from a finished thrust–time history: total
+impulse (the numerical time integral of thrust) and specific impulse.
+
+::: machwave.core.performance

--- a/docs/api/models/feed_systems.md
+++ b/docs/api/models/feed_systems.md
@@ -15,10 +15,10 @@ organised around three concerns:
 
 Every cycle implementation extends [`FeedSystem`][machwave.models.feed_systems.base.FeedSystem] and exposes four methods used by the simulation loop:
 
-- `get_mass_flow_ox(chamber_pressure, *, injector) -> float`
-- `get_mass_flow_fuel(chamber_pressure, *, injector) -> float`
-- `get_oxidizer_tank_pressure() -> float`
-- `get_fuel_tank_pressure() -> float`
+- `get_mass_flow_ox(chamber_pressure, *, injector, oxidizer_mass) -> float`
+- `get_mass_flow_fuel(chamber_pressure, *, injector, fuel_mass, oxidizer_mass) -> float`
+- `get_oxidizer_tank_pressure(*, oxidizer_mass) -> float`
+- `get_fuel_tank_pressure(*, oxidizer_mass, fuel_mass) -> float`
 
 The mass-flow methods take a [`BipropellantInjector`][machwave.models.thrust_chamber.injector.BipropellantInjector] and delegate the orifice dispatch to it. The feed system is responsible for computing the upstream pressure (tank state, piston losses, pump discharge); the injector owns the orifice physics (discharge coefficient, area, and the per-side `MassFlowModel` that selects between single-phase incompressible and homogeneous-equilibrium two-phase flow). This split lets pump-fed cycles substitute a different upstream-pressure source without touching orifice physics.
 

--- a/docs/api/models/feed_systems/components.md
+++ b/docs/api/models/feed_systems/components.md
@@ -85,7 +85,7 @@ Describes a regenerative cooling jacket wrapping the combustion chamber and nozz
 | Field | Units | Constraint |
 | --- | --- | --- |
 | `name` | — | Free-form identifier. |
-| `pressure_drop` | Pa | Non-negative |
+| `pressure_drop` | Pa | Strictly positive |
 | `coolant_temperature_rise` | K | Strictly positive |
 | `heat_pickup` | W | Non-negative |
 

--- a/docs/api/models/feed_systems/tank.md
+++ b/docs/api/models/feed_systems/tank.md
@@ -1,6 +1,6 @@
 # models.feed_systems.tank
 
-Two-phase propellant tank model backed by CoolProp. The `Tank` class tracks fluid mass, computes tank pressure from two-phase thermodynamics (liquid + vapor equilibrium), and provides density at current conditions. Propellant is removed incrementally during simulation via `remove_propellant()`.
+Stateless two-phase propellant tank model backed by CoolProp. The `Tank` carries no propellant-mass state: pressure and density are pure functions of a fluid mass supplied by the caller, so the integrator owns the mass and the model stays re-runnable. `get_pressure(fluid_mass)` returns the tank pressure from two-phase equilibrium (saturation pressure while liquid is present, ideal-gas vapour otherwise), and `get_density(fluid_mass)` the density at current conditions.
 
 Tanks are identified by CoolProp fluid name (e.g., `"N2O"`, `"Oxygen"`, `"Hydrogen"`).
 

--- a/docs/api/models/grain/fmm.md
+++ b/docs/api/models/grain/fmm.md
@@ -3,8 +3,8 @@
 Fast Marching Method (FMM) base classes for grain geometries with complex cross-sections that cannot be described analytically. FMM operates on a 2D (or 3D) distance map to compute burn area and port area as the flame front regresses inward.
 
 - `FMMGrainSegment` — Base class providing the distance-map regression logic.
-- `FMMGrainSegment2D` — Constant cross-section FMM geometries (Star, D-grain).
-- `FMMGrainSegment3D` — Varying cross-section FMM geometries (WagonWheel).
+- `FMMGrainSegment2D` — Constant cross-section FMM geometries (Star, D-grain, wagon-wheel, multi-port, rod-and-tube).
+- `FMMGrainSegment3D` — Varying cross-section FMM geometries (Conical).
 - `FMMSTLGrainSegment` — Import arbitrary grain geometry from an STL mesh file.
 
 Used internally by the concrete geometry classes in [geometries](geometries.md).

--- a/docs/api/models/grain/geometries.md
+++ b/docs/api/models/grain/geometries.md
@@ -4,17 +4,16 @@ Concrete grain segment geometries, both analytical and FMM-based.
 
 **2D (constant cross-section):**
 
-- `BatesSegment` — Standard cylindrical grain with axial core (the most common hobby/amateur geometry).
-- `TubularSegment` — Thin-walled tube, burns from inner and/or outer surfaces.
-- `RodAndTubeSegment` — Central rod surrounded by an outer tubular section.
-- `MultiPortGrainSegment` — Multiple circular ports arranged radially in the cross-section.
-- `StarGrainSegment` — Star-shaped port (FMM-based). Configurable point count, length, and width.
+- `BatesSegment` — Cylindrical grain with an axial core, the most common amateur geometry (analytical).
+- `RodAndTubeGrainSegment` — Central rod surrounded by an outer tube (FMM-based).
+- `MultiPortGrainSegment` — Multiple circular ports arranged radially in the cross-section (FMM-based).
+- `StarGrainSegment` — Star-shaped port with configurable point count, length, and width (FMM-based).
 - `DGrainSegment` — D-shaped slot port (FMM-based).
+- `WagonWheelGrainSegment` — Multi-spoke geometry with a central core and radial ports (FMM-based).
 
 **3D (varying cross-section):**
 
 - `ConicalGrainSegment` — Linearly tapered core from upper to lower diameter.
-- `WagonWheelSegment` — Complex multi-spoke geometry (FMM-based).
 
 All segments implement the `GrainSegment` interface and can be mixed within a single `Grain`.
 

--- a/docs/api/models/thrust_chamber.md
+++ b/docs/api/models/thrust_chamber.md
@@ -4,7 +4,7 @@ Thrust chamber assembly and sub-components.
 
 - `Nozzle` — Conical nozzle defined by throat diameter, expansion ratio, convergent/divergent half-angles, and boundary-layer loss coefficients (`c_1`, `c_2`). Computes throat area and outlet diameter.
 - `CombustionChamber` — Cylindrical casing with thermal liner. Provides internal volume from casing dimensions and liner thickness.
-- `BipropellantInjector` — Injector for biliquid engines, characterized by discharge coefficients, orifice areas, and a per-side `MassFlowModel` for the oxidizer and fuel sides. Owns the orifice mass-flow dispatch: `get_mass_flow_ox(*, tank, pressure_upstream, chamber_pressure)` and `get_mass_flow_fuel(*, tank, pressure_upstream, chamber_pressure)`. Feed systems delegate to these methods.
+- `BipropellantInjector` — Injector for biliquid engines, characterized by discharge coefficients, orifice areas, and a per-side `MassFlowModel` for the oxidizer and fuel sides. Owns the orifice mass-flow dispatch: `get_mass_flow_ox(*, tank, pressure_upstream, chamber_pressure, fluid_mass)` and `get_mass_flow_fuel(*, tank, pressure_upstream, chamber_pressure, fluid_mass)`. Feed systems delegate to these methods.
 - `MassFlowModel` — Enum selecting the orifice flow model. `SPI` (single-phase incompressible) for subcooled liquid propellants; `HEM` (homogeneous-equilibrium two-phase) for self-pressurized propellants such as nitrous oxide, where flow can choke on the two-phase sound speed.
 - `SolidMotorThrustChamber` — Bundles nozzle + chamber + the distance from nozzle exit to grain port.
 - `BiliquidEngineThrustChamber` — Bundles nozzle + chamber + injector.

--- a/docs/api/services/eng.md
+++ b/docs/api/services/eng.md
@@ -1,4 +1,4 @@
-# eng
+# services.eng
 
 Import/export utilities for interoperability with external rocket simulation tools. Provides `.eng` file generation — the standard thrust-curve format used by OpenRocket, RASAero, and other flight simulators. Supply time-thrust arrays from a Machwave simulation and get a ready-to-use `.eng` string.
 

--- a/docs/assets/logo/favicon.svg
+++ b/docs/assets/logo/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <rect x="0" y="0" width="100" height="100" rx="22" fill="#1B1A18"></rect>
+  <path d="M35,23 L62,50 L35,77 L8,50 Z" fill="#E2541C"></path>
+  <path d="M77,35 L92,50 L77,65 L62,50 Z" fill="#FFFFFF"></path>
+</svg>

--- a/docs/assets/logo/machwave-icon-color.svg
+++ b/docs/assets/logo/machwave-icon-color.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-8 0 156 84">
+  <path d="M28,16 L54,42 L28,68 L2,42 Z" fill="#E2541C"></path>
+  <path d="M72.5,23.5 L91,42 L72.5,60.5 L54,42 Z" fill="#1B1A18"></path>
+  <path d="M105,29 L118,42 L105,55 L92,42 Z" fill="#1B1A18" opacity="0.72"></path>
+  <path d="M127.5,33 L136.5,42 L127.5,51 L118.5,42 Z" fill="#1B1A18" opacity="0.45"></path>
+</svg>

--- a/docs/assets/logo/machwave-icon-white.svg
+++ b/docs/assets/logo/machwave-icon-white.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-8 0 156 84">
+  <path d="M28,16 L54,42 L28,68 L2,42 Z" fill="#FFFFFF"></path>
+  <path d="M72.5,23.5 L91,42 L72.5,60.5 L54,42 Z" fill="#FFFFFF"></path>
+  <path d="M105,29 L118,42 L105,55 L92,42 Z" fill="#FFFFFF" opacity="0.72"></path>
+  <path d="M127.5,33 L136.5,42 L127.5,51 L118.5,42 Z" fill="#FFFFFF" opacity="0.45"></path>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,27 +1,21 @@
+<p align="center">
+  <img src="assets/logo/machwave-icon-color.svg#only-light" alt="Machwave" width="120">
+  <img src="assets/logo/machwave-icon-white.svg#only-dark" alt="Machwave" width="120">
+</p>
+
 # Machwave
 
-Machwave is an open source Python library for chemical rocket propulsion simulation. The
-library enables modeling and simulating solid rocket motors and biliquid rocket
-engines; hybrid engines are coming soon.
+Machwave is an open source Python library for chemical rocket propulsion simulation.
+Here is what it is capable of:
 
-### Key Capabilities
-
-- **Propellant modeling** with pre-defined formulations or CEA custom propellants
-- **Propellant grain analysis** with FMM-based regression (BATES, star, finocyl, and
-    more)
-- **Solid rocket motor and biliquid rocket engine modeling and simulation** (hybrid engines coming soon)
-- **Monte Carlo simulation**
-- **RocketPy trajectory simulation integration** (see [docs](api/adapters/rocketpy.md)
-    for details)
-
-## Why Machwave?
-
-Machwave provides a programmatic interface for modeling chemical propulsion systems,
-allowing users to have more control and flexibility over their designs and simulations.
-Other tools may offer similar capabilities, but they often come with limitations such as
-being closed source, lacking integration with trajectory simulations, or not being
-flexible enough for more advanced users.
-
+- **Propellant modeling** with NASA CEA integration and pre-defined formulations
+- **Grain regression analysis** with FMM for 2D and 3D geometries
+- **Rocket motor and engine simulation** for the following categories:
+    - Solid Rocket Motors
+    - *Bi-propellant Liquid Rocket Engines (in development 🔧)*
+    - *Hybrid Rocket Engines (coming soon 🗓️)*
+- **Monte Carlo simulation** for all of the motors/engines above
+- **Integration with RocketPy** for trajectory simulation and analysis
 
 ## Installation
 
@@ -39,24 +33,12 @@ pip install machwave[rocketpy]
 
 ## Quick Start
 
-Start with the step-by-step walkthrough on the
-[Quick Start page](quickstart.md), which covers propellant selection, grain
-geometry, thrust chamber setup, simulation execution, and result plotting.
+The [Quick Start page](quickstart.md) covers a Solid Rocket Motor simulation.
+Propellant selection, grain geometry, nozzle design, simulation execution and result plotting.
 
-For more complete examples, including coupled trajectory simulations and Monte
-Carlo analyses, see the
+For more complete examples, including coupled trajectory with RocketPy and Monte
+Carlo simulation, check out the
 [examples directory](https://github.com/felipebogaertsm/machwave/tree/main/examples).
-
-
-## Development Setup
-
-If you're contributing to Machwave, you'll need [uv](https://docs.astral.sh/uv/) for dependency management.
-
-```bash
-git clone https://github.com/felipebogaertsm/machwave.git
-cd machwave
-uv sync
-```
 
 ## License
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,12 +1,11 @@
 # Quick Start
 
-This walkthrough builds a simple BATES-grain SRM from scratch, runs an internal
-ballistics simulation, and plots the results.
+This guide shows how to simulate a Solid Rocket Motor with a BATES grain geometry using Machwave.
 
 ## 1. Choose a propellant
 
-Machwave ships with several pre-defined solid propellant formulations. Here we
-use KNDX (potassium nitrate / dextrose):
+Machwave ships with several pre-defined solid propellant formulations.
+Here we use KNDX (65% potassium nitrate and 35% dextrose):
 
 ```python
 from machwave import formulations
@@ -15,7 +14,7 @@ propellant = formulations.solid.KNDX
 ```
 
 For a full list of available solid propellants, see the
-[formulations page](https://felipebogaertsm.github.io/machwave/api/models/propulsion/propellants/formulations/).
+[formulations page](api/models/propellants/formulations.md).
 
 ## 2. Define the grain geometry
 

--- a/docs/theory/mass_balance.md
+++ b/docs/theory/mass_balance.md
@@ -31,7 +31,7 @@ Substituting into the mass balance and solving for \(dP_0/dt\):
 \]
 
 The \(-P_0\,\dot V_0/V_0\) term captures pressure decay due to free-volume
-expansion (e.g. grain regression in an SRM, port growth in a hybrid). For a
+expansion (e.g. grain regression in a solid motor, port growth in a hybrid). For a
 rigid control volume \(\dot V_0 = 0\) and the expression reduces to
 \(dP_0/dt = (R T_0/V_0)(\dot m_{gen} - \dot m_{out})\).
 
@@ -41,7 +41,7 @@ It is integrated numerically using the 4th-order Runge–Kutta solver in
 
 ---
 
-## 2.2 Solid Rocket Motor (SRM)
+## 2.2 Solid Rocket Motor
 
 *Reference: Seidel, H. (1965). Transient Chamber Pressure and Thrust in Solid Rocket
 Motors. AFRPL.*
@@ -105,7 +105,7 @@ phase recedes:
 i.e. the volumetric burn rate of the grain. This is passed to the ODE as the
 \(\dot V_0\) term in §2.1.
 
-### 2.2.5 SRM ODE
+### 2.2.5 Solid-Motor ODE
 
 Substituting §2.2.1, §2.2.2–§2.2.3, and §2.2.4 into §2.1:
 
@@ -118,8 +118,8 @@ Evaluated by
 with \(\dot{m}_{in} = \rho_p r A_b\) and `free_chamber_volume_rate` \(= r A_b\),
 as called from
 [`SolidMotorState`][machwave.simulation.solid.states.SolidMotorState]. The
-expansion term shifts steady-state \(P_0\) and total impulse by roughly
-0.5–1.3 % on the standard BATES configurations.
+expansion term slightly lowers steady-state \(P_0\) and total impulse relative to
+a rigid-volume model.
 
 ---
 
@@ -157,7 +157,10 @@ The total inflow is the sum of the fuel and oxidiser streams:
 
 Implemented in `get_mass_flow_orifice` (module
 [`machwave.core.incompressible_flow`](../api/core.md)) and called per stream by the
-feed system (see §2.3.2).
+feed system (see §2.3.2). This single-phase incompressible branch is the default;
+self-pressurised propellants (e.g. nitrous oxide) can instead select a
+homogeneous-equilibrium two-phase model (`get_homogeneous_equilibrium_mass_flux` in
+`machwave.core.two_phase_flow`), which captures choking on the two-phase sound speed.
 
 ### 2.3.2 Upstream Pressure — Pressurised Tank
 
@@ -183,26 +186,22 @@ Huang Ch. 8 for tank thermodynamics). Properties come from CoolProp; details in
 [`Tank`][machwave.models.feed_systems.tank.Tank] and the orchestrating
 [`StackedTankPressureFedFeedSystem`][machwave.models.feed_systems.cycles.stacked_tank_pressure_fed.StackedTankPressureFedFeedSystem].
 
-### 2.3.3 Stoichiometric Limiting-Reagent Adjustment
+### 2.3.3 Propellant Depletion
 
-*References: Sutton & Biblarz (2017) Ch. 6 §6.1 (Mixture Ratio); Huzel & Huang
-(1992) Ch. 1 §1.3 (Performance Parameters).*
-
-The injectors deliver fuel and oxidiser independently, so over a finite step \(\Delta t\)
-one tank can run dry while the other still has propellant. machwave clamps the surplus
-to preserve the design oxidiser–fuel ratio \(\mathrm{O\!/\!F} = \dot{m}_{ox}/\dot{m}_{fuel}\)
-(Sutton & Biblarz §6.1):
+The injectors draw fuel and oxidiser independently, so a tank can be emptied within a
+single step. To keep tank masses non-negative, each stream is capped at the mass
+remaining in its own tank over the step \(\Delta t\):
 
 \[
-\text{if } \dot{m}_{fuel}\Delta t \geq m_{fuel}: \;\;
-\dot{m}_{fuel} \leftarrow m_{fuel}/\Delta t,
-\;\;
-\dot{m}_{ox} \leftarrow \mathrm{O\!/\!F}\cdot\dot{m}_{fuel}
+\dot{m}_{fuel} \leftarrow \min\!\left(\dot{m}_{fuel},\, \frac{m_{fuel}}{\Delta t}\right),
+\qquad
+\dot{m}_{ox} \leftarrow \min\!\left(\dot{m}_{ox},\, \frac{m_{ox}}{\Delta t}\right).
 \]
 
-(and symmetrically when oxidiser is the limiting reagent). This avoids unphysical
-post-burnout transients in which one stream continues for several steps after the
-other has been exhausted. Implemented in
+The two streams are clamped independently — the instantaneous mixture ratio
+\(\mathrm{O\!/\!F} = \dot{m}_{ox}/\dot{m}_{fuel}\) is recomputed from the capped flows
+and passed to the thermochemistry, so a depleting tank simply drives the engine off
+its design ratio. The burn ends as soon as either tank is exhausted. Implemented in
 [`BiliquidEngineState`][machwave.simulation.biliquid.states.BiliquidEngineState].
 
 ### 2.3.4 Mass Exit Rate — Choked Throat
@@ -211,15 +210,15 @@ other has been exhausted. Implemented in
 Huzel & Huang (1992) Ch. 1 §1.4 (The Gas-Flow Processes).*
 
 The exit term is identical to §2.2.2 — the choked-flow expression derived in §1.7
-(Sutton & Biblarz §3.3). For LRE the implementation drops the throat discharge
-coefficient (\(C_d \equiv 1\)) and uses the chamber-state isentropic exponent
-\(k = k_\text{chamber}\):
+(Sutton & Biblarz §3.3). For the biliquid engine the implementation drops the throat
+discharge coefficient (\(C_d \equiv 1\)) and uses the chamber-state isentropic
+exponent \(k = k_\text{chamber}\):
 
 \[
 \dot{m}_{out} = \frac{P_0\, A_t}{\sqrt{R T_0}}\,\sqrt{k}\left(\frac{2}{k+1}\right)^{(k+1)/[2(k-1)]}.
 \]
 
-### 2.3.5 LRE Chamber-Pressure ODE
+### 2.3.5 Biliquid Chamber-Pressure ODE
 
 *References: Huzel & Huang (1992) Ch. 1 §1.4 and Ch. 4 §4.1 (Combustion-Chamber
 Processes); Sutton & Biblarz (2017) Ch. 8 §8.1 (Combustion Chamber Basic
@@ -227,7 +226,7 @@ Configurations).*
 
 Biliquid engines have a rigid combustion chamber (\(\dot V_0 = 0\)), so the
 expansion term in §2.1 vanishes. Substituting §2.3.1 and §2.3.4 into §2.1
-yields the LRE form of the well-stirred reactor balance (Huzel & Huang §1.4;
+yields the biliquid form of the well-stirred reactor balance (Huzel & Huang §1.4;
 Sutton & Biblarz §8.1):
 
 \[
@@ -278,14 +277,15 @@ keep these in mind when interpreting transient results:
   flow uses the bulk mixture density rather than the liquid saturation density —
   acceptable while the tank is mostly liquid, less accurate as it empties
   (Huzel & Huang §4.5 on injector hydraulics).
-- **Stoichiometric clamping.** When one tank empties first, the simulation drops
-  the surplus reagent rather than tracking the fuel-rich (or ox-rich) tail of a
-  real engine (Sutton & Biblarz §6.1).
+- **Burn ends at first depletion.** Each stream is capped at its remaining tank mass
+  and the burn stops as soon as either tank empties (§2.3.3); the fuel-rich (or
+  oxidiser-rich) tail a real engine produces as one propellant runs out is not
+  modelled (Sutton & Biblarz §6.1).
 
 ---
 
 ## References
 
 1. Seidel, H. (1965). *Transient Chamber Pressure and Thrust in Solid Rocket Motors*. Air Force Rocket Propulsion Laboratory (AFRPL).
-2. Sutton, G. P., & Biblarz, O. (2017). *Rocket Propulsion Elements* (9th ed.). Wiley. Ch. 6, 12.
-3. Huzel, D. K., & Huang, D. H. (1992). *Modern Engineering for Design of Liquid-Propellant Rocket Engines*. AIAA Progress in Astronautics and Aeronautics, Vol. 147. Ch. 1, 4, 7.
+2. Sutton, G. P., & Biblarz, O. (2017). *Rocket Propulsion Elements* (9th ed.). Wiley.
+3. Huzel, D. K., & Huang, D. H. (1992). *Modern Engineering for Design of Liquid-Propellant Rocket Engines*. AIAA Progress in Astronautics and Aeronautics, Vol. 147.

--- a/docs/theory/nozzle.md
+++ b/docs/theory/nozzle.md
@@ -149,7 +149,7 @@ Applying continuity between the throat and an arbitrary cross-section of area
 Expressing each factor using §1.2 and §1.3:
 
 \[
-\frac{a^*}{v} = \frac{a^*}{Ma} = \frac{1}{M}\sqrt{\frac{T^*}{T}} = \frac{1}{M}\sqrt{\frac{2}{k+1}\cdot\frac{1}{1+\frac{k-1}{2}M^2}}
+\frac{a^*}{v} = \frac{a^*}{Ma} = \frac{1}{M}\sqrt{\frac{T^*}{T}} = \frac{1}{M}\sqrt{\frac{2}{k+1}\left(1+\frac{k-1}{2}M^2\right)}
 \]
 
 \[
@@ -199,7 +199,8 @@ Substituting \(\rho_0 = P_0/(RT_0)\), \(T^* = 2T_0/(k+1)\):
 \]
 
 This is the key expression linking chamber pressure to propellant mass flow — used
-in all mass-balance ODEs throughout machwave.
+in all mass-balance ODEs throughout machwave. Evaluated in the choked branch of
+[`compute_chamber_pressure_mass_balance`][machwave.core.mass_balance.compute_chamber_pressure_mass_balance].
 
 ---
 

--- a/docs/theory/performance.md
+++ b/docs/theory/performance.md
@@ -31,7 +31,7 @@ numerically. The closed-form equivalent for a constant average thrust is:
 \]
 
 Implemented in
-[`get_total_impulse`](../api/core.md).
+[`get_total_impulse`][machwave.core.performance.get_total_impulse].
 
 ---
 
@@ -50,7 +50,7 @@ The unit *seconds* is universal: it does not depend on the unit system used for
 thrust or mass.
 
 Implemented in
-[`get_specific_impulse`](../api/core.md).
+[`get_specific_impulse`][machwave.core.performance.get_specific_impulse].
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,8 @@ repo_name: felipebogaertsm/machwave
 
 theme:
   name: material
+  logo: assets/logo/machwave-icon-white.svg
+  favicon: assets/logo/favicon.svg
   palette:
     - scheme: default
       primary: deep orange
@@ -58,6 +60,7 @@ nav:
           - compressible_flow: api/core/compressible_flow.md
           - interpolation: api/core/interpolation.md
           - mass_balance: api/core/mass_balance.md
+          - performance: api/core/performance.md
           - solvers: api/core/solvers.md
       - models:
           - Overview: api/models.md


### PR DESCRIPTION
Closes #330.

Reviews the docs against the source (verified with a strict `mkdocs build`) and revises for correctness and concision.

**Correctness**
- Biliquid propellant depletion (`theory/mass_balance.md` §2.3.3): rewritten to match the code — each stream is clamped independently to its remaining tank mass and the burn ends at first depletion, not the oxidiser-to-fuel-ratio-preserving adjustment the page previously described (which the implementation never performs).
- Nozzle theory §1.5: corrected the intermediate area-Mach step (the temperature factor was inverted; the final boxed relation was already correct).
- `api/core/compressible_flow.md`: nozzle losses re-attributed to Coats et al. (AFRPL-TR-75-36, 1975) and corrected to return a fraction in [0, 1], matching `losses.py`.

**Stale API (after the recent stateless-Tank refactor)**
- `feed_systems/tank.md`: stateless model — removed the deleted `remove_propellant()`.
- `feed_systems.md` and `thrust_chamber.md`: added the new mass arguments to the documented signatures.
- `grain/geometries.md`: fixed class names and the 2D/3D split, removed a non-existent geometry.
- `components.md`: `pressure_drop` is strictly positive.

**Links and pages**
- Fixed the broken Quick Start links and removed an inaccurate result-field description.
- Added a `core.performance` API page and wired it into the navigation; theory links now resolve.

**Polish**
- Added the project logo to the landing page and site theme.
- Spelled out abbreviations and tightened prose toward the `index.md` style.