### PR TITLE
Validate 3D FMM normalized axial length is at least 3

### DIFF
--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -74,6 +74,20 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
     def get_normalized_length(self) -> int:
         return int(self.map_dim * self.length / self.outer_diameter)
 
+    def validate(self) -> None:
+        super().validate()
+        self._validate_normalized_length()
+
+    def _validate_normalized_length(self) -> None:
+        # < 3 slices: get_port_area indexes a size-0 axis and inhibition is skipped
+        normalized_length = self.get_normalized_length()
+        if normalized_length < 3:
+            raise grain.GrainGeometryError(
+                f"Normalized axial length must be at least 3, got "
+                f"{normalized_length}; increase map_dim or the "
+                f"length-to-outer-diameter ratio."
+            )
+
     def get_maps(
         self,
     ) -> tuple[

--- a/machwave/models/grain/fmm/stl.py
+++ b/machwave/models/grain/fmm/stl.py
@@ -62,6 +62,7 @@ class FMMSTLGrainSegment(grain_fmm.FMMGrainSegment3D, ABC):
             raise grain.GrainGeometryError(
                 f"Map dimension must be at least 20 for STL grains, got {self.map_dim}"
             )
+        self._validate_normalized_length()
 
     def get_voxel_size(self) -> float:
         """Return the voxelization pitch [m]."""

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_conical.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_conical.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 
 import machwave.core.geometric as geometric
+import machwave.models.grain as grain_models
 from tests.factories import BatesSegmentFactory, ConicalGrainSegmentFactory
 
 TOLERANCE = 0.15
@@ -133,3 +134,25 @@ def test_taper_places_lower_diameter_at_the_nozzle_end():
     # Each end's port matches its own core diameter, not the opposite end's.
     assert abs(nozzle_port - lower_bore) < abs(nozzle_port - upper_bore)
     assert abs(bulkhead_port - upper_bore) < abs(bulkhead_port - lower_bore)
+
+
+def test_segment_too_short_for_axial_map_is_rejected():
+    """int(100 * 0.002 / 0.1) == 2 slices -> rejected."""
+    with pytest.raises(grain_models.GrainGeometryError):
+        ConicalGrainSegmentFactory.build(
+            length=2e-3,
+            outer_diameter=100e-3,
+            upper_core_diameter=15e-3,
+            lower_core_diameter=10e-3,
+        )
+
+
+def test_three_axial_slices_is_accepted():
+    """int(100 * 0.0035 / 0.1) == 3, the minimum that validates."""
+    segment = ConicalGrainSegmentFactory.build(
+        length=3.5e-3,
+        outer_diameter=100e-3,
+        upper_core_diameter=15e-3,
+        lower_core_diameter=10e-3,
+    )
+    assert segment.get_normalized_length() == 3

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_stl.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_stl.py
@@ -60,6 +60,7 @@ def test_volume_matches_the_analytical_tube(tube_segment):
         dict(outer_diameter=-1e-3),
         dict(length=0.0),
         dict(map_dim=10),  # below the STL map-dimension floor of 20
+        dict(length=2e-3),  # axial map collapses below three slices
     ],
 )
 def test_invalid_geometry_raises(tube_stl_path, overrides):


### PR DESCRIPTION
Closes #389. Part of #368. Also closes #342.

A short or large-bore 3D FMM segment truncates `int(map_dim * length / outer_diameter)` to 0, 1, or 2 axial slices. Below 3 slices `get_port_area` indexes a size-0 axis (`IndexError`) and `_apply_inhibition` silently skips all inhibition. This adds a `normalized_length >= 3` check at construction (also covering the STL grain, which overrides `validate`), raising a clear `GrainGeometryError`.

## Tests
- `test_conical.py`: rejects a 2-slice segment, accepts the 3-slice minimum.
- `test_stl.py`: short-length case added to the invalid-geometry parametrization.
