### PR TITLE
Span the full axial web for end-burner grains

### DIFF
--- a/machwave/models/grain/fmm/base.py
+++ b/machwave/models/grain/fmm/base.py
@@ -214,9 +214,9 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
         Return the distance map for grain regression.
 
         Uses the fast marching method (scikit-fmm) on the masked face. Each
-        value represents the distance from the initial face along the
-        cross-section of the grain. When the cross-section has no burning
-        surface (end burner), a static map is returned instead.
+        value is the distance from the initial face along the cross-section.
+        With no burning surface (end burner), returns a static map set to the
+        axial burnout web, so the grain regresses along its length, not a cell.
         """
         if self.regression_map is None:
             masked_face = self.get_masked_face()
@@ -224,10 +224,18 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
             if self.has_cross_section_regression:
                 self.regression_map = self._regression_distance(masked_face)
             else:
-                unmasked = ~np.ma.getmaskarray(masked_face)
+                # End burner: web = length split across exposed ends. Fill the
+                # whole array with one constant (not 0 outside the mask) so the
+                # perimeter tracer finds no spurious contour -> zero core area.
+                exposed_ends = (not self.inhibited_surfaces.upper_end) + (
+                    not self.inhibited_surfaces.lower_end
+                )
+                axial_web = (
+                    self.normalize(self.length / exposed_ends) if exposed_ends else 0.0
+                )
                 self.regression_map = np.ma.MaskedArray(
-                    np.where(unmasked, self.get_cell_size(), 0.0),
-                    mask=~unmasked,
+                    np.full(masked_face.shape, axial_web),
+                    mask=np.ma.getmaskarray(masked_face),
                 )
         return self.regression_map
 

--- a/machwave/models/grain/fmm/base.py
+++ b/machwave/models/grain/fmm/base.py
@@ -226,7 +226,7 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
             else:
                 # End burner: web = length split across exposed ends. Fill the
                 # whole array with one constant (not 0 outside the mask) so the
-                # perimeter tracer finds no spurious contour -> zero core area.
+                # perimeter tracer finds no spurious contour.
                 exposed_ends = (not self.inhibited_surfaces.upper_end) + (
                     not self.inhibited_surfaces.lower_end
                 )

--- a/tests/test_models/test_propulsion/test_grain/test_end_burner.py
+++ b/tests/test_models/test_propulsion/test_grain/test_end_burner.py
@@ -1,0 +1,88 @@
+"""
+End / axial burner: cross-section fully inhibited, only the ends burn.
+
+With no burning front in the cross-section the FMM has nothing to propagate, so
+the regression map is built statically. It must encode the axial web (the grain
+burns along its length), not a single cell, or the grain burns out instantly.
+"""
+
+import pytest
+
+import machwave.models.grain as grain_models
+import machwave.models.grain.geometries as grain_geometries
+
+LENGTH = 100e-3
+OUTER_DIAMETER = 50e-3
+
+STAR_PARAMS = dict(
+    length=LENGTH,
+    outer_diameter=OUTER_DIAMETER,
+    number_of_points=5,
+    point_length=15e-3,
+    point_width=8e-3,
+)
+
+
+def _end_burner(**inhibition):
+    """Star grain with inner + outer surfaces inhibited, leaving only the ends."""
+    return grain_geometries.StarGrainSegment(
+        **STAR_PARAMS,
+        inhibited_surfaces=grain_models.InhibitedSurfaces(
+            inner_surface=True, outer_surface=True, **inhibition
+        ),
+    )
+
+
+def test_cross_section_has_no_burning_surface():
+    """Both radial surfaces inhibited -> no front for the FMM."""
+    assert _end_burner().has_cross_section_regression is False
+
+
+def test_double_ended_web_is_half_the_length():
+    """Two ends meet in the middle -> web = length / 2."""
+    assert _end_burner().get_web_thickness() == pytest.approx(LENGTH / 2)
+
+
+def test_single_ended_web_is_the_full_length():
+    """One end must travel the whole length -> web = length."""
+    assert _end_burner(upper_end=True).get_web_thickness() == pytest.approx(LENGTH)
+
+
+def test_burn_area_is_constant_over_the_burn():
+    """Fixed face area -> burn area holds steady (was instantaneous before)."""
+    segment = _end_burner()
+    web_thickness = segment.get_web_thickness()
+
+    initial = segment.get_burn_area(0.0)
+    assert initial > 0.0
+    for fraction in (0.25, 0.5, 0.75):
+        assert segment.get_burn_area(web_thickness * fraction) == pytest.approx(
+            initial, rel=0.05
+        )
+
+
+def test_no_phantom_core_burning():
+    """Masked bore must not be traced as a burning contour."""
+    assert _end_burner().get_core_area(0.0) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_burn_area_scales_with_exposed_ends():
+    """Two ends burn twice the face area of one."""
+    double = _end_burner().get_burn_area(0.0)
+    single = _end_burner(upper_end=True).get_burn_area(0.0)
+    assert double == pytest.approx(2.0 * single)
+
+
+def test_burn_area_is_zero_past_burnout():
+    """Beyond the web the grain is gone."""
+    segment = _end_burner()
+    assert segment.get_burn_area(segment.get_web_thickness() * 1.1) == 0.0
+
+
+def test_volume_and_burn_area_agree_on_burnout():
+    """Volume hits zero at the web thickness, matching the burn area."""
+    segment = _end_burner()
+    web_thickness = segment.get_web_thickness()
+
+    assert segment.get_volume(0.0) > 0.0
+    assert segment.get_volume(web_thickness) == pytest.approx(0.0, abs=1e-9)


### PR DESCRIPTION
Closes #391. Part of #368.

When the cross-section has no burning surface (an end / axial burner) the regression map is built statically. It set every solid cell to a single cell width, so the grain was modeled as consumed after the front moved one pixel — burnout was near-instantaneous.

This fills the static map with `length / exposed_ends` (full length for one open end, half for two, since two fronts meet in the middle), so web thickness, burn area, and volume all agree. The masked region is filled with the same constant instead of `0.0`, so its boundary is no longer traced as a phantom burning core.

## Tests
- `test_end_burner.py` (new): web is `length` / `length / 2` for one / two open ends, burn area is constant over the burn and scales with exposed ends, core area is zero, and volume reaches zero exactly at the web thickness.
