### PR TITLE
Apply combustion efficiency to the flame temperature in the solid motor

### DIFF
--- a/docs/theory/mass_balance.md
+++ b/docs/theory/mass_balance.md
@@ -121,6 +121,51 @@ as called from
 expansion term slightly lowers steady-state \(P_0\) and total impulse relative to
 a rigid-volume model.
 
+### 2.2.6 Combustion Efficiency
+
+*Reference: Sutton & Biblarz (2017), Ch. 3.*
+
+The **combustion efficiency** \(\eta_\text{comb}\) is the ratio of the actual to the
+ideal (adiabatic) flame temperature, stored per propellant and applied directly to
+the flame temperature in the chamber-pressure balance:
+
+\[
+\eta_\text{comb} = \frac{T_{0,\text{actual}}}{T_{0,\text{adiabatic}}},
+\qquad
+T_{0,\text{eff}} = \eta_\text{comb}\, T_{0,\text{adiabatic}}.
+\]
+
+It derates the characteristic-velocity (choked-outflow) term of §2.2.2 and is not
+applied to the thrust coefficient \(C_F\), which carries the nozzle losses of
+[nozzle losses](nozzle_losses.md).
+
+Characteristic velocity is \(c^* = \sqrt{R T_0}/\Gamma\) with
+\(\Gamma = \sqrt{k}\,(2/(k+1))^{(k+1)/[2(k-1)]}\), so \(c^* \propto \sqrt{T_0}\). The
+combustion efficiency is therefore distinct from the characteristic-velocity
+efficiency \(\eta_{c^*} = c^*_\text{actual}/c^*_\text{ideal}\):
+
+\[
+\eta_{c^*} = \sqrt{\eta_\text{comb}}, \qquad \eta_\text{comb} = \eta_{c^*}^{\,2}.
+\]
+
+Applying \(\eta_\text{comb}\) directly to \(T_0\) follows the Nakka SRM spreadsheet
+convention. With Saint Robert's law \(r = a P_0^n\) and
+\(P_0 = (K_n \rho_p a\, c^*)^{1/(1-n)}\):
+
+\[
+P_0 \propto \eta_\text{comb}^{\,1/[2(1-n)]},
+\qquad
+I_{sp} \propto \eta_{c^*} = \sqrt{\eta_\text{comb}}.
+\]
+
+\(T_{0,\text{eff}}\) is computed by
+[`get_effective_flame_temperature`][machwave.core.performance.get_effective_flame_temperature]
+and passed as `flame_temperature` to
+[`compute_chamber_pressure_mass_balance`][machwave.core.mass_balance.compute_chamber_pressure_mass_balance]
+from [`SolidMotorState`][machwave.simulation.solid.states.SolidMotorState]. As the
+actual chamber-gas temperature, it is used in both the outflow and storage terms of
+the §2.2.5 ODE.
+
 ---
 
 ## 2.3 Biliquid Rocket Engine

