### PR TITLE
Move combustion efficiency from the propellant to the motor

### DIFF
--- a/examples/1kn_biliquid_engine.py
+++ b/examples/1kn_biliquid_engine.py
@@ -35,7 +35,6 @@ def main():
     propellant = propellants.BiliquidPropellant(
         name=f"{OXIDIZER_NAME}/{FUEL_NAME}",
         components=[oxidizer, fuel],
-        combustion_efficiency=0.98,
         oxidizer_to_fuel_ratio=1.9495,
     )
 
@@ -91,6 +90,7 @@ def main():
         thrust_chamber=thrust_chamber,
         oxidizer_tank_cog=0.5,
         fuel_tank_cog=0.4,
+        combustion_efficiency=0.98,
     )
 
     sim_params = simulation_module.InternalBallisticsSimulationParams(

--- a/examples/apcp_motor.py
+++ b/examples/apcp_motor.py
@@ -53,7 +53,10 @@ def main():
     )
 
     motor = motors_models.SolidMotor(
-        grain=grain, propellant=propellant, thrust_chamber=thrust_chamber
+        grain=grain,
+        propellant=propellant,
+        thrust_chamber=thrust_chamber,
+        combustion_efficiency=0.95,
     )
 
     params = simulation.InternalBallisticsSimulationParams(

--- a/examples/biliquid_propellant_composition.py
+++ b/examples/biliquid_propellant_composition.py
@@ -25,7 +25,6 @@ def main() -> None:
     loxlh2 = propellant_categories.BiliquidPropellant(
         name="LOX/LH2",
         components=[lox, lh2],
-        combustion_efficiency=0.99,
         oxidizer_to_fuel_ratio=6.0,
     )
 

--- a/examples/finocyl_motor.py
+++ b/examples/finocyl_motor.py
@@ -48,7 +48,10 @@ def main():
     )
 
     motor = motors_models.SolidMotor(
-        grain=grain, propellant=propellant, thrust_chamber=thrust_chamber
+        grain=grain,
+        propellant=propellant,
+        thrust_chamber=thrust_chamber,
+        combustion_efficiency=0.95,
     )
 
     params = simulation.InternalBallisticsSimulationParams(

--- a/examples/kappa_rnakka.py
+++ b/examples/kappa_rnakka.py
@@ -51,7 +51,10 @@ def main():
     )
 
     motor = motors_models.SolidMotor(
-        grain=grain, propellant=propellant, thrust_chamber=thrust_chamber
+        grain=grain,
+        propellant=propellant,
+        thrust_chamber=thrust_chamber,
+        combustion_efficiency=0.95,
     )
 
     params = simulation.InternalBallisticsSimulationParams(

--- a/examples/nero_motor.py
+++ b/examples/nero_motor.py
@@ -52,7 +52,10 @@ def main():
     )
 
     motor = motors_models.SolidMotor(
-        grain=grain, propellant=propellant, thrust_chamber=thrust_chamber
+        grain=grain,
+        propellant=propellant,
+        thrust_chamber=thrust_chamber,
+        combustion_efficiency=0.95,
     )
 
     params = simulation.InternalBallisticsSimulationParams(

--- a/examples/olympus.py
+++ b/examples/olympus.py
@@ -65,6 +65,7 @@ def main():
         grain=grain,
         propellant=propellant,
         thrust_chamber=thrust_chamber,
+        combustion_efficiency=0.95,
     )
 
     params = simulation.InternalBallisticsSimulationParams(

--- a/examples/olympus_montecarlo.py
+++ b/examples/olympus_montecarlo.py
@@ -60,6 +60,7 @@ def main():
         grain=grain,
         propellant=propellant,
         thrust_chamber=thrust_chamber,
+        combustion_efficiency=0.95,
     )
 
     ib_params = simulation.InternalBallisticsSimulationParams(

--- a/examples/rocketpy_srm_simulation.py
+++ b/examples/rocketpy_srm_simulation.py
@@ -59,6 +59,7 @@ def main():
         grain=grain,
         propellant=propellant,
         thrust_chamber=thrust_chamber,
+        combustion_efficiency=0.95,
     )
 
     # 2. Run machwave internal ballistics simulation

--- a/examples/solid_propellant_composition.py
+++ b/examples/solid_propellant_composition.py
@@ -26,7 +26,6 @@ def main() -> None:
         name="KNSU",
         components=[potassium_nitrate, sucrose],
         mass_fractions=[0.65, 0.35],
