### PR TITLE
Speed up the 3D FMM grain center-of-gravity and moment-of-inertia tests

### DIFF
--- a/tests/test_models/test_propulsion/test_grain/test_cog/test_fmm3d_cog.py
+++ b/tests/test_models/test_propulsion/test_grain/test_cog/test_fmm3d_cog.py
@@ -13,7 +13,7 @@ class TestFMM3DSegmentCoG:
     def test_segment_cog_at_ignition(self, segment_factory, geometry_name):
         """Test CoG of a 3D segment at ignition (web_distance=0)."""
         outer_diameter = 0.1
-        length = 0.2
+        length = 0.02
 
         segment = segment_factory(length=length, outer_diameter=outer_diameter)
         cog = segment.get_center_of_gravity(web_distance=0.0)
@@ -26,7 +26,7 @@ class TestFMM3DSegmentCoG:
 
     def test_segment_cog_during_burn(self, segment_factory, geometry_name):
         """Test that 3D segment CoG remains relatively stable during burn."""
-        segment = segment_factory(length=0.2, outer_diameter=0.1)
+        segment = segment_factory(length=0.02, outer_diameter=0.1)
         web_thickness = segment.get_web_thickness()
 
         # Test at different burn stages
@@ -34,12 +34,12 @@ class TestFMM3DSegmentCoG:
         cog_half = segment.get_center_of_gravity(web_distance=web_thickness * 0.5)
 
         # For symmetric grains, axial CoG should remain near center
-        assert abs(cog_initial[0] - 0.1) < 0.02
-        assert abs(cog_half[0] - 0.1) < 0.02
+        assert abs(cog_initial[0] - 0.01) < 0.002
+        assert abs(cog_half[0] - 0.01) < 0.002
 
     def test_segment_cog_coordinate_system(self, segment_factory, geometry_name):
         """Verify that 3D FMM uses port-origin coordinate system."""
-        length = 0.3
+        length = 0.03
         segment = segment_factory(length=length, outer_diameter=0.12)
         cog = segment.get_center_of_gravity(web_distance=0.0)
 
@@ -48,7 +48,7 @@ class TestFMM3DSegmentCoG:
 
     def test_segment_cog_burnout_behavior(self, segment_factory, geometry_name):
         """Test CoG behavior as segment approaches burnout."""
-        segment = segment_factory(length=0.2, outer_diameter=0.1)
+        segment = segment_factory(length=0.02, outer_diameter=0.1)
         web_thickness = segment.get_web_thickness()
 
         # Test near burnout (95% of web thickness)
@@ -58,7 +58,7 @@ class TestFMM3DSegmentCoG:
 
         # CoG should still be calculable and near center
         assert not np.any(np.isnan(cog_near_burnout))
-        assert abs(cog_near_burnout[0] - 0.1) < 0.05
+        assert abs(cog_near_burnout[0] - 0.01) < 0.005
 
 
 @fmm3d_geometries
@@ -67,59 +67,59 @@ class TestFMM3DGrainMultiSegmentCoG:
 
     def test_single_segment_cog_position(self, segment_factory, geometry_name):
         """Test CoG with a single 3D segment of length 1.0m."""
-        grain = grain_models.Grain(spacing=0.1)
-        segment = segment_factory(length=1.0, outer_diameter=0.1)
+        grain = grain_models.Grain(spacing=0.01)
+        segment = segment_factory(length=0.1, outer_diameter=0.1)
         grain.add_segment(segment)
 
         cog = grain.get_center_of_gravity(web_distance=0.0)
 
         # Single cylindrical segment: CoG at center
-        expected_cog = np.array([0.5, 0.0, 0.0])
+        expected_cog = np.array([0.05, 0.0, 0.0])
         np.testing.assert_array_almost_equal(cog, expected_cog, decimal=2)
 
     def test_two_segments_equal_length_with_spacing(
         self, segment_factory, geometry_name
     ):
         """Test CoG with 2 3D segments of length 1.0m each with 0.1m spacing."""
-        grain = grain_models.Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.01)
 