--- a/machwave/core/mass_balance.py
+++ b/machwave/core/mass_balance.py
@@ -26,7 +26,7 @@ def compute_chamber_pressure_mass_balance(
         throat_area: Nozzle throat area [m^2].
         k: Isentropic exponent of the mix.
         R: Gas constant per molecular weight [J/(kg-K)].
-        flame_temperature: Flame temperature [K].
+        flame_temperature: Effective flame temperature [K].
         nozzle_discharge_coefficient: Nozzle discharge coefficient.
         free_chamber_volume_rate: Rate of change of chamber free volume [m^3/s].
             Defaults to 0, i.e. constant free volume.

--- a/machwave/core/performance.py
+++ b/machwave/core/performance.py
@@ -5,6 +5,23 @@ import numpy.typing as npt
 import scipy.constants
 
 
+def get_effective_flame_temperature(
+    adiabatic_flame_temperature: float, combustion_efficiency: float
+) -> float:
+    """
+    Apply the combustion efficiency to the adiabatic flame temperature.
+
+    Args:
+        adiabatic_flame_temperature: Adiabatic flame temperature [K].
+        combustion_efficiency: Combustion efficiency in [0, 1], the ratio of the actual
+            to the ideal (adiabatic) flame temperature.
+
+    Returns:
+        Effective flame temperature [K].
+    """
+    return combustion_efficiency * adiabatic_flame_temperature
+
+
 def get_total_impulse(
     thrust: npt.NDArray[np.float64],
     time: npt.NDArray[np.float64],

--- a/machwave/models/propellants/categories/base.py
+++ b/machwave/models/propellants/categories/base.py
@@ -45,7 +45,8 @@ class Propellant(abc.ABC):
         Args:
             name: Propellant name.
             components: Chemical components. If None, defaults to empty list.
-            combustion_efficiency: Efficiency factor (0-1).
+            combustion_efficiency: Combustion efficiency in [0, 1], the ratio of the
+                actual to the ideal (adiabatic) flame temperature.
         """
         self.name = name
         self.components = list(components or [])

--- a/machwave/models/propellants/categories/solid.py
+++ b/machwave/models/propellants/categories/solid.py
@@ -46,7 +46,8 @@ class SolidPropellant(propellant_base.Propellant):
                 one oxidizer and one fuel.
             mass_fractions: Mass fractions aligned with `components`. Must
                 sum to 1.0.
-            combustion_efficiency: Efficiency factor in [0, 1].
+            combustion_efficiency: Combustion efficiency in [0, 1], the ratio of the
+                actual to the ideal (adiabatic) flame temperature.
             properties: Pre-defined thermochemical properties. Optional
                 override used by `evaluate()` to skip CEA when provided.
             burn_rate_map: Saint Robert's law coefficients by pressure range.

--- a/machwave/simulation/solid/results.py
+++ b/machwave/simulation/solid/results.py
@@ -32,7 +32,6 @@ class SolidSimulationResult(
     boundary_layer_loss: simulation_results.SimulationResultArray
     two_phase_loss: simulation_results.SimulationResultArray
     nozzle_efficiency: simulation_results.SimulationResultArray
-    overall_efficiency: simulation_results.SimulationResultArray
     propellant_cog: simulation_results.SimulationResultArray
     propellant_moi: simulation_results.SimulationResultArray
     # klemmung is filtered to burn_area > 0, so its length is < len(time).
@@ -83,7 +82,6 @@ class SolidSimulationResult(
             "boundary_layer_loss": np.asarray(state.boundary_layer_loss),
             "two_phase_loss": np.asarray(state.two_phase_loss),
             "nozzle_efficiency": np.asarray(state.nozzle_efficiency),
-            "overall_efficiency": np.asarray(state.overall_efficiency),
             "propellant_cog": np.stack(
                 [np.asarray(cog) for cog in state.propellant_cog]
             ),
@@ -206,10 +204,6 @@ class SolidSimulationResult(
         print("\nNOZZLE DESIGN", file=file)
         print(
             f" Average nozzle efficiency: {np.mean(self.nozzle_efficiency):.3%}",
-            file=file,
-        )
-        print(
-            f" Average overall efficiency: {np.mean(self.overall_efficiency):.3%}",
             file=file,
         )
         print(

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -8,6 +8,7 @@ import machwave.core.compressible_flow.losses as losses
 import machwave.core.compressible_flow.nozzle as nozzle_core
 import machwave.core.conversions as conversions
 import machwave.core.mass_balance as mass_balance
+import machwave.core.performance as performance
 import machwave.core.solvers.rk4 as rk4
 import machwave.models.motors as motors
 import machwave.simulation.solid.results as solid_results
@@ -79,7 +80,6 @@ class SolidMotorState(simulation_states.MotorState):
         self.boundary_layer_loss: simulation_states.SimulationStateArray = []
         self.two_phase_loss: simulation_states.SimulationStateArray = []
         self.nozzle_efficiency: simulation_states.SimulationStateArray = []
-        self.overall_efficiency: simulation_states.SimulationStateArray = []
 
     def get_m_dot_in(self) -> float:
         """Return the propellant mass generation rate from the grain [kg/s]."""
@@ -193,15 +193,11 @@ class SolidMotorState(simulation_states.MotorState):
             two_phase_loss,
             other_losses=self.other_losses,
         )
-        overall_efficiency = (
-            nozzle_efficiency * self.motor.propellant.combustion_efficiency
-        )
         self.divergent_loss.append(divergent_loss)
         self.kinetics_loss.append(kinetics_loss)
         self.boundary_layer_loss.append(boundary_layer_loss)
         self.two_phase_loss.append(two_phase_loss)
         self.nozzle_efficiency.append(nozzle_efficiency)
-        self.overall_efficiency.append(overall_efficiency)
 
         ideal_thrust_coefficient = nozzle_core.get_ideal_thrust_coefficient(
             chamber_pressure,
@@ -212,7 +208,7 @@ class SolidMotorState(simulation_states.MotorState):
         )
         self.ideal_thrust_coefficient.append(ideal_thrust_coefficient)
         thrust_coefficient = nozzle_core.apply_thrust_coefficient_correction(
-            ideal_thrust_coefficient, overall_efficiency
+            ideal_thrust_coefficient, nozzle_efficiency
         )
         self.thrust_coefficient.append(thrust_coefficient)
         thrust = nozzle_core.get_thrust_from_thrust_coefficient(
@@ -239,6 +235,10 @@ class SolidMotorState(simulation_states.MotorState):
         self.time.append(new_time)
         new_web_distance = web_distance + web_consumed
         self.web.append(new_web_distance)
+        effective_flame_temperature = performance.get_effective_flame_temperature(
+            adiabatic_flame_temperature=propellant_properties.adiabatic_flame_temperature,
+            combustion_efficiency=self.motor.propellant.combustion_efficiency,
+        )
         new_chamber_pressure = rk4.rk4th_ode_solver(
             variables={"chamber_pressure": self.chamber_pressure[-1]},
             equation=mass_balance.compute_chamber_pressure_mass_balance,
@@ -249,7 +249,7 @@ class SolidMotorState(simulation_states.MotorState):
             throat_area=nozzle.get_throat_area(),
             k=propellant_properties.k_chamber,
             R=propellant_properties.R_chamber,
-            flame_temperature=propellant_properties.adiabatic_flame_temperature,
+            flame_temperature=effective_flame_temperature,
             nozzle_discharge_coefficient=nozzle.discharge_coefficient,
             free_chamber_volume_rate=free_chamber_volume_rate,
         )[0]

--- a/tests/test_core/test_performance.py
+++ b/tests/test_core/test_performance.py
@@ -25,3 +25,31 @@ def test_get_specific_impulse():
         total_impulse, initial_propellant_mass
     )
     assert specific_impulse == pytest.approx(2.542, rel=1e-2)
+
+
+def test_effective_flame_temperature_unity_efficiency_is_unchanged():
+    """An efficiency of 1.0 returns the flame temperature untouched."""
+    assert core_performance.get_effective_flame_temperature(
+        adiabatic_flame_temperature=2_800.0, combustion_efficiency=1.0
+    ) == pytest.approx(2_800.0)
+
+
+@pytest.mark.parametrize(
+    "combustion_efficiency, adiabatic_flame_temperature, expected",
+    [
+        (0.95, 2_800.0, 0.95 * 2_800.0),
+        (0.5, 2_800.0, 1_400.0),  # the efficiency scales the temperature directly
+    ],
+)
+def test_effective_flame_temperature_applies_efficiency_linearly(
+    combustion_efficiency, adiabatic_flame_temperature, expected
+):
+    """T_eff = combustion_efficiency * T0 (a flame-temperature efficiency).
+
+    The characteristic-velocity efficiency is the square root of this value, since
+    c_star scales with sqrt(T).
+    """
+    assert core_performance.get_effective_flame_temperature(
+        adiabatic_flame_temperature=adiabatic_flame_temperature,
+        combustion_efficiency=combustion_efficiency,
+    ) == pytest.approx(expected)


### PR DESCRIPTION
## Summary

Moves the propellant `combustion_efficiency` off the thrust coefficient and onto the characteristic-velocity side of the solid-motor chamber-pressure balance.

- `combustion_efficiency` is now a flame-temperature efficiency, `eta_comb = T0_actual / T0_adiabatic`, applied directly to the flame temperature through a new `get_effective_flame_temperature` helper: `T0_eff = eta_comb * T0`.
- It is removed from the thrust-coefficient correction, which now carries only the nozzle losses.
- Because characteristic velocity scales with the square root of the flame temperature, this derates the characteristic velocity by `sqrt(eta_comb)`; the relationship to the characteristic-velocity efficiency (`eta_c_star = sqrt(eta_comb)`, `eta_comb = eta_c_star ** 2`) is documented.
- Theory page section 2.2.6 documents the convention (which matches the Nakka solid-rocket-motor spreadsheet) and the relationship between the two efficiencies.

Stored `combustion_efficiency` values are unchanged (~0.95). Before this change the efficiency was applied linearly to the thrust coefficient, so it reduced delivered performance but left chamber pressure un-derated.

## Before / after at `eta_comb = 0.95`

### Effective combustion temperature [K] (now derated)

| Motor | Adiabatic T0 | Before | After | Change |
|---|---|---|---|---|
| apcp | 2800.0 | 2800.0 | 2660.0 | -5.0% |
| kappa_rnakka | 1712.0 | 1712.0 | 1626.4 | -5.0% |
| nero | 1712.0 | 1712.0 | 1626.4 | -5.0% |

### Chamber pressure [MPa] (now derated)

| Motor | Peak before | Peak after | Change | Mean before | Mean after | Change |
|---|---|---|---|---|---|---|
| apcp | 5.564 | 5.356 | -3.7% | 5.199 | 5.006 | -3.7% |
| kappa_rnakka | 8.157 | 7.974 | -2.2% | 7.434 | 7.261 | -2.3% |
| nero | 7.526 | 7.358 | -2.2% | 6.706 | 6.555 | -2.3% |

The pressure derate is `eta_comb ** (1 / (2 * (1 - n)))`; it is larger for APCP (n ~ 0.33 in its operating band) than for the KNDX motors (n ~ -0.15).

### Delivered performance

| Motor | Specific impulse before [s] | after [s] | Change | Total impulse before [N-s] | after [N-s] | Change | Peak thrust before [N] | after [N] | Change |
|---|---|---|---|---|---|---|---|---|---|
| apcp | 185.1 | 189.6 | +2.4% | 10761.6 | 11021.0 | +2.4% | 2529.5 | 2556.9 | +1.1% |
| kappa_rnakka | 117.1 | 120.0 | +2.5% | 1824.6 | 1869.8 | +2.5% | 1319.4 | 1357.3 | +2.9% |
| nero | 114.4 | 117.7 | +2.9% | 647.2 | 665.7 | +2.9% | 658.5 | 677.7 | +2.9% |

Specific impulse and total impulse rise by about 2.5% because the loss now enters as `sqrt(eta_comb)` on the characteristic velocity (-2.5%) rather than as `eta_comb` on the thrust coefficient (-5%).

Closes #340