-        combustion_efficiency=0.95,
         burn_rate_map=[{"min": 0, "max": 100000000, "a": 8.260, "n": 0.319}],
     )
 

--- a/machwave/core/performance.py
+++ b/machwave/core/performance.py
@@ -13,7 +13,7 @@ def get_effective_flame_temperature(
 
     Args:
         adiabatic_flame_temperature: Adiabatic flame temperature [K].
-        combustion_efficiency: Combustion efficiency in [0, 1], the ratio of the actual
+        combustion_efficiency: Combustion efficiency in (0, 1], the ratio of the actual
             to the ideal (adiabatic) flame temperature.
 
     Returns:

--- a/machwave/models/motors/base.py
+++ b/machwave/models/motors/base.py
@@ -18,6 +18,7 @@ class Motor(Generic[P, T], ABC):
         self,
         propellant: P,
         thrust_chamber: T,
+        combustion_efficiency: float = 0.95,
     ) -> None:
         """
         Initialize attributes common to any motor or engine.
@@ -25,9 +26,21 @@ class Motor(Generic[P, T], ABC):
         Args:
             propellant: Propellant used in the motor.
             thrust_chamber: Thrust chamber of the motor.
+            combustion_efficiency: Ratio of the of the actual flame temperature to the
+                ideal adiabatic flame temperature (0, 1].
+
+        Raises:
+            ValueError: If `combustion_efficiency` is not in (0, 1].
         """
+        if not 0.0 < combustion_efficiency <= 1.0:
+            raise ValueError(
+                "combustion_efficiency must be in the range (0, 1], got "
+                f"{combustion_efficiency}"
+            )
+
         self.propellant = propellant
         self.thrust_chamber = thrust_chamber
+        self.combustion_efficiency = combustion_efficiency
 
     @abstractmethod
     def get_launch_mass(self) -> float:

--- a/machwave/models/motors/base.py
+++ b/machwave/models/motors/base.py
@@ -26,8 +26,8 @@ class Motor(Generic[P, T], ABC):
         Args:
             propellant: Propellant used in the motor.
             thrust_chamber: Thrust chamber of the motor.
-            combustion_efficiency: Ratio of the of the actual flame temperature to the
-                ideal adiabatic flame temperature (0, 1].
+            combustion_efficiency: Ratio of the actual flame temperature to the ideal
+                adiabatic flame temperature (0, 1].
 
         Raises:
             ValueError: If `combustion_efficiency` is not in (0, 1].

--- a/machwave/models/motors/biliquid.py
+++ b/machwave/models/motors/biliquid.py
@@ -22,6 +22,7 @@ class BiliquidEngine(
         feed_system: feed_system_base.FeedSystem,
         oxidizer_tank_cog: float | None = None,
         fuel_tank_cog: float | None = None,
+        combustion_efficiency: float = 0.95,
     ) -> None:
         """
         Initialize a biliquid rocket engine.
@@ -38,8 +39,10 @@ class BiliquidEngine(
             fuel_tank_cog: Axial position of the fuel propellant center of
                 gravity, measured from the nozzle exit [m]. If None, uses a
                 default estimate.
+            combustion_efficiency: Ratio of the of the actual flame temperature to the
+                ideal adiabatic flame temperature (0, 1].
         """
-        super().__init__(propellant, thrust_chamber)
+        super().__init__(propellant, thrust_chamber, combustion_efficiency)
         self.feed_system = feed_system
         self.oxidizer_tank_cog = oxidizer_tank_cog
         self.fuel_tank_cog = fuel_tank_cog

