### PR TITLE
Skip the condensed-phase query for propellants with no condensed phase

### DIFF
--- a/machwave/models/propellants/categories/base.py
+++ b/machwave/models/propellants/categories/base.py
@@ -7,6 +7,12 @@ import machwave.services.cea as cea_service
 from .. import components as propellant_components
 from .. import properties as propellant_properties
 
+# Elements that keep their CEA combustion products gaseous at chamber conditions
+# (above 1000K and 10 bar)
+GASEOUS_ONLY_ELEMENTS = frozenset(
+    {"H", "C", "N", "O", "F", "CL", "BR", "I", "HE", "NE", "AR", "KR", "XE"}
+)
+
 
 class PropellantValidationError(Exception):
     """Raised when propellant validation fails."""
@@ -56,6 +62,20 @@ class Propellant(abc.ABC):
     def thermochemical_service(self) -> cea_service.RocketCEAService:
         """Get thermochemical service, cached."""
         return self._get_thermochemical_service()
+
+    @property
+    def has_condensed_phase(self) -> bool:
+        """
+        Whether this propellant can form a condensed combustion phase.
+
+        A propellant built solely from elements in `GASEOUS_ONLY_ELEMENTS` cannot form a
+        condensed phase.
+        """
+        return any(
+            element.strip().upper() not in GASEOUS_ONLY_ELEMENTS
+            for component in self.components
+            for element in component.chemical_formula
+        )
 
     @abc.abstractmethod
     def _validate_components(self):

--- a/machwave/models/propellants/categories/biliquid.py
+++ b/machwave/models/propellants/categories/biliquid.py
@@ -85,4 +85,5 @@ class BiliquidPropellant(propellant_base.Propellant):
             oxidizer_name=oxidizer.name,
             fuel_name=fuel.name,
             oxidizer_to_fuel_ratio=self.oxidizer_to_fuel_ratio,
+            has_condensed_phase=self.has_condensed_phase,
         )

--- a/machwave/models/propellants/categories/solid.py
+++ b/machwave/models/propellants/categories/solid.py
@@ -134,6 +134,7 @@ class SolidPropellant(propellant_base.Propellant):
         return cea_service.create_cea_service(
             propellant_name=cea_service.normalize_custom_propellant_name(self.name),
             card_string=card_string,
+            has_condensed_phase=self.has_condensed_phase,
         )
 
     def evaluate(

--- a/machwave/services/cea.py
+++ b/machwave/services/cea.py
@@ -66,6 +66,7 @@ def create_cea_service(
     fuel_name: str | None = None,
     fuel_card_string: str | None = None,
     oxidizer_to_fuel_ratio: float | None = None,
+    has_condensed_phase: bool = True,
 ) -> "RocketCEAService":
     """
     Create a `RocketCEAService` and register propellants if needed.
@@ -85,6 +86,8 @@ def create_cea_service(
         fuel_name: Fuel name for a biliquid propellant.
         fuel_card_string: CEA card string for a custom fuel.
         oxidizer_to_fuel_ratio: O/F ratio for a biliquid propellant.
+        has_condensed_phase: Whether the propellant can form a condensed combustion
+            phase. When False, condensed-phase queries are assumed 0.
 
     Returns:
         Configured `RocketCEAService` instance.
@@ -148,7 +151,7 @@ def create_cea_service(
             "Must provide either propellant_name or (oxidizer_name and fuel_name)"
         )
 
-    return RocketCEAService(cea_obj, oxidizer_to_fuel_ratio)
+    return RocketCEAService(cea_obj, oxidizer_to_fuel_ratio, has_condensed_phase)
 
 
 class RocketCEAService:
@@ -158,7 +161,12 @@ class RocketCEAService:
     Use `create_cea_service()` to instantiate with custom propellants.
     """
 
-    def __init__(self, cea_obj: CEA_Obj, oxidizer_to_fuel_ratio: float | None = None):
+    def __init__(
+        self,
+        cea_obj: CEA_Obj,
+        oxidizer_to_fuel_ratio: float | None = None,
+        has_condensed_phase: bool = True,
+    ):
         """
         Initialize the service from a configured `CEA_Obj`.
 
@@ -166,9 +174,12 @@ class RocketCEAService:
             cea_obj: RocketCEA `CEA_Obj` instance.
             oxidizer_to_fuel_ratio: O/F ratio for biliquid propellants
                 (optional).
+            has_condensed_phase: Whether the propellant can form a condensed combustion
+                phase. When False, condensed-phase queries are assumed 0.
         """
         self.cea_obj = cea_obj
         self.oxidizer_to_fuel_ratio = oxidizer_to_fuel_ratio
+        self.has_condensed_phase = has_condensed_phase
 
     def _resolve_mixture_ratio(self, mixture_ratio: float | None) -> float | None:
         if mixture_ratio is not None:
@@ -298,6 +309,9 @@ class RocketCEAService:
         mixture_ratio: float | None = None,
     ) -> tuple[float, float]:
         """Get condensed phase mass fractions: (chamber, exhaust)."""
