### PR TITLE
Parallelize the test suite with pytest-xdist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ verify-version:
 	fi; \
 	echo "Version verified: $$PKG_VERSION"
 test:
-	@uv run pytest
+	@uv run pytest -n auto
 benchmark:
 	@uv run pytest tests/benchmarks --benchmark-only --benchmark-columns=min,median,mean,stddev,rounds
 publish:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "polyfactory>=3.1.0,<4.0.0",
     "rocketpy>=1.11.0,<2.0.0",
     "pre-commit>=4.0.0,<5.0.0",
+    "pytest-xdist>=3.6.0,<4.0.0",
 ]
 docs = [
     "mkdocs>=1.6.0,<2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -462,6 +462,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "faker"
 version = "40.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -802,6 +811,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "rocketpy" },
     { name = "ruff" },
 ]
@@ -838,6 +848,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-benchmark", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-cov", specifier = ">=6.2.1,<8.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.0,<4.0.0" },
     { name = "rocketpy", specifier = ">=1.11.0,<2.0.0" },
     { name = "ruff" },
 ]
@@ -1617,6 +1628,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/30/4c/f883ab8f0daad69f47efdf95f55a66b51a8b939c430dadce0611508d9e99/pytest_cov-6.3.0.tar.gz", hash = "sha256:35c580e7800f87ce892e687461166e1ac2bcb8fb9e13aea79032518d6e503ff2", size = 70398, upload-time = "2025-09-06T15:40:14.361Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/b4/bb7263e12aade3842b938bc5c6958cae79c5ee18992f9b9349019579da0f/pytest_cov-6.3.0-py3-none-any.whl", hash = "sha256:440db28156d2468cafc0415b4f8e50856a0d11faefa38f30906048fe490f1749", size = 25115, upload-time = "2025-09-06T15:40:12.44Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #382.

The test suite ran on a single core even though the tests are independent and CPU-bound, which made both local runs and the nine-job CI matrix slow.

## Change

- Add `pytest-xdist` to the dev dependency group.
- Run the suite with `-n auto` in the `make test` target (which CI invokes). The `benchmark` target stays serial, since `pytest-benchmark` cannot aggregate timings across xdist workers.

## Measured impact (full suite, 14-core machine, on top of #380)

| workers | wall time | speedup |
|---|---|---|
| serial (1) | 150.3s | 1.0x |
| 4 | 62.8s | 2.4x |
| 8 | 56.3s | 2.7x |
| auto (14) | 57.9s | 2.6x |

The speedup plateaus near 4 to 8 workers because the wall-clock floor is the longest indivisible test chain — the biliquid simulation tests, which a single worker must run end to end. The GitHub-hosted CI runners have two to four cores, so `-n auto` lands them in the efficient part of this curve.

## Verification

- 732 passed, 2 skipped under `-n auto` with no test-isolation failures.
- The 2 skipped are the benchmark cases, which `--benchmark-skip` (already in the pytest config) skips cleanly under xdist.