--- a/machwave/models/motors/biliquid.py
+++ b/machwave/models/motors/biliquid.py
@@ -39,8 +39,8 @@ class BiliquidEngine(
             fuel_tank_cog: Axial position of the fuel propellant center of
                 gravity, measured from the nozzle exit [m]. If None, uses a
                 default estimate.
-            combustion_efficiency: Ratio of the of the actual flame temperature to the
-                ideal adiabatic flame temperature (0, 1].
+            combustion_efficiency: Ratio of the actual flame temperature to the ideal
+                adiabatic flame temperature (0, 1].
         """
         super().__init__(propellant, thrust_chamber, combustion_efficiency)
         self.feed_system = feed_system

--- a/machwave/models/motors/solid.py
+++ b/machwave/models/motors/solid.py
@@ -19,6 +19,7 @@ class SolidMotor(
         grain: grain.Grain,
         propellant: propellants.SolidPropellant,
         thrust_chamber: thrust_chamber.SolidMotorThrustChamber,
+        combustion_efficiency: float = 0.95,
     ) -> None:
         """
         Initialize a solid rocket motor.
@@ -27,8 +28,10 @@ class SolidMotor(
             grain: Grain geometry configuration.
             propellant: Solid propellant properties.
             thrust_chamber: Thrust chamber model.
+            combustion_efficiency: Ratio of the of the actual flame temperature to the
+                ideal adiabatic flame temperature (0, 1].
         """
-        super().__init__(propellant, thrust_chamber)
+        super().__init__(propellant, thrust_chamber, combustion_efficiency)
 
         self.grain = grain
         self.propellant: propellants.SolidPropellant = propellant

--- a/machwave/models/motors/solid.py
+++ b/machwave/models/motors/solid.py
@@ -28,8 +28,8 @@ class SolidMotor(
             grain: Grain geometry configuration.
             propellant: Solid propellant properties.
             thrust_chamber: Thrust chamber model.
-            combustion_efficiency: Ratio of the of the actual flame temperature to the
-                ideal adiabatic flame temperature (0, 1].
+            combustion_efficiency: Ratio of the actual flame temperature to the ideal
+                adiabatic flame temperature (0, 1].
         """
         super().__init__(propellant, thrust_chamber, combustion_efficiency)
 

--- a/machwave/models/propellants/categories/base.py
+++ b/machwave/models/propellants/categories/base.py
@@ -37,7 +37,6 @@ class Propellant(abc.ABC):
         self,
         name: str,
         components: list[propellant_components.PropellantComponent] | None = None,
-        combustion_efficiency: float = 0.95,
     ):
         """
         Initialize a propellant.
@@ -45,12 +44,9 @@ class Propellant(abc.ABC):
         Args:
             name: Propellant name.
             components: Chemical components. If None, defaults to empty list.
-            combustion_efficiency: Combustion efficiency in [0, 1], the ratio of the
-                actual to the ideal (adiabatic) flame temperature.
         """
         self.name = name
         self.components = list(components or [])
-        self.combustion_efficiency = combustion_efficiency
 
     @functools.cached_property
     def thermochemical_service(self) -> cea_service.RocketCEAService:

--- a/machwave/models/propellants/categories/biliquid.py
+++ b/machwave/models/propellants/categories/biliquid.py
@@ -13,7 +13,6 @@ class BiliquidPropellant(propellant_base.Propellant):
         self,
         name: str,
         components: list[propellant_components.PropellantComponent] | None = None,
-        combustion_efficiency: float = 0.95,
         oxidizer_to_fuel_ratio: float | None = None,
     ):
         """
@@ -22,7 +21,6 @@ class BiliquidPropellant(propellant_base.Propellant):
         Args:
             name: Propellant name.
             components: Chemical components (should be exactly 2: oxidizer and fuel).
-            combustion_efficiency: Efficiency factor (0-1).
             oxidizer_to_fuel_ratio: Oxidizer-to-fuel mass ratio for this
                 formulation. Used as the default mixture_ratio at the
                 thermochemical service layer; callers can override per-call
@@ -35,7 +33,6 @@ class BiliquidPropellant(propellant_base.Propellant):
         super().__init__(
             name=name,
             components=components,
-            combustion_efficiency=combustion_efficiency,
         )
 
         self.oxidizer_to_fuel_ratio = oxidizer_to_fuel_ratio

--- a/machwave/models/propellants/categories/solid.py
+++ b/machwave/models/propellants/categories/solid.py
@@ -33,7 +33,6 @@ class SolidPropellant(propellant_base.Propellant):
         name: str,
         components: list[propellant_components.PropellantComponent] | None = None,
         mass_fractions: list[float] | None = None,
-        combustion_efficiency: float = 0.95,
         properties: propellant_properties.ThermochemicalProperties | None = None,
         burn_rate_map: list[dict[str, float | int]] | None = None,
     ):
@@ -46,8 +45,6 @@ class SolidPropellant(propellant_base.Propellant):
                 one oxidizer and one fuel.
             mass_fractions: Mass fractions aligned with `components`. Must
                 sum to 1.0.
-            combustion_efficiency: Combustion efficiency in [0, 1], the ratio of the
-                actual to the ideal (adiabatic) flame temperature.
             properties: Pre-defined thermochemical properties. Optional
                 override used by `evaluate()` to skip CEA when provided.
             burn_rate_map: Saint Robert's law coefficients by pressure range.
@@ -59,7 +56,6 @@ class SolidPropellant(propellant_base.Propellant):
         super().__init__(
             name=name,
             components=components,
-            combustion_efficiency=combustion_efficiency,
         )
 
         self._properties = properties

--- a/machwave/models/propellants/formulations/base.py
+++ b/machwave/models/propellants/formulations/base.py
@@ -157,7 +157,6 @@ def _create_propellant(
             name=data["name"],
             components=components,
             mass_fractions=mass_fractions,
-            combustion_efficiency=data.get("combustion_efficiency", 0.95),
             properties=properties,
             burn_rate_map=data.get("burn_rate_map", data.get("burn_rate", [])),
         )
@@ -165,7 +164,6 @@ def _create_propellant(
         return propellant_categories.BiliquidPropellant(
             name=data["name"],
             components=components,
-            combustion_efficiency=data.get("combustion_efficiency", 0.98),
             oxidizer_to_fuel_ratio=data.get("oxidizer_to_fuel_ratio"),
         )
     else:

--- a/machwave/models/propellants/formulations/biliquid/lox_lh2_6_0.json
+++ b/machwave/models/propellants/formulations/biliquid/lox_lh2_6_0.json
@@ -21,6 +21,5 @@
       "temperature": 298.15
     }
   ],
-  "oxidizer_to_fuel_ratio": 6.0,
-  "combustion_efficiency": 0.98
+  "oxidizer_to_fuel_ratio": 6.0
 }

--- a/machwave/models/propellants/formulations/solid/kndx.json
+++ b/machwave/models/propellants/formulations/solid/kndx.json
@@ -38,6 +38,5 @@
     "i_sp_shifting": 154.1,
     "qsi_chamber": 0.307,
     "qsi_exhaust": 0.321
-  },
-  "combustion_efficiency": 0.95
+  }
 }

--- a/machwave/models/propellants/formulations/solid/kner.json
+++ b/machwave/models/propellants/formulations/solid/kner.json
@@ -34,6 +34,5 @@
     "i_sp_shifting": 156.0,
     "qsi_chamber": 0.315,
     "qsi_exhaust": 0.321
-  },
-  "combustion_efficiency": 0.94
+  }
 }

--- a/machwave/models/propellants/formulations/solid/knsb.json
+++ b/machwave/models/propellants/formulations/solid/knsb.json
@@ -34,6 +34,5 @@
     "i_sp_shifting": 153.5,
     "qsi_chamber": 0.316,
     "qsi_exhaust": 0.321
-  },
-  "combustion_efficiency": 0.95
+  }
 }

--- a/machwave/models/propellants/formulations/solid/knsb_nakka.json
+++ b/machwave/models/propellants/formulations/solid/knsb_nakka.json
@@ -38,6 +38,5 @@
     "i_sp_shifting": 153.5,
     "qsi_chamber": 0.316,
     "qsi_exhaust": 0.321
-  },
-  "combustion_efficiency": 0.95
+  }
 }

--- a/machwave/models/propellants/formulations/solid/knsu.json
+++ b/machwave/models/propellants/formulations/solid/knsu.json
@@ -34,6 +34,5 @@
     "i_sp_shifting": 155.1,
     "qsi_chamber": 0.306,
     "qsi_exhaust": 0.321
-  },
-  "combustion_efficiency": 0.95
+  }
 }

--- a/machwave/models/propellants/formulations/solid/mit_cherry_limeade.json
+++ b/machwave/models/propellants/formulations/solid/mit_cherry_limeade.json
@@ -43,6 +43,5 @@
     "i_sp_shifting": 245.1,
     "qsi_chamber": 0.138,
     "qsi_exhaust": 0.139
-  },
-  "combustion_efficiency": 0.95
+  }
 }

--- a/machwave/models/propellants/formulations/solid/rnx_57.json
+++ b/machwave/models/propellants/formulations/solid/rnx_57.json
@@ -43,6 +43,5 @@
     "i_sp_shifting": 158.1,
     "qsi_chamber": 0.306,
     "qsi_exhaust": 0.321
-  },
-  "combustion_efficiency": 0.85
+  }
 }

--- a/machwave/models/propellants/formulations/solid/rnx_71v.json
+++ b/machwave/models/propellants/formulations/solid/rnx_71v.json
@@ -43,6 +43,5 @@
     "i_sp_shifting": 153.6,
     "qsi_chamber": 0.306,
     "qsi_exhaust": 0.321
-  },
-  "combustion_efficiency": 0.85
+  }
 }

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -164,9 +164,7 @@ class BiliquidEngineState(simulation_states.MotorState):
         nozzle_efficiency = losses.get_overall_nozzle_efficiency(
             divergent_loss, kinetics_loss, 0.0, 0.0, other_losses=self.other_losses
         )
-        nozzle_correction_factor = (
-            nozzle_efficiency * self.motor.propellant.combustion_efficiency
-        )
+        nozzle_correction_factor = nozzle_efficiency * self.motor.combustion_efficiency
         self.nozzle_correction_factor.append(nozzle_correction_factor)
 
         ideal_thrust_coefficient = nozzle_core.get_ideal_thrust_coefficient(

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -237,7 +237,7 @@ class SolidMotorState(simulation_states.MotorState):
         self.web.append(new_web_distance)
         effective_flame_temperature = performance.get_effective_flame_temperature(
             adiabatic_flame_temperature=propellant_properties.adiabatic_flame_temperature,
-            combustion_efficiency=self.motor.propellant.combustion_efficiency,
+            combustion_efficiency=self.motor.combustion_efficiency,
         )
         new_chamber_pressure = rk4.rk4th_ode_solver(
             variables={"chamber_pressure": self.chamber_pressure[-1]},

--- a/tests/factories/propellants.py
+++ b/tests/factories/propellants.py
@@ -147,7 +147,6 @@ class BiliquidPropellantFactory:
         kwargs: dict[str, Any] = dict(
             name="N2O/Ethanol",
             components=component_list,
-            combustion_efficiency=0.98,
             oxidizer_to_fuel_ratio=2.0,
         )
         kwargs.update(overrides)

--- a/tests/test_models/test_propulsion/test_motors/test_combustion_efficiency.py
+++ b/tests/test_models/test_propulsion/test_motors/test_combustion_efficiency.py
@@ -1,0 +1,49 @@
+"""Combustion efficiency lives on the motor, not the propellant."""
+
+import pytest
+
+import machwave.models.propellants.formulations.solid as solid_propellants
+
+from tests.factories import BiliquidEngineFactory, SolidMotorFactory
+
+
+def test_solid_motor_defaults_to_0_95():
+    """A solid motor built without an explicit value uses the 0.95 default."""
+    motor = SolidMotorFactory.build()
+    assert motor.combustion_efficiency == 0.95
+
+
+def test_biliquid_engine_defaults_to_0_95():
+    """A biliquid engine built without an explicit value uses the 0.95 default."""
+    engine = BiliquidEngineFactory.build()
+    assert engine.combustion_efficiency == 0.95
+
+
+def test_solid_motor_accepts_explicit_value():
+    """An explicit combustion efficiency overrides the default."""
+    motor = SolidMotorFactory.build(combustion_efficiency=0.88)
+    assert motor.combustion_efficiency == 0.88
+
+
+def test_biliquid_engine_carries_combustion_efficiency():
+    """The biliquid engine exposes combustion efficiency at the motor level."""
+    engine = BiliquidEngineFactory.build(combustion_efficiency=0.97)
+    assert engine.combustion_efficiency == 0.97
+
+
+def test_unitary_efficiency_is_allowed():
+    """An efficiency of 1.0 (ideal adiabatic limit) is a valid input."""
+    motor = SolidMotorFactory.build(combustion_efficiency=1.0)
+    assert motor.combustion_efficiency == 1.0
+
+
+@pytest.mark.parametrize("value", [-0.1, 0.0, 1.01, 2.0])
+def test_out_of_range_efficiency_raises(value):
+    """Values outside (0, 1] are rejected at construction."""
+    with pytest.raises(ValueError, match="combustion_efficiency"):
+        SolidMotorFactory.build(combustion_efficiency=value)
+
+
+def test_propellant_no_longer_carries_combustion_efficiency():
+    """Combustion efficiency was moved off the propellant entirely."""
+    assert not hasattr(solid_propellants.KNDX, "combustion_efficiency")

--- a/tests/test_models/test_propulsion/test_motors/test_combustion_efficiency.py
+++ b/tests/test_models/test_propulsion/test_motors/test_combustion_efficiency.py
@@ -4,7 +4,11 @@ import pytest
 
 import machwave.models.propellants.formulations.solid as solid_propellants
 
-from tests.factories import BiliquidEngineFactory, SolidMotorFactory
+from tests.factories import (
+    BiliquidEngineFactory,
+    BiliquidPropellantFactory,
+    SolidMotorFactory,
+)
 
 
 def test_solid_motor_defaults_to_0_95():
@@ -31,19 +35,22 @@ def test_biliquid_engine_carries_combustion_efficiency():
     assert engine.combustion_efficiency == 0.97
 
 
-def test_unitary_efficiency_is_allowed():
-    """An efficiency of 1.0 (ideal adiabatic limit) is a valid input."""
-    motor = SolidMotorFactory.build(combustion_efficiency=1.0)
-    assert motor.combustion_efficiency == 1.0
+@pytest.mark.parametrize("value", [1e-9, 1.0])
+def test_boundary_values_are_allowed(value):
+    """The open-lower/closed-upper range (0, 1] accepts near-zero and unity."""
+    motor = SolidMotorFactory.build(combustion_efficiency=value)
+    assert motor.combustion_efficiency == value
 
 
+@pytest.mark.parametrize("factory", [SolidMotorFactory, BiliquidEngineFactory])
 @pytest.mark.parametrize("value", [-0.1, 0.0, 1.01, 2.0])
-def test_out_of_range_efficiency_raises(value):
-    """Values outside (0, 1] are rejected at construction."""
+def test_out_of_range_efficiency_raises(factory, value):
+    """Values outside (0, 1] are rejected at construction, for every motor type."""
     with pytest.raises(ValueError, match="combustion_efficiency"):
-        SolidMotorFactory.build(combustion_efficiency=value)
+        factory.build(combustion_efficiency=value)
 
 
 def test_propellant_no_longer_carries_combustion_efficiency():
-    """Combustion efficiency was moved off the propellant entirely."""
+    """Combustion efficiency was moved off both propellant categories."""
     assert not hasattr(solid_propellants.KNDX, "combustion_efficiency")
+    assert not hasattr(BiliquidPropellantFactory.build(), "combustion_efficiency")

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_base.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_base.py
@@ -243,7 +243,6 @@ class TestCreatePropellant:
     def test_create_solid_propellant(self):
         data = {
             "name": "Test Solid",
-            "combustion_efficiency": 0.95,
             "burn_rate_map": [{"min": 0, "max": 1e7, "a": 5.0, "n": 0.5}],
         }
         components = [
@@ -275,13 +274,11 @@ class TestCreatePropellant:
 
         assert isinstance(result, propellant_categories.SolidPropellant)
         assert result.name == "Test Solid"
-        assert result.combustion_efficiency == 0.95
         assert len(result.burn_rate_map) == 1
 
     def test_create_biliquid_propellant(self):
         data = {
             "name": "Test Biliquid",
-            "combustion_efficiency": 0.98,
             "oxidizer_to_fuel_ratio": 2.5,
         }
         components = [
@@ -313,59 +310,4 @@ class TestCreatePropellant:
 
         assert isinstance(result, propellant_categories.BiliquidPropellant)
         assert result.name == "Test Biliquid"
-        assert result.combustion_efficiency == 0.98
         assert result.oxidizer_to_fuel_ratio == 2.5
-
-    def test_create_solid_with_default_efficiency(self):
-        data = {"name": "Test"}
-        components = [
-            propellant_components.PropellantComponent(
-                name="KNO3",
-                role=propellant_components.ComponentRole.OXIDIZER,
-                density=2109.0,
-                chemical_formula={"K": 1, "N": 1, "O": 3},
-                enthalpy=-494600.0,
-            ),
-            propellant_components.PropellantComponent(
-                name="Sucrose",
-                role=propellant_components.ComponentRole.FUEL,
-                density=1587.0,
-                chemical_formula={"C": 12, "H": 22, "O": 11},
-                enthalpy=-2226100.0,
-            ),
-        ]
-        result = formulations_base._create_propellant(
-            propellant_categories.MixtureType.SOLID,
-            data,
-            components,
-            [0.65, 0.35],
-            None,
-        )
-
-        assert isinstance(result, propellant_categories.SolidPropellant)
-        assert result.combustion_efficiency == 0.95
-
-    def test_create_biliquid_with_default_efficiency(self):
-        data = {"name": "Test"}
-        components = [
-            propellant_components.PropellantComponent(
-                name="LOX",
-                role=propellant_components.ComponentRole.OXIDIZER,
-                density=1141.0,
-                chemical_formula={"O": 2},
-                enthalpy=0.0,
-            ),
-            propellant_components.PropellantComponent(
-                name="LH2",
-                role=propellant_components.ComponentRole.FUEL,
-                density=70.8,
-                chemical_formula={"H": 2},
-                enthalpy=0.0,
-            ),
-        ]
-        result = formulations_base._create_propellant(
-            propellant_categories.MixtureType.BILIQUID, data, components, None, None
-        )
-
-        assert isinstance(result, propellant_categories.BiliquidPropellant)
-        assert result.combustion_efficiency == 0.98

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_json_loader.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_json_loader.py
@@ -69,9 +69,6 @@ class TestJSONFormulationLoading:
         # Verify basic fields
         assert propellant.name, f"{json_file.stem}: Missing name"
         assert len(propellant.components) > 0, f"{json_file.stem}: No components"
-        assert 0 < propellant.combustion_efficiency <= 1.0, (
-            f"{json_file.stem}: Invalid combustion_efficiency"
-        )
 
         # Verify components have required fields
         for comp in propellant.components:
@@ -144,9 +141,6 @@ class TestJSONFormulationLoading:
         assert propellant.name, f"{json_file.stem}: Missing name"
         assert len(propellant.components) == 2, (
             f"{json_file.stem}: Biliquid must have exactly 2 components"
-        )
-        assert 0 < propellant.combustion_efficiency <= 1.0, (
-            f"{json_file.stem}: Invalid combustion_efficiency"
         )
         assert propellant.oxidizer_to_fuel_ratio is not None, (
             f"{json_file.stem}: Missing O/F ratio"
@@ -314,7 +308,6 @@ class TestJSONFormulationLoading:
             name=f"{loaded.name}__CEA__{json_file.stem}",
             components=loaded.components,
             mass_fractions=loaded.mass_fractions,
-            combustion_efficiency=loaded.combustion_efficiency,
             properties=None,
             burn_rate_map=loaded.burn_rate_map,
         )
@@ -348,7 +341,6 @@ class TestJSONFormulationLoading:
             name=f"{loaded.name}__CEA__{json_stem}",
             components=loaded.components,
             mass_fractions=loaded.mass_fractions,
-            combustion_efficiency=loaded.combustion_efficiency,
             properties=None,
             burn_rate_map=loaded.burn_rate_map,
         )

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_solid.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_solid.py
@@ -110,11 +110,6 @@ class TestAllSolidPropellants:
         assert propellant.properties.i_sp_frozen > 0, f"{name} frozen Isp invalid"
         assert propellant.properties.i_sp_shifting > 0, f"{name} shifting Isp invalid"
 
-        # Check operational properties are accessible from propellant class
-        assert propellant.combustion_efficiency > 0, (
-            f"{name} combustion efficiency invalid"
-        )
-
 
 class TestFixedSolidPropellantSpecifics:
     """Test specific behaviors of solid propellants with pre-defined properties."""
@@ -164,20 +159,6 @@ class TestBurnRateBehavior:
 
 class TestConsistency:
     """Test consistency across all formulations."""
-
-    @pytest.mark.parametrize("name,propellant", ALL_SOLID_PROPELLANTS)
-    def test_combustion_efficiency_field(self, name, propellant):
-        """Verify combustion_efficiency field exists and is valid."""
-        # Ensure properties exist
-        if propellant.properties is None:
-            propellant.evaluate(5e6, 8.0)
-
-        assert hasattr(propellant, "combustion_efficiency"), (
-            f"{name} should have combustion_efficiency field"
-        )
-        assert 0 < propellant.combustion_efficiency <= 1, (
-            f"{name} combustion_efficiency should be between 0 and 1"
-        )
 
     @pytest.mark.parametrize("name,propellant", ALL_SOLID_PROPELLANTS)
     def test_isp_relationship(self, name, propellant):

--- a/tests/test_simulations/motor_builders.py
+++ b/tests/test_simulations/motor_builders.py
@@ -208,6 +208,7 @@ def build_1kn_biliquid_engine() -> tuple[
         thrust_chamber=thrust_chamber,
         oxidizer_tank_cog=0.5,
         fuel_tank_cog=0.4,
+        combustion_efficiency=0.98,
     )
     params = machwave_simulation.InternalBallisticsSimulationParams(
         d_t=1e-4,

--- a/tests/test_simulations/test_biliquid_engine_simulation.py
+++ b/tests/test_simulations/test_biliquid_engine_simulation.py
@@ -187,3 +187,29 @@ def test_simulation_runs_through_burnout_without_crashing(
 ) -> None:
     assert simulation_result.end_thrust is True
     assert simulation_result.propellant_mass[-1] <= simulation_result.propellant_mass[0]
+
+
+def test_nozzle_correction_factor_uses_motor_combustion_efficiency() -> None:
+    """The biliquid read site sources combustion efficiency from the motor.
+
+    ``nozzle_correction_factor = nozzle_efficiency * motor.combustion_efficiency``.
+    The nozzle efficiency depends only on geometry and losses, which are identical
+    across the two runs' first step, so the recorded correction factor must scale
+    linearly with the motor's combustion efficiency.
+    """
+
+    def first_nozzle_correction(combustion_efficiency: float) -> float:
+        motor, params = motor_builders.build_1kn_biliquid_engine()
+        motor.combustion_efficiency = combustion_efficiency
+        state = biliquid_simulation.BiliquidEngineState(
+            motor=motor,
+            igniter_pressure=params.igniter_pressure,
+            external_pressure=params.external_pressure,
+            other_losses=params.other_losses,
+        )
+        state.run_timestep(d_t=params.d_t, external_pressure=params.external_pressure)
+        return state.nozzle_correction_factor[-1]
+
+    assert first_nozzle_correction(1.0) == pytest.approx(
+        first_nozzle_correction(0.5) * 2.0
+    )

--- a/tests/test_simulations/test_solid_motor_simulation.py
+++ b/tests/test_simulations/test_solid_motor_simulation.py
@@ -102,3 +102,26 @@ def test_recorded_per_timestep_arrays_are_aligned(
     simulation_result: solid_simulation.SolidSimulationResult,
 ) -> None:
     assert_recorded_arrays_aligned(simulation_result)
+
+
+def test_effective_flame_temperature_uses_motor_combustion_efficiency() -> None:
+    """The solid read site sources combustion efficiency from the motor.
+
+    The effective flame temperature scales with the motor's combustion
+    efficiency, so a more efficient motor produces a higher chamber pressure
+    after one identical time step.
+    """
+
+    def first_step_chamber_pressure(combustion_efficiency: float) -> float:
+        motor, params = motor_builders.build_nero_motor()
+        motor.combustion_efficiency = combustion_efficiency
+        state = solid_simulation.SolidMotorState(
+            motor=motor,
+            igniter_pressure=params.igniter_pressure,
+            external_pressure=params.external_pressure,
+            other_losses=params.other_losses,
+        )
+        state.run_timestep(d_t=params.d_t, external_pressure=params.external_pressure)
+        return state.chamber_pressure[-1]
+
+    assert first_step_chamber_pressure(1.0) > first_step_chamber_pressure(0.5)


### PR DESCRIPTION
Closes #371.

`combustion_efficiency` reflects how completely a motor burns its charge — a function of chamber geometry, residence time, and scale — not a property of the propellant chemistry. This moves it from the propellant layer onto the motor.

## Changes
- **Motor** (`models/motors/`): `Motor.__init__` now owns `combustion_efficiency` (default `0.95`) and validates it is in `(0, 1]`; threaded through `SolidMotor` and `BiliquidEngine`.
- **Propellant** (`models/propellants/`): removed the attribute from `Propellant`/`SolidPropellant`/`BiliquidPropellant`, the JSON loader, and all 9 formulation cards.
- **Simulation**: both read sites (`simulation/solid/states.py`, `simulation/biliquid/states.py`) now read `self.motor.combustion_efficiency`.
- **Examples**: `combustion_efficiency` is set explicitly on every motor (solids `0.95`, the 1kN biliquid engine `0.98`).
- **Tests**: moved/added coverage for the default, explicit override, the `(0, 1]` boundaries and out-of-range rejection (both motor types), the propellant no longer carrying the attribute, and end-to-end regressions confirming the simulation consumes the motor value.
- Minor: aligned the `get_effective_flame_temperature` docstring range to `(0, 1]`.

## Behavior note
The removed cards `rnx_57`/`rnx_71v` (0.85), `kner` (0.94), and `lox_lh2_6_0` (0.98) previously encoded non-default efficiencies, but none are used to build a motor anywhere, so no simulation result changes. A motor using those propellants now takes the `0.95` default unless set explicitly.

## Verification
- Full suite green: 724 passed, 2 skipped.
- `ruff` lint + format clean; all example scripts run.