+        if not self.has_condensed_phase:
+            return 0.0, 0.0
+
         chamber_pressure_psi = conversions.convert_pa_to_psi(chamber_pressure)
         mr = self._resolve_mixture_ratio(mixture_ratio)
 

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_biliquid.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_biliquid.py
@@ -60,3 +60,44 @@ class TestBiliquidEvaluateMixtureRatio:
     def test_design_attribute_unchanged_after_evaluate(self, lox_rp1_propellant):
         lox_rp1_propellant.evaluate(chamber_pressure=3e6, mixture_ratio=1.5)
         assert lox_rp1_propellant.oxidizer_to_fuel_ratio == 2.5
+
+
+def _biliquid_with_fuel_formula(
+    fuel_formula: dict[str, int],
+) -> propellants_models.BiliquidPropellant:
+    oxidizer = propellant_components.PropellantComponent(
+        name="LOX",
+        density=1141.0,
+        chemical_formula={"O": 2},
+        enthalpy=0.0,
+        role=propellant_components.ComponentRole.OXIDIZER,
+    )
+    fuel = propellant_components.PropellantComponent(
+        name="FUEL",
+        density=820.0,
+        chemical_formula=fuel_formula,
+        enthalpy=0.0,
+        role=propellant_components.ComponentRole.FUEL,
+    )
+    return propellants_models.BiliquidPropellant(
+        name="PROBE", components=[oxidizer, fuel], oxidizer_to_fuel_ratio=2.5
+    )
+
+
+class TestBiliquidCondensedPhase:
+    def test_gaseous_only_propellant_reports_no_condensed_phase(
+        self, lox_rp1_propellant
+    ):
+        assert lox_rp1_propellant.has_condensed_phase is False
+
+    def test_metal_component_reports_condensed_phase(self):
+        propellant = _biliquid_with_fuel_formula({"Al": 1})
+        assert propellant.has_condensed_phase is True
+
+    def test_element_matching_is_case_insensitive(self):
+        # "cl" must classify as the gaseous-only element Cl.
+        propellant = _biliquid_with_fuel_formula({"cl": 1, "h": 1})
+        assert propellant.has_condensed_phase is False
+
+    def test_service_inherits_no_condensed_phase_flag(self, lox_rp1_propellant):
+        assert lox_rp1_propellant.thermochemical_service.has_condensed_phase is False

--- a/tests/test_services/test_cea.py
+++ b/tests/test_services/test_cea.py
@@ -526,6 +526,54 @@ def test_generate_card_string_utility():
         cea_service.generate_card_string([])
 
 
+class TestCondensedPhaseShortCircuit:
+    """Test skipping the condensed-phase query when there is no condensed phase."""
+
+    def _knsu_card(self) -> str:
+        return cea_service.generate_card_string(
+            [
+                {
+                    "name": "KNO3",
+                    "formula": {"K": 1.0, "N": 1.0, "O": 3.0},
+                    "weight_percent": 65.0,
+                    "heat_of_formation": -118200.0,
+                    "temperature": 298.15,
+                    "density": 2.109,
+                },
+                {
+                    "name": "Sucrose",
+                    "formula": {"C": 12.0, "H": 22.0, "O": 11.0},
+                    "weight_percent": 35.0,
+                    "heat_of_formation": -531900.0,
+                    "temperature": 298.15,
+                    "density": 1.587,
+                },
+            ]
+        )
+
+    def test_default_keeps_condensed_phase_query(self):
+        service = cea_service.create_cea_service(propellant_name="AP")
+        assert service.has_condensed_phase is True
+
+    def test_flag_off_overrides_real_condensed_phase(self):
+        # KNSU has a significant condensed phase when queried, but flagging it
+        # off must skip the query and report zero for the same composition.
+        card = self._knsu_card()
+
+        queried = cea_service.create_cea_service(
+            propellant_name="TEST_KNSU_QUERIED", card_string=card
+        )
+        skipped = cea_service.create_cea_service(
+            propellant_name="TEST_KNSU_SKIPPED",
+            card_string=card,
+            has_condensed_phase=False,
+        )
+
+        assert queried.get_condensed_phase_fractions(3e6, 8.0)[0] > 0.2
+        assert skipped.has_condensed_phase is False
+        assert skipped.get_condensed_phase_fractions(3e6, 8.0) == (0.0, 0.0)
+
+
 class TestMixtureRatioOverride:
     @pytest.fixture
     def lox_rp1_service(self):


### PR DESCRIPTION
Closes #384.

`RocketCEAService.get_condensed_phase_fractions` is the most expensive single CEA query but returns approximately zero for propellants whose combustion products stay gaseous, such as nitrous oxide / ethanol.

Propellants now expose a `has_condensed_phase` property derived from their component elements: a formulation built solely from gaseous-product elements (hydrogen, carbon, nitrogen, oxygen, halogens, noble gases) cannot condense, while anything outside that set (metals, alkali species) may. The flag is threaded into `RocketCEAService`, which short-circuits the condensed-phase query to `(0.0, 0.0)` when it is False. The default stays True, so the query is only skipped when a propellant is known to be gaseous-only.