### PR TITLE
Fix inverted ConicalGrainSegment taper direction

### DIFF
--- a/machwave/models/grain/geometries/conical.py
+++ b/machwave/models/grain/geometries/conical.py
@@ -70,7 +70,8 @@ class ConicalGrainSegment(grain_fmm.FMMGrainSegment3D):
         lower_core_norm = self.normalize(self.lower_core_diameter)
 
         radius = np.sqrt(map_x**2 + map_y**2)
-        core_diameter = map_z * (upper_core_norm - lower_core_norm) + lower_core_norm
+        # map_z is 1 at the aft (nozzle) slice and 0 at the forward (bulkhead) slice.
+        core_diameter = map_z * (lower_core_norm - upper_core_norm) + upper_core_norm
 
         core_map[radius < core_diameter / 2] = 0
         core_map[0] = 0  # Inhibit the bottom end

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_conical.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_conical.py
@@ -17,6 +17,7 @@ lower map_dim) for the last 20% of the web thickness.
 import numpy as np
 import pytest
 
+import machwave.core.geometric as geometric
 from tests.factories import BatesSegmentFactory, ConicalGrainSegmentFactory
 
 TOLERANCE = 0.15
@@ -72,3 +73,37 @@ def test_port_area(conical_grain_segment_1, bates_equivalent_1):
     assert value == pytest.approx(expected_value, abs=tolerance), (
         f"Expected value {expected_value} with tolerance {tolerance}"
     )
+
+
+def test_taper_places_lower_diameter_at_the_nozzle_end():
+    """An asymmetric cone places the lower (nozzle) core diameter at the aft end.
+
+    The z map runs from 1 at the aft slice to 0 at the forward slice, and
+    get_port_area treats z index 0 as the nozzle end. So the larger of the two
+    bores below must show up as the larger port area near the nozzle, and the
+    smaller bore near the bulkhead -- not the other way around.
+    """
+    lower_diameter = 30e-3  # nozzle (aft) end, larger bore
+    upper_diameter = 8e-3  # bulkhead (forward) end, smaller bore
+    segment = ConicalGrainSegmentFactory.build(
+        length=68e-3,
+        outer_diameter=41e-3,
+        upper_core_diameter=upper_diameter,
+        lower_core_diameter=lower_diameter,
+    )
+    length = segment.length
+
+    # Sample just inside each end; the very end slices are inhibited open faces.
+    nozzle_port = segment.get_port_area(web_distance=0.0, z=0.05 * length)
+    bulkhead_port = segment.get_port_area(web_distance=0.0, z=0.95 * length)
+
+    # At web distance zero the open port is the core bore at that slice.
+    lower_bore = geometric.get_circle_area(lower_diameter)
+    upper_bore = geometric.get_circle_area(upper_diameter)
+
+    # The larger bore is at the nozzle, the smaller at the bulkhead.
+    assert nozzle_port > bulkhead_port
+
+    # Each end's port matches its own core diameter, not the opposite end's.
+    assert abs(nozzle_port - lower_bore) < abs(nozzle_port - upper_bore)
+    assert abs(bulkhead_port - upper_bore) < abs(bulkhead_port - lower_bore)


### PR DESCRIPTION
## Summary

The conical grain's core-diameter interpolation placed the upper (bulkhead) diameter at the aft slice. The z map runs from 1 at the aft slice to 0 at the forward slice, and `get_port_area` treats z index 0 as the nozzle, so this inverted the taper — flipping the port-area-versus-axial-position profile and the center of gravity for any cone whose two end diameters differ.

## Changes

- Swap the core-diameter interpolation so the lower (nozzle) diameter lands at the aft slice and the upper (bulkhead) diameter at the forward slice.
- Add a regression test that builds an asymmetric cone and asserts the port area at each end matches that end's own core diameter.

## Why it is safe

A symmetric cone (equal end diameters) produces an identical face map either way, and the test factory default is symmetric, so every existing center-of-gravity, moment-of-inertia, adapter, and burn-area test is unaffected. The change only alters asymmetric cones.

## Testing

- Verified directly from the face map: for a 30 mm nozzle / 8 mm bulkhead cone, the measured bore is 29.4 mm at the aft end and 8.2 mm at the forward end, matching the lower and upper diameters respectively.
- Full grain test suite passes (232 tests).

Closes #365.
