### PR TITLE
Cache thermochemical evaluations by quantized chamber pressure

### DIFF
--- a/machwave/models/propellants/categories/base.py
+++ b/machwave/models/propellants/categories/base.py
@@ -141,8 +141,7 @@ class Propellant(abc.ABC):
         Evaluate thermochemical properties at given conditions.
 
         Chamber pressure is quantized to `CHAMBER_PRESSURE_QUANTIZATION_PA` and the
-        result is cached per `(chamber_pressure, expansion_ratio, mixture_ratio)` for
-        performance.
+        result is cached per `(chamber_pressure, expansion_ratio, mixture_ratio)`.
 
         Args:
             chamber_pressure: Chamber pressure [Pa].

--- a/machwave/models/propellants/categories/base.py
+++ b/machwave/models/propellants/categories/base.py
@@ -33,6 +33,9 @@ class Propellant(abc.ABC):
 
     mixture_type: MixtureType
 
+    # Chamber pressure is quantized to this width [Pa] before evaluation.
+    CHAMBER_PRESSURE_QUANTIZATION_PA: float = 200.0
+
     def __init__(
         self,
         name: str,
@@ -47,6 +50,7 @@ class Propellant(abc.ABC):
         """
         self.name = name
         self.components = list(components or [])
+        self._evaluation_cache: dict = {}
 
     @functools.cached_property
     def thermochemical_service(self) -> cea_service.RocketCEAService:
@@ -79,26 +83,13 @@ class Propellant(abc.ABC):
         """
         pass
 
-    def evaluate(
+    def _compute_thermochemical_properties(
         self,
         chamber_pressure: float,
-        expansion_ratio: float = 8.0,
-        mixture_ratio: float | None = None,
+        expansion_ratio: float,
+        mixture_ratio: float | None,
     ) -> propellant_properties.ThermochemicalProperties:
-        """
-        Evaluate thermochemical properties at given conditions.
-
-        Args:
-            chamber_pressure: Chamber pressure [Pa].
-            expansion_ratio: Nozzle area ratio (Ae/At).
-            mixture_ratio: Ratio of the propellant mixture.
-
-        Returns:
-            ThermochemicalProperties.
-
-        Raises:
-            ValueError: If evaluation fails.
-        """
+        """Query the thermochemical service at the given conditions."""
         service = self.thermochemical_service
 
         adiabatic_flame_temperature = service.get_adiabatic_flame_temperature(
@@ -128,7 +119,7 @@ class Propellant(abc.ABC):
             mixture_ratio=mixture_ratio,
         )
 
-        properties = propellant_properties.ThermochemicalProperties(
+        return propellant_properties.ThermochemicalProperties(
             k_chamber=k_chamber,
             k_exhaust=k_exhaust,
             adiabatic_flame_temperature=adiabatic_flame_temperature,
@@ -139,4 +130,44 @@ class Propellant(abc.ABC):
             qsi_chamber=qsi_chamber,
             qsi_exhaust=qsi_exhaust,
         )
+
+    def evaluate(
+        self,
+        chamber_pressure: float,
+        expansion_ratio: float = 8.0,
+        mixture_ratio: float | None = None,
+    ) -> propellant_properties.ThermochemicalProperties:
+        """
+        Evaluate thermochemical properties at given conditions.
+
+        Chamber pressure is quantized to `CHAMBER_PRESSURE_QUANTIZATION_PA` and the
+        result is cached per `(chamber_pressure, expansion_ratio, mixture_ratio)` for
+        performance.
+
+        Args:
+            chamber_pressure: Chamber pressure [Pa].
+            expansion_ratio: Nozzle area ratio (Ae/At).
+            mixture_ratio: Ratio of the propellant mixture.
+
+        Returns:
+            ThermochemicalProperties.
+
+        Raises:
+            ValueError: If evaluation fails.
+        """
+        quantized_chamber_pressure = (
+            round(chamber_pressure / self.CHAMBER_PRESSURE_QUANTIZATION_PA)
+            * self.CHAMBER_PRESSURE_QUANTIZATION_PA
+        )
+        cache_key = (quantized_chamber_pressure, expansion_ratio, mixture_ratio)
+        cached_properties = self._evaluation_cache.get(cache_key)
+        if cached_properties is not None:
+            return cached_properties
+
+        properties = self._compute_thermochemical_properties(
+            chamber_pressure=quantized_chamber_pressure,
+            expansion_ratio=expansion_ratio,
+            mixture_ratio=mixture_ratio,
+        )
+        self._evaluation_cache[cache_key] = properties
         return properties


### PR DESCRIPTION
Closes #379.

`Propellant.evaluate` runs six NASA CEA queries on every call, which dominated biliquid engine simulation time (one 44,000-timestep run spent ~46s almost entirely in CEA). The chamber pressure drifts minutely each timestep, so `rocketcea`'s own exact-float cache almost never hits.

## Approach

- Quantize the chamber pressure to a fixed bucket width and memoize the result per `(chamber_pressure, expansion_ratio, mixture_ratio)` on the propellant instance. `mixture_ratio` is kept exact, so live oxidizer-to-fuel-ratio variation is still resolved.
- Move the six service queries into `_compute_thermochemical_properties`, leaving `evaluate` as a thin caching layer.
- The bucket width is the `CHAMBER_PRESSURE_QUANTIZATION_PA` class attribute (default 200 Pa), so it can be overridden per propellant, per subclass, or globally.

## Measured impact (1 kN biliquid engine, full run)

At the 200 Pa default: run time **47s to 19s** (2.5x), with peak-thrust error **7e-8** and total-impulse error **4e-8** — far below the time-integration error. The solid-motor path is unchanged (it barely uses CEA).

Sweeping the bucket width shows the speedup plateaus near 1 kPa (the remaining floor is uncached CoolProp tank lookups), and pointwise accuracy degrades sharply past ~5 kPa, so 200 Pa is a conservative default.

## Verification

- 140 propellant-formulation and end-to-end simulation tests pass, including the re-runnable and live-mixture-ratio cases.
- `ruff` clean.