### PR TITLE
Standardize CoolProp access behind a CoolPropService

### DIFF
--- a/machwave/core/two_phase_flow.py
+++ b/machwave/core/two_phase_flow.py
@@ -1,5 +1,6 @@
-import CoolProp.CoolProp as CP
 import numpy as np
+
+import machwave.services.coolprop as coolprop_service
 
 
 def get_homogeneous_equilibrium_mass_flux(
@@ -34,8 +35,10 @@ def get_homogeneous_equilibrium_mass_flux(
     if sweep_points < 2:
         raise ValueError("sweep_points must be at least 2")
 
+    coolprop = coolprop_service.CoolPropService(fluid_name)
+
     upstream_pressure = (
-        CP.PropsSI("P", "T", temperature_upstream, "Q", 0, fluid_name)
+        coolprop.get_saturation_pressure(temperature_upstream)
         if pressure_upstream is None
         else pressure_upstream
     )
@@ -44,21 +47,21 @@ def get_homogeneous_equilibrium_mass_flux(
         return 0.0
 
     upstream_enthalpy, upstream_entropy = _get_stagnation_enthalpy_and_entropy(
-        fluid_name, temperature_upstream, upstream_pressure
+        coolprop, temperature_upstream, upstream_pressure
     )
 
     pressures = np.linspace(pressure_downstream, upstream_pressure, sweep_points)
     mass_flux = np.zeros_like(pressures)
     for index, pressure in enumerate(pressures):
         mass_flux[index] = _get_isentropic_mass_flux(
-            fluid_name, pressure, upstream_enthalpy, upstream_entropy
+            coolprop, pressure, upstream_enthalpy, upstream_entropy
         )
 
     return float(mass_flux.max())
 
 
 def _get_stagnation_enthalpy_and_entropy(
-    fluid_name: str,
+    coolprop: coolprop_service.CoolPropService,
     temperature: float,
     pressure: float,
 ) -> tuple[float, float]:
@@ -69,7 +72,7 @@ def _get_stagnation_enthalpy_and_entropy(
     when the pressure-temperature pair lies on the saturation curve.
 
     Args:
-        fluid_name: CoolProp fluid name.
+        coolprop: Fluid-property service bound to the working fluid.
         temperature: Stagnation temperature [K].
         pressure: Stagnation pressure [Pa].
 
@@ -77,17 +80,17 @@ def _get_stagnation_enthalpy_and_entropy(
         Tuple of enthalpy [J/kg] and entropy [J/(kg K)].
     """
     try:
-        enthalpy = CP.PropsSI("H", "P", pressure, "T", temperature, fluid_name)
-        entropy = CP.PropsSI("S", "P", pressure, "T", temperature, fluid_name)
+        enthalpy = coolprop.get_enthalpy_at_temperature_pressure(temperature, pressure)
+        entropy = coolprop.get_entropy_at_temperature_pressure(temperature, pressure)
         return enthalpy, entropy
     except ValueError:
-        enthalpy = CP.PropsSI("H", "T", temperature, "Q", 0, fluid_name)
-        entropy = CP.PropsSI("S", "T", temperature, "Q", 0, fluid_name)
+        enthalpy = coolprop.get_saturated_liquid_enthalpy(temperature)
+        entropy = coolprop.get_saturated_liquid_entropy(temperature)
         return enthalpy, entropy
 
 
 def _get_isentropic_mass_flux(
-    fluid_name: str,
+    coolprop: coolprop_service.CoolPropService,
     pressure: float,
     enthalpy_upstream: float,
     entropy_upstream: float,
@@ -96,7 +99,7 @@ def _get_isentropic_mass_flux(
     Get the isentropic mass flux at a given pressure for a known upstream state.
 
     Args:
-        fluid_name: CoolProp fluid name.
+        coolprop: Fluid-property service bound to the working fluid.
         pressure: Downstream pressure [Pa].
         enthalpy_upstream: Upstream stagnation enthalpy [J/kg].
         entropy_upstream: Upstream stagnation entropy [J/(kg K)].
@@ -106,8 +109,8 @@ def _get_isentropic_mass_flux(
         the upstream value or if CoolProp cannot evaluate the state.
     """
     try:
-        density = CP.PropsSI("D", "P", pressure, "S", entropy_upstream, fluid_name)
-        enthalpy = CP.PropsSI("H", "P", pressure, "S", entropy_upstream, fluid_name)
+        density = coolprop.get_density_at_pressure_entropy(pressure, entropy_upstream)
+        enthalpy = coolprop.get_enthalpy_at_pressure_entropy(pressure, entropy_upstream)
     except ValueError:
         return 0.0
     delta_enthalpy = enthalpy_upstream - enthalpy

--- a/machwave/models/feed_systems/tank.py
+++ b/machwave/models/feed_systems/tank.py
@@ -1,6 +1,5 @@
-import CoolProp.CoolProp as CP
-
 import machwave.core.ideal_gas as ideal_gas
+import machwave.services.coolprop as coolprop_service
 
 
 class Tank:
@@ -51,12 +50,14 @@ class Tank:
 
         self._validate()
 
+        self._coolprop = coolprop_service.CoolPropService(fluid_name)
+
         # The tank is isothermal with a fixed fluid, so these properties are constant
         # and cached
-        self.molar_mass = CP.PropsSI("M", fluid_name)  # kg/mol
-        self.saturation_pressure = CP.PropsSI("P", "T", temperature, "Q", 0, fluid_name)
-        self.saturated_liquid_density = CP.PropsSI(
-            "D", "T", temperature, "Q", 0, fluid_name
+        self.molar_mass = self._coolprop.get_molar_mass()  # kg/mol
+        self.saturation_pressure = self._coolprop.get_saturation_pressure(temperature)
+        self.saturated_liquid_density = self._coolprop.get_saturated_liquid_density(
+            temperature
         )
         # Single phase density at the tank temperature, memoized per pressure.
         self._density_by_pressure: dict[float, float | None] = {}
@@ -174,8 +175,10 @@ class Tank:
         """
         if pressure not in self._density_by_pressure:
             try:
-                self._density_by_pressure[pressure] = CP.PropsSI(
-                    "D", "T", self.temperature, "P", pressure, self.fluid_name
+                self._density_by_pressure[pressure] = (
+                    self._coolprop.get_density_at_temperature_pressure(
+                        self.temperature, pressure
+                    )
                 )
             except ValueError:
                 self._density_by_pressure[pressure] = None

--- a/machwave/services/coolprop.py
+++ b/machwave/services/coolprop.py
@@ -1,0 +1,146 @@
+"""Fluid property service wrapper around CoolProp."""
+
+import CoolProp.CoolProp as CP
+
+
+class CoolPropService:
+    """Thin wrapper around CoolProp `PropsSI` bound to a single fluid."""
+
+    def __init__(self, fluid_name: str) -> None:
+        """
+        Initialize the service.
+
+        Args:
+            fluid_name: Name of the fluid in the CoolProp database.
+        """
+        self.fluid_name = fluid_name
+
+    def get_molar_mass(self) -> float:
+        """
+        Get the molar mass of the fluid.
+
+        Returns:
+            Molar mass [kg/mol].
+        """
+        return CP.PropsSI("M", self.fluid_name)
+
+    def get_saturation_pressure(self, temperature: float) -> float:
+        """
+        Get the saturation pressure on the liquid side of the saturation curve.
+
+        Args:
+            temperature: Temperature [K].
+
+        Returns:
+            Saturation pressure [Pa].
+        """
+        return CP.PropsSI("P", "T", temperature, "Q", 0, self.fluid_name)
+
+    def get_saturated_liquid_density(self, temperature: float) -> float:
+        """
+        Get the saturated-liquid density at a given temperature.
+
+        Args:
+            temperature: Temperature [K].
+
+        Returns:
+            Saturated-liquid density [kg/m^3].
+        """
+        return CP.PropsSI("D", "T", temperature, "Q", 0, self.fluid_name)
+
+    def get_saturated_liquid_enthalpy(self, temperature: float) -> float:
+        """
+        Get the saturated-liquid specific enthalpy at a given temperature.
+
+        Args:
+            temperature: Temperature [K].
+
+        Returns:
+            Saturated-liquid specific enthalpy [J/kg].
+        """
+        return CP.PropsSI("H", "T", temperature, "Q", 0, self.fluid_name)
+
+    def get_saturated_liquid_entropy(self, temperature: float) -> float:
+        """
+        Get the saturated-liquid specific entropy at a given temperature.
+
+        Args:
+            temperature: Temperature [K].
+
+        Returns:
+            Saturated-liquid specific entropy [J/(kg K)].
+        """
+        return CP.PropsSI("S", "T", temperature, "Q", 0, self.fluid_name)
+
+    def get_density_at_temperature_pressure(
+        self, temperature: float, pressure: float
+    ) -> float:
+        """
+        Get the single-phase density at a given temperature and pressure.
+
+        Args:
+            temperature: Temperature [K].
+            pressure: Pressure [Pa].
+
+        Returns:
+            Density [kg/m^3].
+        """
+        return CP.PropsSI("D", "T", temperature, "P", pressure, self.fluid_name)
+
+    def get_enthalpy_at_temperature_pressure(
+        self, temperature: float, pressure: float
+    ) -> float:
+        """
+        Get the specific enthalpy at a given temperature and pressure.
+
+        Args:
+            temperature: Temperature [K].
+            pressure: Pressure [Pa].
+
+        Returns:
+            Specific enthalpy [J/kg].
+        """
+        return CP.PropsSI("H", "T", temperature, "P", pressure, self.fluid_name)
+
+    def get_entropy_at_temperature_pressure(
+        self, temperature: float, pressure: float
+    ) -> float:
+        """
+        Get the specific entropy at a given temperature and pressure.
+
+        Args:
+            temperature: Temperature [K].
+            pressure: Pressure [Pa].
+
+        Returns:
+            Specific entropy [J/(kg K)].
+        """
+        return CP.PropsSI("S", "T", temperature, "P", pressure, self.fluid_name)
+
+    def get_density_at_pressure_entropy(self, pressure: float, entropy: float) -> float:
+        """
+        Get the density at a given pressure and specific entropy.
+
+        Args:
+            pressure: Pressure [Pa].
+            entropy: Specific entropy [J/(kg K)].
+
+        Returns:
+            Density [kg/m^3].
+        """
+        return CP.PropsSI("D", "P", pressure, "S", entropy, self.fluid_name)
+
+    def get_enthalpy_at_pressure_entropy(
+        self, pressure: float, entropy: float
+    ) -> float:
+        """
+        Get the specific enthalpy at a given pressure and specific entropy.
+
+        Args:
+            pressure: Pressure [Pa].
+            entropy: Specific entropy [J/(kg K)].
+
+        Returns:
+            Specific enthalpy [J/kg].
+        """
+        return CP.PropsSI("H", "P", pressure, "S", entropy, self.fluid_name)

--- a/tests/test_services/test_coolprop.py
+++ b/tests/test_services/test_coolprop.py
@@ -1,0 +1,79 @@
+"""Tests for CoolPropService."""
+
+import CoolProp.CoolProp as CP
+import pytest
+
+import machwave.services.coolprop as coolprop_service
+
+FLUID_NAME = "N2O"
+TEMPERATURE = 293.0
+
+
+@pytest.fixture
+def service() -> coolprop_service.CoolPropService:
+    return coolprop_service.CoolPropService(FLUID_NAME)
+
+
+def test_get_molar_mass(service):
+    assert service.get_molar_mass() == CP.PropsSI("M", FLUID_NAME)
+
+
+def test_get_saturation_pressure(service):
+    assert service.get_saturation_pressure(TEMPERATURE) == CP.PropsSI(
+        "P", "T", TEMPERATURE, "Q", 0, FLUID_NAME
+    )
+
+
+def test_get_saturated_liquid_density(service):
+    assert service.get_saturated_liquid_density(TEMPERATURE) == CP.PropsSI(
+        "D", "T", TEMPERATURE, "Q", 0, FLUID_NAME
+    )
+
+
+def test_get_saturated_liquid_enthalpy(service):
+    assert service.get_saturated_liquid_enthalpy(TEMPERATURE) == CP.PropsSI(
+        "H", "T", TEMPERATURE, "Q", 0, FLUID_NAME
+    )
+
+
+def test_get_saturated_liquid_entropy(service):
+    assert service.get_saturated_liquid_entropy(TEMPERATURE) == CP.PropsSI(
+        "S", "T", TEMPERATURE, "Q", 0, FLUID_NAME
+    )
+
+
+def test_get_density_at_temperature_pressure(service):
+    pressure = service.get_saturation_pressure(TEMPERATURE) + 5e5
+    assert service.get_density_at_temperature_pressure(
+        TEMPERATURE, pressure
+    ) == CP.PropsSI("D", "T", TEMPERATURE, "P", pressure, FLUID_NAME)
+
+
+def test_get_enthalpy_at_temperature_pressure(service):
+    pressure = service.get_saturation_pressure(TEMPERATURE) + 5e5
+    assert service.get_enthalpy_at_temperature_pressure(
+        TEMPERATURE, pressure
+    ) == CP.PropsSI("H", "T", TEMPERATURE, "P", pressure, FLUID_NAME)
+
+
+def test_get_entropy_at_temperature_pressure(service):
+    pressure = service.get_saturation_pressure(TEMPERATURE) + 5e5
+    assert service.get_entropy_at_temperature_pressure(
+        TEMPERATURE, pressure
+    ) == CP.PropsSI("S", "T", TEMPERATURE, "P", pressure, FLUID_NAME)
+
+
+def test_get_density_at_pressure_entropy(service):
+    pressure = service.get_saturation_pressure(TEMPERATURE)
+    entropy = service.get_saturated_liquid_entropy(TEMPERATURE)
+    assert service.get_density_at_pressure_entropy(pressure, entropy) == CP.PropsSI(
+        "D", "P", pressure, "S", entropy, FLUID_NAME
+    )
+
+
+def test_get_enthalpy_at_pressure_entropy(service):
+    pressure = service.get_saturation_pressure(TEMPERATURE)
+    entropy = service.get_saturated_liquid_entropy(TEMPERATURE)
+    assert service.get_enthalpy_at_pressure_entropy(pressure, entropy) == CP.PropsSI(
+        "H", "P", pressure, "S", entropy, FLUID_NAME
+    )


### PR DESCRIPTION
Closes #326.

CoolProp was called raw via `CP.PropsSI` in [tank.py](machwave/models/feed_systems/tank.py) and [two_phase_flow.py](machwave/core/two_phase_flow.py), unlike CEA which is wrapped in [services/cea.py](machwave/services/cea.py).

Adds `machwave/services/coolprop.py` with a `CoolPropService` that binds a single fluid and exposes the SI lookups those two modules use, then routes both through it. No raw `PropsSI` calls remain in `machwave/` outside the service.

## Changes

- New `CoolPropService(fluid_name)` exposing molar mass, the saturated-liquid (`Q=0`) lookups, the temperature/pressure lookups, and the pressure/entropy lookups.
- [tank.py](machwave/models/feed_systems/tank.py): constructs one service in `__init__` and uses it for the cached isothermal constants and the memoized single-phase density. The existing caching is untouched, so values stay bit-identical.
- [two_phase_flow.py](machwave/core/two_phase_flow.py): builds the service once per `get_homogeneous_equilibrium_mass_flux` call and threads it through the two private helpers. Public signatures are unchanged, so the injector call site is unaffected.
- Adds `tests/test_services/test_coolprop.py` checking each method against the raw `PropsSI` call.

## Verification

- `ruff check` clean on all changed files.
- Service, two-phase-flow, and tank suites pass.