### PR TITLE
Guard grain center of gravity against zero total mass

### DIFF
--- a/machwave/models/grain/base.py
+++ b/machwave/models/grain/base.py
@@ -444,9 +444,14 @@ class Grain:
         total_mass_normalized = float(np.sum(volumes * density_ratios))
 
         if total_mass_normalized <= 0.0:
-            # zero mass (burnout / zero density): mass-weighted CoG is undefined,
-            # fall back to the geometric centroid instead of dividing by zero
-            return np.stack(global_cogs, axis=0).mean(axis=0, dtype=np.float64)
+            # zero mass (burnout / zero density): mass-weighted CoG is undefined.
+            # Weight by initial (unburned) volume instead -- non-zero for any
+            # valid grain and continuous with the burn, so no end-of-trace spike.
+            # global_cogs is in reversed-segment order, so reverse the weights.
+            weights = self.get_propellant_volume_per_segment(0.0)[::-1]
+            return np.average(
+                np.stack(global_cogs, axis=0), axis=0, weights=weights
+            ).astype(np.float64)
 
         total_weighted_cogs = np.stack(weighted_cogs, axis=0).sum(
             axis=0, dtype=np.float64

--- a/machwave/models/grain/base.py
+++ b/machwave/models/grain/base.py
@@ -421,6 +421,7 @@ class Grain:
             raise ValueError("No segments found, cannot compute CoG.")
 
         weighted_cogs = []
+        global_cogs = []
         # Iterate segments in reverse order (last added is closest to port)
         axial_position = 0.0
 
@@ -431,19 +432,25 @@ class Grain:
             # Global CoG position from grain's port
             global_cog = local_cog.copy()
             global_cog[0] = axial_position + local_cog[0]
+            global_cogs.append(global_cog)
 
             mass = segment.get_volume(web_distance=web_distance) * segment.density_ratio
             weighted_cogs.append(global_cog * mass)
 
             axial_position += segment.length + self.spacing
 
-        total_weighted_cogs = np.stack(weighted_cogs, axis=0).sum(
-            axis=0, dtype=np.float64
-        )
         volumes = self.get_propellant_volume_per_segment(web_distance)
         density_ratios = self.get_density_ratio_per_segment()
         total_mass_normalized = float(np.sum(volumes * density_ratios))
 
+        if total_mass_normalized <= 0.0:
+            # zero mass (burnout / zero density): mass-weighted CoG is undefined,
+            # fall back to the geometric centroid instead of dividing by zero
+            return np.stack(global_cogs, axis=0).mean(axis=0, dtype=np.float64)
+
+        total_weighted_cogs = np.stack(weighted_cogs, axis=0).sum(
+            axis=0, dtype=np.float64
+        )
         return (total_weighted_cogs / total_mass_normalized).astype(np.float64)
 
     def get_moment_of_inertia(

--- a/machwave/models/grain/base.py
+++ b/machwave/models/grain/base.py
@@ -444,10 +444,6 @@ class Grain:
         total_mass_normalized = float(np.sum(volumes * density_ratios))
 
         if total_mass_normalized <= 0.0:
-            # zero mass (burnout / zero density): mass-weighted CoG is undefined.
-            # Weight by initial (unburned) volume instead -- non-zero for any
-            # valid grain and continuous with the burn, so no end-of-trace spike.
-            # global_cogs is in reversed-segment order, so reverse the weights.
             weights = self.get_propellant_volume_per_segment(0.0)[::-1]
             return np.average(
                 np.stack(global_cogs, axis=0), axis=0, weights=weights

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -134,9 +134,13 @@ class SolidMotorState(simulation_states.MotorState):
         propellant_mass = float(np.sum(propellant_mass_per_segment))
         self.propellant_mass.append(propellant_mass)
 
-        propellant_cog = self.motor.grain.get_center_of_gravity(
-            web_distance=web_distance
-        )
+        # No propellant left -> CoG is undefined; record a gap, not a value
+        if propellant_mass > 0.0:
+            propellant_cog = self.motor.grain.get_center_of_gravity(
+                web_distance=web_distance
+            )
+        else:
+            propellant_cog = np.full(3, np.nan)
         self.propellant_cog.append(propellant_cog)
         propellant_moi = self.motor.grain.get_moment_of_inertia(
             ideal_density=ideal_propellant_density, web_distance=web_distance

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -134,12 +134,11 @@ class SolidMotorState(simulation_states.MotorState):
         propellant_mass = float(np.sum(propellant_mass_per_segment))
         self.propellant_mass.append(propellant_mass)
 
-        # No propellant left -> CoG is undefined; record a gap, not a value
         if propellant_mass > 0.0:
             propellant_cog = self.motor.grain.get_center_of_gravity(
                 web_distance=web_distance
             )
-        else:
+        else:  # no propellant left, CoG is undefined
             propellant_cog = np.full(3, np.nan)
         self.propellant_cog.append(propellant_cog)
         propellant_moi = self.motor.grain.get_moment_of_inertia(

--- a/tests/test_models/test_propulsion/test_grain/test_cog/test_bates_cog.py
+++ b/tests/test_models/test_propulsion/test_grain/test_cog/test_bates_cog.py
@@ -221,42 +221,49 @@ class TestBatesGrainCenterOfGravity:
         # CoG should be closer to segment 1 (more massive)
         assert cog[0] > 1.05, "CoG should be pulled toward the denser segment"
 
-    def test_zero_total_mass_falls_back_to_geometric_centroid(self):
-        """Zero density everywhere -> CoG is the geometric centroid, not nan."""
+    def test_zero_mass_cog_is_initial_volume_weighted(self):
+        """Zero density on unequal segments -> CoG is the initial-volume centroid."""
         grain = grain_models.Grain(spacing=0.1)
-        for _ in range(2):
-            grain.add_segment(
-                grain_geometries.BatesSegment(
-                    outer_diameter=117e-3,
-                    core_diameter=45e-3,
-                    length=1.0,
-                    density_ratio=0.0,
-                )
-            )
+        small = grain_geometries.BatesSegment(
+            outer_diameter=117e-3, core_diameter=45e-3, length=1.0, density_ratio=0.0
+        )
+        big = grain_geometries.BatesSegment(
+            outer_diameter=117e-3, core_diameter=45e-3, length=3.0, density_ratio=0.0
+        )
+        grain.add_segment(small)  # forward, center at 3.6
+        grain.add_segment(big)  # aft, center at 1.5
 
         cog = grain.get_center_of_gravity(web_distance=0.0)
 
+        v_small, v_big = small.get_volume(0.0), big.get_volume(0.0)
+        expected_x = (3.6 * v_small + 1.5 * v_big) / (v_small + v_big)
         assert np.all(np.isfinite(cog)), "CoG must stay finite when total mass is zero"
-        np.testing.assert_array_almost_equal(cog, np.array([1.05, 0.0, 0.0]))
+        np.testing.assert_array_almost_equal(cog, np.array([expected_x, 0.0, 0.0]))
 
-    def test_full_burnout_cog_stays_finite(self):
-        """Past burnout every segment has zero mass -> CoG stays finite."""
+    def test_full_burnout_cog_has_no_large_spike(self):
+        """Unequal segments: burnout CoG stays near the pre-burnout limit.
+
+        The unweighted centroid would jump ~0.5 m at the dead tail; weighting by
+        initial volume keeps it continuous with the burn.
+        """
         grain = grain_models.Grain(spacing=0.1)
-        for _ in range(2):
-            grain.add_segment(
-                grain_geometries.BatesSegment(
-                    outer_diameter=117e-3,
-                    core_diameter=45e-3,
-                    length=1.0,
-                    density_ratio=1.0,
-                )
+        grain.add_segment(
+            grain_geometries.BatesSegment(
+                outer_diameter=117e-3, core_diameter=45e-3, length=1.0
             )
+        )
+        grain.add_segment(
+            grain_geometries.BatesSegment(
+                outer_diameter=117e-3, core_diameter=45e-3, length=3.0
+            )
+        )
 
         web_thickness = grain.segments[0].get_web_thickness()
-        cog = grain.get_center_of_gravity(web_distance=web_thickness * 2)
+        before = grain.get_center_of_gravity(web_distance=web_thickness * 0.99)
+        after = grain.get_center_of_gravity(web_distance=web_thickness * 1.5)
 
-        assert np.all(np.isfinite(cog)), "CoG must stay finite at full burnout"
-        np.testing.assert_array_almost_equal(cog, np.array([1.05, 0.0, 0.0]))
+        assert np.all(np.isfinite(after)), "CoG must stay finite at full burnout"
+        np.testing.assert_allclose(after, before, atol=0.05)
 
     def test_two_segments_zero_spacing(self):
         """Test CoG with 2 BATES segments with zero spacing (touching)."""

--- a/tests/test_models/test_propulsion/test_grain/test_cog/test_bates_cog.py
+++ b/tests/test_models/test_propulsion/test_grain/test_cog/test_bates_cog.py
@@ -221,6 +221,43 @@ class TestBatesGrainCenterOfGravity:
         # CoG should be closer to segment 1 (more massive)
         assert cog[0] > 1.05, "CoG should be pulled toward the denser segment"
 
+    def test_zero_total_mass_falls_back_to_geometric_centroid(self):
+        """Zero density everywhere -> CoG is the geometric centroid, not nan."""
+        grain = grain_models.Grain(spacing=0.1)
+        for _ in range(2):
+            grain.add_segment(
+                grain_geometries.BatesSegment(
+                    outer_diameter=117e-3,
+                    core_diameter=45e-3,
+                    length=1.0,
+                    density_ratio=0.0,
+                )
+            )
+
+        cog = grain.get_center_of_gravity(web_distance=0.0)
+
+        assert np.all(np.isfinite(cog)), "CoG must stay finite when total mass is zero"
+        np.testing.assert_array_almost_equal(cog, np.array([1.05, 0.0, 0.0]))
+
+    def test_full_burnout_cog_stays_finite(self):
+        """Past burnout every segment has zero mass -> CoG stays finite."""
+        grain = grain_models.Grain(spacing=0.1)
+        for _ in range(2):
+            grain.add_segment(
+                grain_geometries.BatesSegment(
+                    outer_diameter=117e-3,
+                    core_diameter=45e-3,
+                    length=1.0,
+                    density_ratio=1.0,
+                )
+            )
+
+        web_thickness = grain.segments[0].get_web_thickness()
+        cog = grain.get_center_of_gravity(web_distance=web_thickness * 2)
+
+        assert np.all(np.isfinite(cog)), "CoG must stay finite at full burnout"
+        np.testing.assert_array_almost_equal(cog, np.array([1.05, 0.0, 0.0]))
+
     def test_two_segments_zero_spacing(self):
         """Test CoG with 2 BATES segments with zero spacing (touching)."""
         grain = grain_models.Grain(spacing=0.0)


### PR DESCRIPTION
Closes #390. Part of #368.

`Grain.get_center_of_gravity` divided the mass-weighted sum by the total mass with no zero check. Total mass is zero at full burnout (all propellant gone) or when every segment has `density_ratio = 0`, so the result was `nan`/`inf` and silently poisoned downstream inertia and dynamics.

When total mass is `<= 0` the mass-weighted average is undefined. The fallback weights the segment centers by their **initial (unburned) volume** — non-zero for any valid grain and continuous with the burn, so it does not introduce an end-of-trace spike. (An unweighted centroid jumps ~0.5 m on the final massless sample of an unequal multi-segment grain.)

The simulation also records `NaN` for the propellant center of gravity once `propellant_mass <= 0` ([states.py](machwave/simulation/solid/states.py)), so the dead tail of the recorded trace reads as a gap rather than a meaningless value (and avoids evaluating segment CoG past burnout). The propellant CoG there is multiplied by zero mass in the motor CoG anyway, so nothing downstream depends on the discarded value.

## Tests
- `test_bates_cog.py`: zero-density unequal segments give the initial-volume-weighted centroid; a fully burned-out unequal grain stays finite with no large CoG spike.
