### PR TITLE
Default FMM 3D segment port area to the nozzle-end slice

### DIFF
--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -41,7 +41,7 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
             density_ratio=density_ratio,
         )
 
-    def get_port_area(self, web_distance: float, z: float) -> float:
+    def get_port_area(self, web_distance: float, z: float = 0.0) -> float:
         """
         Calculates the port area at a given web distance and axial height z.
 
@@ -51,9 +51,9 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
 
         Args:
             web_distance: The distance traveled into the grain web.
-            z: Axial position (in meters) along the grain, where z=0 is the top
-                and z=self.length is the bottom (or vice versa, depending on
-                geometry setup).
+            z: Axial position (in meters) along the grain, measured from the aft
+                (nozzle) end, where z=0 is the nozzle end and z=self.length is the
+                far end. Defaults to the nozzle end.
 
         Returns:
             A float representing the port area at the specified z slice, in m^2.

--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -51,9 +51,8 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
 
         Args:
             web_distance: The distance traveled into the grain web.
-            z: Axial position (in meters) along the grain, measured from the aft
-                (nozzle) end, where z=0 is the nozzle end and z=self.length is the
-                far end. Defaults to the nozzle end.
+            z: Axial position along the grain [m], measured from the aft
+                (nozzle) end. Defaults to nozzle end.
 
         Returns:
             A float representing the port area at the specified z slice, in m^2.


### PR DESCRIPTION
`Grain.get_mass_flux_per_segment` calls `get_port_area` with no axial position, which raised `TypeError` for `FMMGrainSegment3D` segments and crashed result construction for every simulation using a 3D FMM segment (finocyl today). Default `z` to `0.0` (the nozzle end) so the aggregation works.

Scope: this is the segment-level part of #351. The grain-level aggregation still uses each segment's own port area rather than the aft-most segment's port; that redesign remains open.

Refs #351.