### PR TITLE
Calibrate the 3D regression field per axis and trace continuous slices

### DIFF
--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -2,6 +2,7 @@ from abc import ABC
 from collections.abc import Callable
 
 import numpy as np
+import skfmm
 from numpy.typing import NDArray
 from scipy.interpolate import interp1d
 
@@ -129,38 +130,40 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
 
         return face_map, outside
 
+    def _regression_distance(self, masked_face: np.ndarray) -> np.ndarray:
+        # Regression speed needs to be calibrated for the z axes separately from the x
+        # and y axes, because the 3D grid is anisotropic
+        axial_pitch = self.length / max(self.get_normalized_length() - 1, 1)
+        radial_pitch = self.outer_diameter / (self.map_dim - 1)
+        distance = skfmm.distance(
+            masked_face, dx=[axial_pitch, radial_pitch, radial_pitch]
+        )
+        return distance * (2.0 / self.outer_diameter)
+
     def get_contours(
         self, web_distance: float, length_normalized: float
     ) -> list[NDArray[np.float64]]:
         map_dist = self.normalize(web_distance)
-        valid = np.logical_not(self.get_mask())
-        boolean_3d = np.logical_and(self.get_regression_map() > map_dist, valid)
-
         z_index = int(round(length_normalized))
-        boolean_slice_2d = boolean_3d[z_index]
-
-        return fmm_contours.get_contours(
-            boolean_slice_2d,
-            map_dist,
-        )
+        regression_slice = self.get_regression_map()[z_index]
+        return fmm_contours.get_contours(regression_slice, map_dist)
 
     def _get_burn_area_uncached(self, *, map_dist: float) -> float:
-        valid = np.logical_not(self.get_mask())
-        boolean_3d = np.logical_and(self.get_regression_map() > map_dist, valid)
+        regression_map = self.get_regression_map()
 
         web_distance = float(self.denormalize(map_dist))
         length_factor = self.get_length(web_distance=web_distance) / self.map_dim
 
-        # Slices with an identical boolean cross-section trace to an identical
-        # contour at this map_dist, so each distinct slice is traced only once.
+        # Slices with an identical cross-section trace to an identical contour at
+        # this map_dist, so each distinct slice is traced only once.
         perimeter_by_slice: dict[bytes, float] = {}
         total = 0.0
         for z_index in range(self.get_normalized_length()):
-            boolean_slice_2d = boolean_3d[z_index]
-            key = np.asarray(boolean_slice_2d).tobytes()
+            regression_slice = regression_map[z_index]
+            key = np.asarray(regression_slice).tobytes()
             perimeter = perimeter_by_slice.get(key)
             if perimeter is None:
