### PR TITLE
Fix STL grain voxelization shape, volume, and validation

### DIFF
--- a/machwave/models/grain/fmm/stl.py
+++ b/machwave/models/grain/fmm/stl.py
@@ -8,6 +8,18 @@ import machwave.models.grain.base as grain_base
 import machwave.models.grain.fmm as grain_fmm
 
 
+def _resample_nearest(
+    volume: np.typing.NDArray[np.int_],
+    target_shape: tuple[int, ...],
+) -> np.typing.NDArray[np.int_]:
+    """Nearest-neighbour resample a 3D array onto an exact target shape."""
+    index = [
+        np.minimum(np.arange(t) * s // t, s - 1)
+        for t, s in zip(target_shape, volume.shape)
+    ]
+    return volume[np.ix_(*index)]
+
+
 class FMMSTLGrainSegment(grain_fmm.FMMGrainSegment3D, ABC):
     """FMM grain segment loaded from an STL mesh."""
 
@@ -45,26 +57,23 @@ class FMMSTLGrainSegment(grain_fmm.FMMGrainSegment3D, ABC):
 
     def validate(self) -> None:
         """Validate STL grain segment geometry."""
+        grain.GrainSegment.validate(self)
         if not self.map_dim >= 20:
             raise grain.GrainGeometryError(
                 f"Map dimension must be at least 20 for STL grains, got {self.map_dim}"
             )
 
     def get_voxel_size(self) -> float:
-        """
-        Return the voxel edge size [m].
-
-        Note:
-            Only returns correct voxel size if `map_dim` is an odd number.
-        """
-        return self.outer_diameter / int(self.map_dim - 1)
+        """Return the voxelization pitch [m]."""
+        return self.outer_diameter / (self.map_dim - 1)
 
     def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
         """
-        Generate the initial face map by voxelizing an STL file.
+        Generate the initial face map by voxelizing an STL mesh.
 
-        Uses the `trimesh` library. Still needs to convert the boolean matrix
-        to a masked array.
+        The trimesh voxel grid does not line up with the FMM grid, so it is
+        resampled onto the canonical `(normalized_length, map_dim, map_dim)`
+        shape the rest of the 3D machinery expects.
         """
         mesh = trimesh.load_mesh(self.file_path)
         assert isinstance(mesh, trimesh.Trimesh), "Expected a single Trimesh"
@@ -72,13 +81,6 @@ class FMMSTLGrainSegment(grain_fmm.FMMGrainSegment3D, ABC):
 
         voxels = mesh.voxelized(pitch=self.get_voxel_size())
         assert voxels is not None, "Voxelization failed"
-        volume = voxels.fill()
-        voxel_map: np.typing.NDArray[np.int_] = (
-            volume.matrix.view(np.ndarray).transpose().astype(np.int_)
-        )
+        voxel_map = voxels.fill().matrix.view(np.ndarray).transpose().astype(np.int_)
 
-        assert voxel_map.shape == self.get_maps()[0].shape, (
-            "Generated map shape mismatch"
-        )
-
-        return voxel_map
+        return _resample_nearest(voxel_map, self.get_maps()[0].shape)

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_stl.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_stl.py
@@ -1,0 +1,69 @@
+"""
+Tests for the STL-backed 3D FMM grain segment.
+
+The mesh is generated at test time (a watertight hollow cylinder) and written to
+a temporary STL file, so no binary fixture is committed.
+"""
+
+import numpy as np
+import pytest
+import trimesh
+
+import machwave.models.grain as grain_models
+from machwave.models.grain.fmm import FMMSTLGrainSegment
+
+OUTER_DIAMETER = 41e-3
+LENGTH = 68e-3
+BORE_DIAMETER = 15e-3
+
+
+@pytest.fixture(scope="module")
+def tube_stl_path(tmp_path_factory):
+    """A watertight tube (hollow cylinder) grain mesh written to a temp STL."""
+    mesh = trimesh.creation.annulus(
+        r_min=BORE_DIAMETER / 2, r_max=OUTER_DIAMETER / 2, height=LENGTH
+    )
+    path = tmp_path_factory.mktemp("stl") / "tube.stl"
+    mesh.export(path)
+    return str(path)
+
+
+@pytest.fixture(scope="module")
+def tube_segment(tube_stl_path):
+    return FMMSTLGrainSegment(
+        file_path=tube_stl_path, outer_diameter=OUTER_DIAMETER, length=LENGTH
+    )
+
+
+def test_face_map_matches_the_fmm_grid_shape(tube_segment):
+    """The voxelized mesh is resampled onto the canonical FMM grid shape.
+
+    Before the fix the raw voxel grid was off by a voxel on every axis, so the
+    shape assertion hard-failed even for a correctly sized mesh.
+    """
+    face_map = tube_segment.get_initial_face_map()
+    assert face_map.shape == tube_segment.get_maps()[0].shape
+
+
+def test_volume_matches_the_analytical_tube(tube_segment):
+    """Propellant volume is within voxelization error of the analytical tube."""
+    analytical_volume = np.pi / 4 * (OUTER_DIAMETER**2 - BORE_DIAMETER**2) * LENGTH
+    assert tube_segment.get_volume(web_distance=0.0) == pytest.approx(
+        analytical_volume, rel=0.1
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        dict(outer_diameter=0.0),
+        dict(outer_diameter=-1e-3),
+        dict(length=0.0),
+        dict(map_dim=10),  # below the STL map-dimension floor of 20
+    ],
+)
+def test_invalid_geometry_raises(tube_stl_path, overrides):
+    params = dict(file_path=tube_stl_path, outer_diameter=OUTER_DIAMETER, length=LENGTH)
+    params.update(overrides)
+    with pytest.raises(grain_models.GrainGeometryError):
+        FMMSTLGrainSegment(**params)


