### PR TITLE
Deduplicate identical slices in 3D FMM burn-area regression

### DIFF
--- a/docs/api/models/grain/fmm.md
+++ b/docs/api/models/grain/fmm.md
@@ -1,11 +1,11 @@
 # models.grain.fmm
 
-Fast Marching Method (FMM) base classes for grain geometries with complex cross-sections that cannot be described analytically. FMM operates on a 2D (or 3D) distance map to compute burn area and port area as the flame front regresses inward.
+Fast Marching Method (FMM) base classes for grain geometries whose cross-section cannot be described analytically. The burning surface at any web distance is read off a single distance map of the initial port (solved with scikit-fmm), instead of re-meshing the geometry at every regression step.
 
-- `FMMGrainSegment` — Base class providing the distance-map regression logic.
-- `FMMGrainSegment2D` — Constant cross-section FMM geometries (Star, D-grain, wagon-wheel, multi-port, rod-and-tube).
-- `FMMGrainSegment3D` — Varying cross-section FMM geometries (Conical).
-- `FMMSTLGrainSegment` — Import arbitrary grain geometry from an STL mesh file.
+- `FMMGrainSegment` — Shared regression logic: builds the distance map and derives web thickness, the regressed face map, and port and burn area from it.
+- `FMMGrainSegment2D` — Constant cross-section geometries (Star, D-grain, wagon-wheel, multi-port, rod-and-tube). Burn area is the core perimeter (a single contour of the distance map) times the grain length, plus any exposed end faces.
+- `FMMGrainSegment3D` — Axially varying cross-section geometries (Conical, Finocyl). The port is a stack of axial slices through a 3D distance map; burn area integrates each slice's regressing perimeter along the length, and port area is read from a chosen slice.
+- `FMMSTLGrainSegment` — Arbitrary grain geometry imported from an STL mesh file.
 
 Used internally by the concrete geometry classes in [geometries](geometries.md).
 

--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -150,15 +150,26 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         web_distance = float(self.denormalize(map_dist))
         length_factor = self.get_length(web_distance=web_distance) / self.map_dim
 
+        # Slices with an identical boolean cross-section trace to an identical
+        # contour at this map_dist, so each distinct slice is traced only once.
+        perimeter_by_slice: dict[bytes, float] = {}
         total = 0.0
         for z_index in range(self.get_normalized_length()):
             boolean_slice_2d = boolean_3d[z_index]
-            contours = fmm_contours.get_contours(boolean_slice_2d, map_dist)
-            perimeter = sum(
-                self.map_to_length(fmm_contours.get_length(contour, self.map_dim))
-                for contour in contours
-            )
-            total += float(perimeter) * float(length_factor)
+            key = np.asarray(boolean_slice_2d).tobytes()
+            perimeter = perimeter_by_slice.get(key)
+            if perimeter is None:
+                contours = fmm_contours.get_contours(boolean_slice_2d, map_dist)
+                perimeter = float(
+                    sum(
+                        self.map_to_length(
+                            fmm_contours.get_length(contour, self.map_dim)
+                        )
+                        for contour in contours
+                    )
+                )
+                perimeter_by_slice[key] = perimeter
+            total += perimeter * float(length_factor)
 
         return float(total)
 

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 
 import machwave.models.grain as grain_models
+import machwave.models.grain.fmm.contours as fmm_contours
 import machwave.models.grain.geometries as grain_geometries
 
 # Aft-flush finned section over the lower 40% of the segment. The unfinned
@@ -52,6 +53,37 @@ def test_burn_area_is_positive_float(finocyl_segment):
         value = finocyl_segment.get_burn_area(web_distance)
         assert isinstance(value, float), f"Expected float, but got {type(value)}"
         assert value > 0
+
+
+def test_burn_area_dedup_matches_per_slice_sum(finocyl_segment):
+    """Slice deduplication must reproduce the brute-force per-slice perimeter sum.
+
+    ``_get_burn_area_uncached`` caches the traced perimeter per distinct slice;
+    this guards that the cache key never collapses slices that actually differ.
+    """
+    segment = finocyl_segment
+    map_dist = segment.normalize(segment.get_web_thickness() * 0.3)
+
+    valid = np.logical_not(segment.get_mask())
+    boolean_3d = np.logical_and(segment.get_regression_map() > map_dist, valid)
+    length_factor = (
+        segment.get_length(web_distance=float(segment.denormalize(map_dist)))
+        / segment.map_dim
+    )
+
+    # Reference: trace every slice independently, with no caching.
+    reference = 0.0
+    for z_index in range(segment.get_normalized_length()):
+        contours = fmm_contours.get_contours(boolean_3d[z_index], map_dist)
+        perimeter = sum(
+            segment.map_to_length(fmm_contours.get_length(contour, segment.map_dim))
+            for contour in contours
+        )
+        reference += float(perimeter) * float(length_factor)
+
+    assert segment._get_burn_area_uncached(map_dist=map_dist) == pytest.approx(
+        reference, rel=1e-12
+    )
 
 
 def test_port_area_returns_float(finocyl_segment):


### PR DESCRIPTION
## Summary

`_get_burn_area_uncached` in `machwave/models/grain/fmm/_3d.py` traced a contour (`skimage.measure.find_contours`) for every axial slice at every web step — `normalized_length × step_count` calls, ~94% of 3D regression-analysis runtime. Within a single web step, slices with an identical boolean cross-section trace to an identical contour, so the perimeter is now cached per distinct slice and reused. The result is exact (machine precision) and self-adapting: constant-section runs collapse to one trace, structured regions still trace each distinct slice.

## Linked issue

Closes #354

## Test plan

- [x] `make check` passes — `ruff format --check`, `ruff check .`, `pyright machwave` all clean
- [x] Affected suite passes — 69 FMM-3D tests (segment, CoG, MoI). Full `make test` not run; change is localized to `_get_burn_area_uncached`
- [x] New test covers the change — `test_burn_area_dedup_matches_per_slice_sum` asserts the deduplicated result equals a brute-force per-slice sum (`rel=1e-12`)
- [x] Manual verification — realistic finocyl burn-area build at map_dim=150: **48s → 9.8s (~4.9×)**, burn areas monotonic and physical. Prototype measured 9.5× (fully-finned) / 5.0× (tapered)

## Documentation

- [x] `docs/api/models/grain/fmm.md` sharpened: describes how 2D (single contour × length + end faces) and 3D (stacked-slice perimeter integration; port area from a chosen slice) compute their areas, and adds Finocyl to the 3D line

## Additional notes

- Constant-factor win; does **not** change the O(map_dim³) memory footprint.
- The cache key is the exact boolean slice, not its `count_nonzero` (equal cell counts can have different perimeters), and deduplication is per-web-step (the contour position depends on the iso-level).
- Optional follow-ups, not included: `np.packbits` key and one-time constant-interior-block detection to approach the ~16× theoretical ceiling.