-                contours = fmm_contours.get_contours(boolean_slice_2d, map_dist)
+                contours = fmm_contours.get_contours(regression_slice, map_dist)
                 perimeter = float(
                     sum(
                         self.map_to_length(

--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -136,7 +136,8 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         axial_pitch = self.length / max(self.get_normalized_length() - 1, 1)
         radial_pitch = self.outer_diameter / (self.map_dim - 1)
         distance = skfmm.distance(
-            masked_face, dx=[axial_pitch, radial_pitch, radial_pitch]
+            masked_face,
+            dx=[axial_pitch, radial_pitch, radial_pitch],  # type: ignore[arg-type]
         )
         return distance * (2.0 / self.outer_diameter)
 

--- a/machwave/models/grain/fmm/base.py
+++ b/machwave/models/grain/fmm/base.py
@@ -205,6 +205,10 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
         unmasked = ~np.ma.getmaskarray(masked_face)
         return bool(np.any(masked_face.data[np.asarray(unmasked, dtype=bool)] == 0))
 
+    def _regression_distance(self, masked_face: np.ndarray) -> np.ndarray:
+        """Return the regression distance from the burning surface in normalized web units."""
+        return skfmm.distance(masked_face, dx=self.get_cell_size()) * 2
+
     def get_regression_map(self):
         """
         Return the distance map for grain regression.
@@ -218,9 +222,7 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
             masked_face = self.get_masked_face()
 
             if self.has_cross_section_regression:
-                self.regression_map = (
-                    skfmm.distance(masked_face, dx=self.get_cell_size()) * 2
-                )
+                self.regression_map = self._regression_distance(masked_face)
             else:
                 unmasked = ~np.ma.getmaskarray(masked_face)
                 self.regression_map = np.ma.MaskedArray(

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_conical.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_conical.py
@@ -75,6 +75,32 @@ def test_port_area(conical_grain_segment_1, bates_equivalent_1):
     )
 
 
+def test_axial_burnout_web_is_calibrated_on_the_anisotropic_grid():
+    """A short, both-ends-exposed tube burns out axially before radially.
+
+    Its web thickness is then set by the axial half-length, not the radial web.
+    That only comes out right if the axial axis of the anisotropic 3D grid is
+    calibrated separately from the cross-section; a single scalar dx mis-scales
+    it by the length-to-diameter ratio.
+    """
+    outer_diameter = 41e-3
+    bore_diameter = 30e-3
+    length = 8e-3  # axial half-length (4 mm) is below the radial web (5.5 mm)
+
+    segment = ConicalGrainSegmentFactory.build(
+        length=length,
+        outer_diameter=outer_diameter,
+        upper_core_diameter=bore_diameter,
+        lower_core_diameter=bore_diameter,
+    )
+
+    radial_web = (outer_diameter - bore_diameter) / 2
+    axial_half_length = length / 2
+    assert axial_half_length < radial_web  # the grain is axial-limited by design
+
+    assert segment.get_web_thickness() == pytest.approx(axial_half_length, rel=0.1)
+
+
 def test_taper_places_lower_diameter_at_the_nozzle_end():
     """An asymmetric cone places the lower (nozzle) core diameter at the aft end.
 

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl.py
@@ -64,8 +64,7 @@ def test_burn_area_dedup_matches_per_slice_sum(finocyl_segment):
     segment = finocyl_segment
     map_dist = segment.normalize(segment.get_web_thickness() * 0.3)
 
-    valid = np.logical_not(segment.get_mask())
-    boolean_3d = np.logical_and(segment.get_regression_map() > map_dist, valid)
+    regression_map = segment.get_regression_map()
     length_factor = (
         segment.get_length(web_distance=float(segment.denormalize(map_dist)))
         / segment.map_dim
@@ -74,7 +73,7 @@ def test_burn_area_dedup_matches_per_slice_sum(finocyl_segment):
     # Reference: trace every slice independently, with no caching.
     reference = 0.0
     for z_index in range(segment.get_normalized_length()):
-        contours = fmm_contours.get_contours(boolean_3d[z_index], map_dist)
+        contours = fmm_contours.get_contours(regression_map[z_index], map_dist)
         perimeter = sum(
             segment.map_to_length(fmm_contours.get_length(contour, segment.map_dim))
             for contour in contours


### PR DESCRIPTION
## Summary

Two coupled defects in how the 3D regression field is built and traced:

- **Anisotropic grid, scalar dx.** The fast marching solver was given a single scalar grid spacing, but the normalized 3D grid is anisotropic — the cross-section axes span the diameter while the axial axis spans the (generally different) length. The axial front was therefore mis-scaled by the length-to-diameter ratio (about 3–4×), corrupting the web and burn area near axial features (fin ends, exposed end faces).
- **Boolean-slice tracing.** Each slice was thresholded to a 0/1 mask and traced at level `map_dist`, unlike the 2D path which traces the continuous field. This produced a staircased, level-dependent perimeter (biased ~5–6% high) that collapsed to zero as `map_dist` approached 1.

## Changes

- Extract the scikit-fmm call into an overridable `_regression_distance`. The 3D segment overrides it to pass a per-axis physical pitch (axial vs radial), then converts to normalized web units. The isotropic 2D path is unchanged.
- Trace the burn-area contours on the continuous `regression_map[z]` slice instead of a thresholded boolean slice, matching the 2D path. The deduplication reference test is updated to the same continuous tracing.

## Verification

- A short, both-ends-exposed tube (8 mm long, 41 mm outer, 30 mm bore) now burns out axially before radially: its web thickness is **4.0 mm = the axial half-length**, not the 5.5 mm radial web. With the old scalar dx the axial axis was mis-scaled, so this came out wrong. Longer tubes correctly fall back to the radial web (~5.4 mm). New test: `test_axial_burnout_web_is_calibrated_on_the_anisotropic_grid`.
- The continuous tracing also lowers the perimeter bias, which brings the constant-bore conical-vs-BATES burn-area comparison closer to the analytical value.
- All grain tests pass.

Closes #367.