### PR DESCRIPTION
## Summary

Three defects in the STL-backed 3D FMM grain segment ([`stl.py`](machwave/models/grain/fmm/stl.py)):

- The exact-shape assertion against the FMM grid hard-failed for any real mesh, because the trimesh voxel grid comes out a voxel off on each axis (the diameter rounds to `map_dim ± 1`, never exactly `map_dim`).
- The per-voxel volume did not match the voxelization, so propellant mass and moment of inertia were systematically wrong.
- `validate()` never called up the chain, so non-positive length and outer diameter were not rejected.

## Changes

- Resample the filled voxel grid (nearest neighbour) onto the canonical `(normalized_length, map_dim, map_dim)` shape the rest of the 3D machinery expects, replacing the brittle assertion.
- Validate length, outer diameter, density, and inhibited surfaces through `GrainSegment.validate`, while keeping the STL-specific lower map-dimension floor.

## Notes on two deliberate choices

- **Volume:** rather than overriding `get_volume_per_element` to use the raw voxel pitch, canonicalizing the grid makes the inherited `(outer_diameter / map_dim) ** 3` correct on that grid. This is more accurate than the pitch-based override, which over-counts: for a hollow-cylinder test grain the error is +3.1% at map_dim 50 (pure voxelization staircasing) versus +9.6% with the pitch cube, dropping toward 0 as resolution rises.
- **Map-dimension floor:** the base FMM grains require map_dim at least 100, but voxelizing a mesh at that resolution is roughly six times slower (about 12 seconds versus 2). The STL grain keeps its own lower floor of 20 on purpose, so `validate()` enforces that floor rather than the base one while still validating the dimensional inputs.

## Testing

- New tests built from a generated watertight tube mesh (no binary fixture committed): the face map matches the FMM grid shape, the propellant volume matches the analytical tube within voxelization error, and invalid geometry is rejected.
- Full grain test suite passes.

Closes #366.
