### PR TITLE
Expose map_dim in the FMM grain segment constructors

### DIFF
--- a/machwave/models/grain/geometries/conical.py
+++ b/machwave/models/grain/geometries/conical.py
@@ -15,6 +15,7 @@ class ConicalGrainSegment(grain_fmm.FMMGrainSegment3D):
         upper_core_diameter: float,
         lower_core_diameter: float,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
+        map_dim: int = 100,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -26,6 +27,7 @@ class ConicalGrainSegment(grain_fmm.FMMGrainSegment3D):
             upper_core_diameter: Core diameter at the upper (bulkhead) end [m].
             lower_core_diameter: Core diameter at the lower (nozzle) end [m].
             inhibited_surfaces: Surfaces inhibited from burning.
+            map_dim: Pixel resolution of the cross-section map.
             density_ratio: Ratio of real to ideal propellant density.
         """
         self.upper_core_diameter = upper_core_diameter
@@ -35,6 +37,7 @@ class ConicalGrainSegment(grain_fmm.FMMGrainSegment3D):
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
+            map_dim=map_dim,
             density_ratio=density_ratio,
         )
 

--- a/machwave/models/grain/geometries/d_grain.py
+++ b/machwave/models/grain/geometries/d_grain.py
@@ -14,6 +14,7 @@ class DGrainSegment(grain_fmm.FMMGrainSegment2D):
         outer_diameter: float,
         slot_offset: float,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
+        map_dim: int = 100,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -24,6 +25,7 @@ class DGrainSegment(grain_fmm.FMMGrainSegment2D):
             outer_diameter: Outer diameter [m].
             slot_offset: Distance from the grain center to the slot face [m].
             inhibited_surfaces: Surfaces inhibited from burning.
+            map_dim: Pixel resolution of the cross-section map.
             density_ratio: Ratio of real to ideal propellant density.
         """
         self.slot_offset = slot_offset
@@ -32,6 +34,7 @@ class DGrainSegment(grain_fmm.FMMGrainSegment2D):
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
+            map_dim=map_dim,
             density_ratio=density_ratio,
         )
 

--- a/machwave/models/grain/geometries/finocyl.py
+++ b/machwave/models/grain/geometries/finocyl.py
@@ -20,6 +20,7 @@ class FinocylGrainSegment(grain_fmm.FMMGrainSegment3D):
         fin_axial_offset: float = 0.0,
         transition_length: float = 0.0,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
+        map_dim: int = 100,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -41,6 +42,7 @@ class FinocylGrainSegment(grain_fmm.FMMGrainSegment3D):
                 applied at each interface between the finned and cylindrical
                 sections. A value of 0.0 gives an abrupt step [m].
             inhibited_surfaces: Surfaces inhibited from burning.
+            map_dim: Pixel resolution of the cross-section map.
             density_ratio: Ratio of real to ideal propellant density.
         """
         self.core_diameter = core_diameter
@@ -55,6 +57,7 @@ class FinocylGrainSegment(grain_fmm.FMMGrainSegment3D):
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
+            map_dim=map_dim,
             density_ratio=density_ratio,
         )
 

--- a/machwave/models/grain/geometries/multi_port.py
+++ b/machwave/models/grain/geometries/multi_port.py
@@ -16,6 +16,7 @@ class MultiPortGrainSegment(grain_fmm.FMMGrainSegment2D):
         port_radial_count: float,
         port_level_count: float,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
+        map_dim: int = 100,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -28,6 +29,7 @@ class MultiPortGrainSegment(grain_fmm.FMMGrainSegment2D):
             port_radial_count: Number of ports per concentric ring.
             port_level_count: Number of concentric rings of ports.
             inhibited_surfaces: Surfaces inhibited from burning.
+            map_dim: Pixel resolution of the cross-section map.
             density_ratio: Ratio of real to ideal propellant density.
         """
         self.port_diameter = port_diameter
@@ -38,6 +40,7 @@ class MultiPortGrainSegment(grain_fmm.FMMGrainSegment2D):
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
+            map_dim=map_dim,
             density_ratio=density_ratio,
         )
 

--- a/machwave/models/grain/geometries/rod_and_tube.py
+++ b/machwave/models/grain/geometries/rod_and_tube.py
@@ -15,6 +15,7 @@ class RodAndTubeGrainSegment(grain_fmm.FMMGrainSegment2D):
         rod_outer_diameter: float,
         tube_inner_diameter: float,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
+        map_dim: int = 100,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -26,6 +27,7 @@ class RodAndTubeGrainSegment(grain_fmm.FMMGrainSegment2D):
             rod_outer_diameter: Central rod outer diameter [m].
             tube_inner_diameter: Tube inner diameter [m].
             inhibited_surfaces: Surfaces inhibited from burning.