-        segment1 = segment_factory(length=1.0, outer_diameter=0.1)
-        segment2 = segment_factory(length=1.0, outer_diameter=0.1)
+        segment1 = segment_factory(length=0.1, outer_diameter=0.1)
+        segment2 = segment_factory(length=0.1, outer_diameter=0.1)
 
         grain.add_segment(segment1)
         grain.add_segment(segment2)
 
         cog = grain.get_center_of_gravity(web_distance=0.0)
 
-        # Total length: 2.1m, expected CoG: 1.05m
-        expected_cog = np.array([1.05, 0.0, 0.0])
+        # Total length: 0.21m, expected CoG: 0.105m
+        expected_cog = np.array([0.105, 0.0, 0.0])
         np.testing.assert_array_almost_equal(cog, expected_cog, decimal=2)
 
     def test_two_segments_zero_spacing(self, segment_factory, geometry_name):
         """Test CoG with 2 3D segments with zero spacing."""
         grain = grain_models.Grain(spacing=0.0)
 
-        segment1 = segment_factory(length=1.0, outer_diameter=0.1)
-        segment2 = segment_factory(length=1.0, outer_diameter=0.1)
+        segment1 = segment_factory(length=0.1, outer_diameter=0.1)
+        segment2 = segment_factory(length=0.1, outer_diameter=0.1)
 
         grain.add_segment(segment1)
         grain.add_segment(segment2)
 
         cog = grain.get_center_of_gravity(web_distance=0.0)
 
-        # Total length: 2.0m, CoG at center: 1.0m
-        expected_cog = np.array([1.0, 0.0, 0.0])
+        # Total length: 0.2m, CoG at center: 0.1m
+        expected_cog = np.array([0.1, 0.0, 0.0])
         np.testing.assert_array_almost_equal(cog, expected_cog, decimal=2)
 
     def test_three_segments_burn_progression_constant_cog(
         self, segment_factory, geometry_name
     ):
         """Test that CoG remains relatively constant during burn for 3 identical 3D segments."""
-        grain = grain_models.Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.01)
 
-        segment1 = segment_factory(length=1.0, outer_diameter=0.1)
-        segment2 = segment_factory(length=1.0, outer_diameter=0.1)
-        segment3 = segment_factory(length=1.0, outer_diameter=0.1)
+        segment1 = segment_factory(length=0.1, outer_diameter=0.1)
+        segment2 = segment_factory(length=0.1, outer_diameter=0.1)
+        segment3 = segment_factory(length=0.1, outer_diameter=0.1)
 
         grain.add_segment(segment1)
         grain.add_segment(segment2)
@@ -136,16 +136,16 @@ class TestFMM3DGrainMultiSegmentCoG:
         np.testing.assert_array_almost_equal(cog_initial, cog_quarter, decimal=2)
         np.testing.assert_array_almost_equal(cog_initial, cog_half, decimal=2)
 
-        # Expected CoG at center: 1.6m
-        expected_cog = np.array([1.6, 0.0, 0.0])
+        # Expected CoG at center: 0.16m
+        expected_cog = np.array([0.16, 0.0, 0.0])
         np.testing.assert_array_almost_equal(cog_initial, expected_cog, decimal=2)
 
     def test_two_segments_different_densities(self, segment_factory, geometry_name):
         """Test CoG with 2 3D segments of same geometry but different densities."""
-        grain = grain_models.Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.01)
 
-        segment1 = segment_factory(length=1.0, outer_diameter=0.1, density_ratio=1.0)
-        segment2 = segment_factory(length=1.0, outer_diameter=0.1, density_ratio=0.7)
+        segment1 = segment_factory(length=0.1, outer_diameter=0.1, density_ratio=1.0)
+        segment2 = segment_factory(length=0.1, outer_diameter=0.1, density_ratio=0.7)
 
         grain.add_segment(segment1)
         grain.add_segment(segment2)
@@ -159,4 +159,4 @@ class TestFMM3DGrainMultiSegmentCoG:
         np.testing.assert_almost_equal(vol1, vol2, decimal=5)
 
         # CoG should be closer to segment 1 (denser)
-        assert cog[0] > 1.05, "CoG should be pulled toward the denser segment"
+        assert cog[0] > 0.105, "CoG should be pulled toward the denser segment"

