### PR TITLE
Scale the 3D FMM burn area by axial slice count, not map dimension

### DIFF
--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -166,8 +166,7 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
     def _get_burn_area_uncached(self, *, map_dist: float) -> float:
         regression_map = self.get_regression_map()
 
-        web_distance = float(self.denormalize(map_dist))
-        length_factor = self.get_length(web_distance=web_distance) / self.map_dim
+        length_factor = self.length / self.get_normalized_length()
 
         # Slices with an identical cross-section trace to an identical contour at
         # this map_dist, so each distinct slice is traced only once.

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_burn_area_axial_scaling.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_burn_area_axial_scaling.py
@@ -1,0 +1,45 @@
+"""Burn area must not scale with the length-to-outer-diameter ratio.
+
+A pure-radial tube (inhibited ends, constant bore) has the exact lateral burn
+area pi * core_diameter * length at ignition, independent of how long the tube
+is. The 3D FMM once scaled this by length / outer_diameter; these guard that the
+ignition burn area stays near the analytical value and, above all, stays
+constant across length-to-outer-diameter ratios.
+"""
+
+import numpy as np
+import pytest
+
+from machwave.models.grain.base import InhibitedSurfaces
+from tests.factories import ConicalGrainSegmentFactory
+
+OUTER_DIAMETER = 0.1
+CORE_DIAMETER = 0.03
+INHIBITED_ENDS = InhibitedSurfaces(outer_surface=True, upper_end=True, lower_end=True)
+LENGTH_TO_DIAMETER_RATIOS = [0.5, 1.0, 2.0, 3.0]
+
+
+def _radial_tube(length_to_diameter):
+    return ConicalGrainSegmentFactory.build(
+        length=length_to_diameter * OUTER_DIAMETER,
+        outer_diameter=OUTER_DIAMETER,
+        upper_core_diameter=CORE_DIAMETER,
+        lower_core_diameter=CORE_DIAMETER,
+        inhibited_surfaces=INHIBITED_ENDS,
+    )
+
+
+@pytest.mark.parametrize("length_to_diameter", LENGTH_TO_DIAMETER_RATIOS)
+def test_ignition_burn_area_matches_radial_tube(length_to_diameter):
+    segment = _radial_tube(length_to_diameter)
+    expected = np.pi * CORE_DIAMETER * (length_to_diameter * OUTER_DIAMETER)
+    assert segment.get_burn_area(0.0) == pytest.approx(expected, rel=0.07)
+
+
+def test_burn_area_is_constant_across_length_to_diameter():
+    ratios = [
+        _radial_tube(r).get_burn_area(0.0)
+        / (np.pi * CORE_DIAMETER * (r * OUTER_DIAMETER))
+        for r in LENGTH_TO_DIAMETER_RATIOS
+    ]
+    assert max(ratios) / min(ratios) < 1.03

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_conical.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_conical.py
@@ -1,17 +1,11 @@
 """
-NOTE: Due to the nature of the FMM algorithm, the results of this test are
-dependent on the map_dim parameter. The higher the map_dim, the more accurate
-the results will be, but the slower the algorithm will be.
+Constant-bore conical burn area versus the analytical hollow cylinder.
 
-The burn-area curve is additionally passed through a Savitzky-Golay smoothing
-filter, which replaces individual quantized samples with a local trend and so
-shifts the comparison by a couple of percent (it reveals that the systematic
-overestimate for this constant-bore conical grain is closer to ten percent than
-the luckier raw samples suggested). Combined with the map_dim discretization
-bias and small floating-point differences across platforms, the tolerance is set
-to 15% of the expected value. The tests only run for a web distance up to 80% of
-the web thickness, since the FMM algorithm is not accurate enough (given the
-lower map_dim) for the last 20% of the web thickness.
+The 3D per-slice integration accumulates the core (lateral) burning surface, so
+the comparison is against the BATES core area rather than its full burn area,
+which also counts the two exposed end faces. Results depend on map_dim; the 15%
+tolerance absorbs the marching-squares quantization and the Savitzky-Golay
+smoothing, and the sweep stops at 80% web where the near-casing accuracy drops.
 """
 
 import numpy as np
@@ -55,7 +49,7 @@ def test_burn_area(conical_grain_segment_1, bates_equivalent_1):
 
         assert isinstance(value, float), f"Expected float, but got {type(value)}"
 
-        expected_value = bates_equivalent_1.get_burn_area(web_distance)
+        expected_value = bates_equivalent_1.get_core_area(web_distance)
         tolerance = expected_value * TOLERANCE
 
         assert value == pytest.approx(expected_value, abs=tolerance), (

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl.py
@@ -65,10 +65,7 @@ def test_burn_area_dedup_matches_per_slice_sum(finocyl_segment):
     map_dist = segment.normalize(segment.get_web_thickness() * 0.3)
 
     regression_map = segment.get_regression_map()
-    length_factor = (
-        segment.get_length(web_distance=float(segment.denormalize(map_dist)))
-        / segment.map_dim
-    )
+    length_factor = segment.length / segment.get_normalized_length()
 
     # Reference: trace every slice independently, with no caching.
     reference = 0.0


### PR DESCRIPTION
The 3D per-slice burn-area integration divided by `map_dim` while looping over `get_normalized_length() = int(map_dim * length / outer_diameter)` slices, so the axial sum spanned `length ** 2 / outer_diameter` and scaled every 3D burn area by `length / outer_diameter`. This swaps in the grid's actual axial slice thickness, `length / get_normalized_length()`.

A new radial-tube test pins the ignition burn area to its analytical lateral area `pi * core_diameter * length` across length-to-outer-diameter ratios (the ratio was 0.51, 1.02, 2.03, 3.05 before; ~1.0 after). The constant-bore conical test now compares against the BATES core area, since the 3D path accumulates only the core (lateral) surface and the end-face term is still missing.

Independent check against a CAD finocyl (12 in long, 4 in outer diameter, length-to-diameter 3.0): the total exposed surface now matches to +0.7% (164,161 vs 163,003 mm²); before this fix the port-wall surface alone was about three times too large.

Fixes #400.