+            map_dim: Pixel resolution of the cross-section map.
             density_ratio: Ratio of real to ideal propellant density.
         """
         self.rod_outer_diameter = rod_outer_diameter
@@ -35,6 +37,7 @@ class RodAndTubeGrainSegment(grain_fmm.FMMGrainSegment2D):
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
+            map_dim=map_dim,
             density_ratio=density_ratio,
         )
 

--- a/machwave/models/grain/geometries/star.py
+++ b/machwave/models/grain/geometries/star.py
@@ -16,6 +16,7 @@ class StarGrainSegment(grain_fmm.FMMGrainSegment2D):
         point_length: float,
         point_width: float,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
+        map_dim: int = 100,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -28,6 +29,7 @@ class StarGrainSegment(grain_fmm.FMMGrainSegment2D):
             point_length: Radial length of each point [m].
             point_width: Width of each point at the base [m].
             inhibited_surfaces: Surfaces inhibited from burning.
+            map_dim: Pixel resolution of the cross-section map.
             density_ratio: Ratio of real to ideal propellant density.
         """
         self.number_of_points = int(number_of_points)
@@ -38,6 +40,7 @@ class StarGrainSegment(grain_fmm.FMMGrainSegment2D):
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
+            map_dim=map_dim,
             density_ratio=density_ratio,
         )
 

--- a/machwave/models/grain/geometries/wagon_wheel.py
+++ b/machwave/models/grain/geometries/wagon_wheel.py
@@ -18,6 +18,7 @@ class WagonWheelGrainSegment(grain_fmm.FMMGrainSegment2D):
         port_outer_diameter: float,
         port_angular_width: float,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
+        map_dim: int = 100,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -32,6 +33,7 @@ class WagonWheelGrainSegment(grain_fmm.FMMGrainSegment2D):
             port_outer_diameter: Outer radial extent of each spoke port [m].
             port_angular_width: Angular width of each spoke port [deg].
             inhibited_surfaces: Surfaces inhibited from burning.
+            map_dim: Pixel resolution of the cross-section map.
             density_ratio: Ratio of real to ideal propellant density.
         """
         self.core_diameter = core_diameter
@@ -44,6 +46,7 @@ class WagonWheelGrainSegment(grain_fmm.FMMGrainSegment2D):
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
+            map_dim=map_dim,
             density_ratio=density_ratio,
         )
 

--- a/tests/test_models/test_propulsion/test_grain/test_map_dim_forwarding.py
+++ b/tests/test_models/test_propulsion/test_grain/test_map_dim_forwarding.py
@@ -1,0 +1,38 @@
+import pytest
+
+from tests.factories import (
+    ConicalGrainSegmentFactory,
+    DGrainSegmentFactory,
+    FinocylGrainSegmentFactory,
+    MultiPortGrainSegmentFactory,
+    RodAndTubeGrainSegmentFactory,
+    StarGrainSegmentFactory,
+    WagonWheelGrainSegmentFactory,
+)
+
+fmm_factories = pytest.mark.parametrize(
+    "factory",
+    [
+        StarGrainSegmentFactory,
+        WagonWheelGrainSegmentFactory,
+        RodAndTubeGrainSegmentFactory,
+        MultiPortGrainSegmentFactory,
+        DGrainSegmentFactory,
+        ConicalGrainSegmentFactory,
+        FinocylGrainSegmentFactory,
+    ],
+)
+
+
+@fmm_factories
+def test_map_dim_forwarded_to_segment(factory):
+    """The constructor forwards map_dim to the FMM base instead of dropping it."""
+    segment = factory.build(map_dim=120)
+    assert segment.map_dim == 120
+
+
+@fmm_factories
+def test_map_dim_defaults_to_100(factory):
+    """Omitting map_dim keeps the base default."""
+    segment = factory.build()
+    assert segment.map_dim == 100


### PR DESCRIPTION
Closes #353.

The FMM grain geometry constructors called `super().__init__` without forwarding `map_dim`, so the cross-section resolution was stuck at the base default of 100 and could not be set when creating a segment. Forward `map_dim` through every 2D and 3D concrete constructor, matching what the STL grain segment already does, so it is a public argument on any FMM grain segment.

Affects the 2D constructors (Star, WagonWheel, RodAndTube, MultiPort, DGrain) and the 3D constructors (Finocyl, Conical). The default stays 100 and behavior is unchanged when the argument is omitted; a new test locks in both the forwarding and the default.