--- a/tests/test_models/test_propulsion/test_grain/test_moi/test_fmm3d_moi.py
+++ b/tests/test_models/test_propulsion/test_grain/test_moi/test_fmm3d_moi.py
@@ -16,7 +16,7 @@ class TestFMM3DSegmentMomentOfInertia:
     def test_segment_moi_at_ignition(self, segment_factory, geometry_name):
         """Test MOI of a 3D segment at ignition (web_distance=0)."""
         outer_diameter = 0.1
-        length = 0.2
+        length = 0.02
         ideal_density = 1800.0
 
         segment = segment_factory(length=length, outer_diameter=outer_diameter)
@@ -41,7 +41,7 @@ class TestFMM3DSegmentMomentOfInertia:
 
     def test_segment_moi_tensor_structure(self, segment_factory, geometry_name):
         """Test that MOI tensor has expected structure."""
-        segment = segment_factory(length=0.2, outer_diameter=0.1)
+        segment = segment_factory(length=0.02, outer_diameter=0.1)
         ideal_density = 1800.0
 
         moi = segment.get_moment_of_inertia(
@@ -57,7 +57,7 @@ class TestFMM3DSegmentMomentOfInertia:
 
     def test_segment_moi_decreases_with_burn(self, segment_factory, geometry_name):
         """Test that MOI decreases as propellant burns (mass decreases)."""
-        segment = segment_factory(length=0.2, outer_diameter=0.1)
+        segment = segment_factory(length=0.02, outer_diameter=0.1)
         ideal_density = 1800.0
         web_thickness = segment.get_web_thickness()
 
@@ -75,7 +75,7 @@ class TestFMM3DSegmentMomentOfInertia:
 
     def test_segment_moi_scales_with_density(self, segment_factory, geometry_name):
         """Test that MOI scales linearly with density."""
-        segment = segment_factory(length=0.2, outer_diameter=0.1)
+        segment = segment_factory(length=0.02, outer_diameter=0.1)
 
         density_low = 1500.0
         density_high = 2100.0
@@ -96,8 +96,8 @@ class TestFMM3DSegmentMomentOfInertia:
         outer_diameter = 0.1
         ideal_density = 1800.0
 
-        segment_short = segment_factory(length=0.1, outer_diameter=outer_diameter)
-        segment_long = segment_factory(length=0.3, outer_diameter=outer_diameter)
+        segment_short = segment_factory(length=0.01, outer_diameter=outer_diameter)
+        segment_long = segment_factory(length=0.03, outer_diameter=outer_diameter)
 
         moi_short = segment_short.get_moment_of_inertia(
             web_distance=0.0, ideal_density=ideal_density
@@ -113,7 +113,7 @@ class TestFMM3DSegmentMomentOfInertia:
 
     def test_segment_moi_burnout_behavior(self, segment_factory, geometry_name):
         """Test MOI behavior as segment approaches burnout."""
-        segment = segment_factory(length=0.2, outer_diameter=0.1)
+        segment = segment_factory(length=0.02, outer_diameter=0.1)
         ideal_density = 1800.0
         web_thickness = segment.get_web_thickness()
 
@@ -139,7 +139,7 @@ class TestFMM3DGrainMultiSegmentMomentOfInertia:
     def test_single_segment_grain_moi(self, segment_factory, geometry_name):
         """Test MOI for a grain with a single 3D segment."""
         grain = grain_models.Grain(spacing=0.0)
-        segment = segment_factory(length=0.2, outer_diameter=0.1)
+        segment = segment_factory(length=0.02, outer_diameter=0.1)
         grain.add_segment(segment)
 
         ideal_density = 1800.0
@@ -157,8 +157,8 @@ class TestFMM3DGrainMultiSegmentMomentOfInertia:
     def test_two_segments_equal_moi(self, segment_factory, geometry_name):
         """Test MOI for two identical 3D segments."""
         grain = grain_models.Grain(spacing=0.0)
-        segment1 = segment_factory(length=0.2, outer_diameter=0.1)
-        segment2 = segment_factory(length=0.2, outer_diameter=0.1)
+        segment1 = segment_factory(length=0.02, outer_diameter=0.1)
+        segment2 = segment_factory(length=0.02, outer_diameter=0.1)
 
         grain.add_segment(segment1)
         grain.add_segment(segment2)
@@ -180,10 +180,10 @@ class TestFMM3DGrainMultiSegmentMomentOfInertia:
 
     def test_three_segments_with_spacing(self, segment_factory, geometry_name):
         """Test MOI for three 3D segments with spacing."""
-        grain = grain_models.Grain(spacing=0.05)  # 50mm spacing
+        grain = grain_models.Grain(spacing=0.005)  # 5mm spacing
 
         for _ in range(3):
-            segment = segment_factory(length=0.2, outer_diameter=0.1)
+            segment = segment_factory(length=0.02, outer_diameter=0.1)
             grain.add_segment(segment)
 
         ideal_density = 1800.0
@@ -201,7 +201,7 @@ class TestFMM3DGrainMultiSegmentMomentOfInertia:
         grain = grain_models.Grain(spacing=0.0)
 
         for _ in range(2):
-            segment = segment_factory(length=0.2, outer_diameter=0.1)
+            segment = segment_factory(length=0.02, outer_diameter=0.1)
             grain.add_segment(segment)
 
         ideal_density = 1800.0
@@ -225,15 +225,15 @@ class TestFMM3DGrainMultiSegmentMomentOfInertia:
 
         # Grain with no spacing
         grain_no_spacing = grain_models.Grain(spacing=0.0)
-        segment1 = segment_factory(length=0.2, outer_diameter=0.1)
-        segment2 = segment_factory(length=0.2, outer_diameter=0.1)
+        segment1 = segment_factory(length=0.02, outer_diameter=0.1)
+        segment2 = segment_factory(length=0.02, outer_diameter=0.1)
         grain_no_spacing.add_segment(segment1)
         grain_no_spacing.add_segment(segment2)
 
         # Grain with spacing
-        grain_with_spacing = grain_models.Grain(spacing=0.1)
-        segment3 = segment_factory(length=0.2, outer_diameter=0.1)
-        segment4 = segment_factory(length=0.2, outer_diameter=0.1)
+        grain_with_spacing = grain_models.Grain(spacing=0.01)
+        segment3 = segment_factory(length=0.02, outer_diameter=0.1)
+        segment4 = segment_factory(length=0.02, outer_diameter=0.1)
         grain_with_spacing.add_segment(segment3)
         grain_with_spacing.add_segment(segment4)
 
@@ -255,11 +255,11 @@ class TestFMM3DGrainMultiSegmentMomentOfInertia:
 
     def test_parallel_axis_theorem_validation(self, segment_factory, geometry_name):
         """Validate that parallel axis theorem is correctly applied in multi-segment grain."""
-        grain = grain_models.Grain(spacing=0.1)
+        grain = grain_models.Grain(spacing=0.01)
 
         # Create two segments
-        segment1 = segment_factory(length=0.2, outer_diameter=0.1)
-        segment2 = segment_factory(length=0.2, outer_diameter=0.1)
+        segment1 = segment_factory(length=0.02, outer_diameter=0.1)
+        segment2 = segment_factory(length=0.02, outer_diameter=0.1)
 
         grain.add_segment(segment1)
         grain.add_segment(segment2)


### PR DESCRIPTION
Closes #385.

The center-of-gravity and moment-of-inertia tests ran scikit-fmm on roughly ten million-voxel grids because the segments had a ten-to-one length-to-diameter ratio at the default map dimension of 100. Shorten the test segments tenfold so the axial layer count drops while the cross-section resolution stays at 100; lengths, spacings, and the expected centers all scale linearly, and the moment-of-inertia assertions are resolution-independent. Cuts the 3D suite from about 91 seconds to about 5 seconds.

This is test-only. The map dimension stays 100 as both the default and the hard minimum: an end-to-end convergence study showed the simulation does not converge on a coarse mesh (total impulse at map dimension 20 is about 63 percent below map dimension 100), so lowering the floor was rejected in favor of shorter grains.