### PR TITLE
Mesh the 3D FMM burning surface with marching cubes to include end faces

### DIFF
--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -5,6 +5,7 @@ import numpy as np
 import skfmm
 from numpy.typing import NDArray
 from scipy.interpolate import interp1d
+from skimage import measure
 
 import machwave.core.filters as filters
 import machwave.core.geometric as geometric
@@ -163,42 +164,32 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         regression_slice = self.get_regression_map()[z_index]
         return fmm_contours.get_contours(regression_slice, map_dist)
 
-    def _get_burn_area_uncached(self, *, map_dist: float) -> float:
-        regression_map = self.get_regression_map()
-
-        length_factor = self.length / self.get_normalized_length()
-
-        # Slices with an identical cross-section trace to an identical contour at
-        # this map_dist, so each distinct slice is traced only once.
-        perimeter_by_slice: dict[bytes, float] = {}
-        total = 0.0
-        for z_index in range(self.get_normalized_length()):
-            regression_slice = regression_map[z_index]
-            key = np.asarray(regression_slice).tobytes()
-            perimeter = perimeter_by_slice.get(key)
-            if perimeter is None:
-                contours = fmm_contours.get_contours(regression_slice, map_dist)
-                perimeter = float(
-                    sum(
-                        self.map_to_length(
-                            fmm_contours.get_length(contour, self.map_dim)
-                        )
-                        for contour in contours
-                    )
-                )
-                perimeter_by_slice[key] = perimeter
-            total += perimeter * float(length_factor)
-
-        return float(total)
+    @staticmethod
+    def _measure_iso_surface_area(
+        regression_field: NDArray[np.float64],
+        level: float,
+        voxel_spacing: tuple[float, float, float],
+    ) -> float:
+        """Marching-cubes area [m^2] of one regression iso-level, 0 if empty."""
+        try:
+            vertices, faces, _, _ = measure.marching_cubes(
+                regression_field, level=level, spacing=voxel_spacing
+            )
+        except (ValueError, RuntimeError):
+            return 0.0
+        return float(measure.mesh_surface_area(vertices, faces))
 
     def get_burn_area_interp_func(self) -> Callable[[float], float]:
-        """Return a cached interpolator for burn area [m^2] vs normalized web."""
+        """Return a cached interpolator for burn area [m^2] vs web distance [m]."""
         if self.burn_area_interp_func is None:
             regression_map = self.get_regression_map()
-            valid = np.logical_not(self.get_mask())
-
-            values = np.asarray(regression_map[valid], dtype=np.float64).ravel()
-            if values.size == 0:
+            regression_values = np.asarray(
+                regression_map[~np.ma.getmaskarray(regression_map)], dtype=np.float64
+            )
+            max_level = (
+                float(regression_values.max()) if regression_values.size else 0.0
+            )
+            if max_level <= 0.0:
                 self.burn_area_interp_func = interp1d(
                     np.asarray([0.0], dtype=np.float64),
                     np.asarray([0.0], dtype=np.float64),
@@ -208,26 +199,41 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
                 )
                 return self.burn_area_interp_func
 
-            values.sort()
-            max_dist = float(values[-1])
-            oversample = 3
-            denom = float(self.map_dim * oversample)
-            step_count = int(max_dist * denom) + 2
-            distances = np.arange(step_count, dtype=np.float64) / denom
+            # Lift the inhibited casing above every iso level so marching cubes
+            # meshes only the burning front, not the wall.
+            regression_field = np.ma.filled(regression_map, max_level + 1.0)
+            axial_spacing = self.length / max(self.get_normalized_length() - 1, 1)
+            radial_spacing = self.outer_diameter / (self.map_dim - 1)
+            voxel_spacing = (axial_spacing, radial_spacing, radial_spacing)
 
-            burn_area_values = np.empty_like(distances, dtype=np.float64)
-            for i, dist in enumerate(distances):
-                burn_area_values[i] = self._get_burn_area_uncached(map_dist=float(dist))
+            # The iso-surface at level 0 lies on the voxelized initial face and is
+            # degenerate, so sample above it and hold the first area back to web 0.
+            sample_count = 80
+            levels = np.linspace(max_level / sample_count, max_level, sample_count)
+            surface_areas = np.array(
+                [
+                    self._measure_iso_surface_area(
+                        regression_field, float(level), voxel_spacing
+                    )
+                    for level in levels
+                ],
+                dtype=np.float64,
+            )
+            web_distances = np.concatenate(
+                ([0.0], np.asarray(self.denormalize(levels), dtype=np.float64))
+            )
+            surface_areas = np.concatenate(([surface_areas[0]], surface_areas))
 
-            burn_area_values = np.asarray(burn_area_values, dtype=np.float64)
-            smoothed_burn_area = filters.smooth_savitzky_golay(burn_area_values)
+            smoothed_areas = filters.smooth_savitzky_golay(
+                surface_areas, window_length=9, polyorder=3
+            )
             self.burn_area_interp_func = interp1d(
-                distances,
-                smoothed_burn_area,
+                web_distances,
+                smoothed_areas,
                 bounds_error=False,
                 fill_value=(
-                    float(smoothed_burn_area[0]),
-                    float(smoothed_burn_area[-1]),
+                    float(smoothed_areas[0]),
+                    float(smoothed_areas[-1]),
                 ),  # type: ignore[arg-type]
                 assume_sorted=True,
             )
@@ -237,9 +243,7 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
     def get_burn_area(self, web_distance: float) -> float:
         if web_distance > self.get_web_thickness():
             return 0.0
-        map_distance = self.normalize(web_distance)
-        value = float(self.get_burn_area_interp_func()(map_distance))
-        return max(0.0, value)
+        return max(0.0, float(self.get_burn_area_interp_func()(web_distance)))
 
     def get_volume_per_element(self) -> float:
         return (float(self.denormalize(self.get_cell_size())) * 2) ** 3

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_conical.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_conical.py
@@ -74,6 +74,19 @@ def test_burn_area(radial_conical):
         )
 
 
+def test_burn_area_includes_end_faces(conical_grain_segment_1, bates_equivalent_1):
+    """With exposed ends, the burn area counts the two end faces (core + 2 faces).
+
+    The marching-cubes surface meshes the axial end faces that a per-slice
+    perimeter misses, so an uninhibited constant-bore conical matches the full
+    BATES burn area, not just its core area.
+    """
+    conical_initial = conical_grain_segment_1.get_burn_area(0.0)
+    bates_initial = bates_equivalent_1.get_burn_area(0.0)  # core + 2 end faces
+
+    assert conical_initial == pytest.approx(bates_initial, rel=TOLERANCE)
+
+
 def test_port_area(conical_grain_segment_1, bates_equivalent_1):
     value = conical_grain_segment_1.get_port_area(0, 0.01)
 

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl.py
@@ -11,7 +11,6 @@ import numpy as np
 import pytest
 
 import machwave.models.grain as grain_models
-import machwave.models.grain.fmm.contours as fmm_contours
 import machwave.models.grain.geometries as grain_geometries
 
 # Aft-flush finned section over the lower 40% of the segment. The unfinned
@@ -55,76 +54,23 @@ def test_burn_area_is_positive_float(finocyl_segment):
         assert value > 0
 
 
-def test_burn_area_dedup_matches_per_slice_sum(finocyl_segment):
-    """Slice deduplication must reproduce the brute-force per-slice perimeter sum.
+def test_burn_area_curve_is_smooth_and_non_negative(finocyl_segment):
+    """The marching-cubes burn-area curve is smooth and never negative.
 
-    ``_get_burn_area_uncached`` caches the traced perimeter per distinct slice;
-    this guards that the cache key never collapses slices that actually differ.
+    The iso-surface area varies gently with web, so the interpolated curve must
+    stay non-negative and have only low high-frequency ripple across the whole
+    web (a quantization sawtooth would maximize the second difference).
     """
     segment = finocyl_segment
-    map_dist = segment.normalize(segment.get_web_thickness() * 0.3)
-
-    regression_map = segment.get_regression_map()
-    length_factor = segment.length / segment.get_normalized_length()
-
-    # Reference: trace every slice independently, with no caching.
-    reference = 0.0
-    for z_index in range(segment.get_normalized_length()):
-        contours = fmm_contours.get_contours(regression_map[z_index], map_dist)
-        perimeter = sum(
-            segment.map_to_length(fmm_contours.get_length(contour, segment.map_dim))
-            for contour in contours
-        )
-        reference += float(perimeter) * float(length_factor)
-
-    assert segment._get_burn_area_uncached(map_dist=map_dist) == pytest.approx(
-        reference, rel=1e-12
-    )
-
-
-def test_burn_area_curve_is_smoothed(finocyl_segment):
-    """The 3D burn-area interpolator smooths marching-squares quantization
-    ripple, mirroring the 2D path.
-
-    Sampling the interpolator at its own web grid must yield a curve with far
-    less high-frequency ripple than the raw per-web samples it is built from,
-    while preserving the burn-area integral (total impulse).
-    """
-    segment = finocyl_segment
-
-    # Reconstruct the normalized-web grid the interpolator samples internally
-    # (see _3d.get_burn_area_interp_func: oversample=3 over the distance map).
-    oversample = 3
-    regression_map = segment.get_regression_map()
-    valid = np.logical_not(segment.get_mask())
-    values = np.asarray(regression_map[valid], dtype=np.float64).ravel()
-    max_dist = float(values.max())
-    denom = segment.map_dim * oversample
-    step_count = int(max_dist * denom) + 2
-    distances = np.arange(step_count, dtype=np.float64) / denom
-
-    raw = np.array(
-        [segment._get_burn_area_uncached(map_dist=float(d)) for d in distances]
-    )
-    interpolate = segment.get_burn_area_interp_func()
-    smoothed = np.array([float(interpolate(d)) for d in distances])
-
-    def high_frequency_ripple(curve):
-        # RMS of the discrete second difference relative to the mean: a
-        # quantization sawtooth maximizes curvature, a smooth trend minimizes it.
-        second_difference = curve[2:] - 2.0 * curve[1:-1] + curve[:-2]
-        return float(np.sqrt(np.mean(second_difference**2)) / np.mean(np.abs(curve)))
-
-    # Smoothing removes the bulk of the ripple (observed ~4x; assert a safe 3x).
-    assert high_frequency_ripple(smoothed) < high_frequency_ripple(raw) / 3
-
-    # The average burn area, and therefore the total impulse, is preserved.
-    assert smoothed.mean() == pytest.approx(raw.mean(), rel=0.01)
-
-    # The public burn area stays non-negative across the whole web.
     web_thickness = segment.get_web_thickness()
-    for web_distance in np.linspace(0, web_thickness, 25):
-        assert segment.get_burn_area(web_distance) >= 0.0
+    webs = np.linspace(0.0, web_thickness, 60)
+    curve = np.array([segment.get_burn_area(w) for w in webs])
+
+    assert np.all(curve >= 0.0)
+
+    second_difference = curve[2:] - 2.0 * curve[1:-1] + curve[:-2]
+    ripple = float(np.sqrt(np.mean(second_difference**2)) / np.mean(np.abs(curve)))
+    assert ripple < 0.1
 
 
 def test_port_area_returns_float(finocyl_segment):


### PR DESCRIPTION
The 3D per-slice perimeter integration measured only the in-plane (radial) burning surface, so it never counted the axial end faces of a grain with exposed ends. An uninhibited constant-bore tube reported about 40 percent of its true area (core only, no end faces).

This meshes the regression iso-surface with marching cubes, whose area naturally includes the end faces and the rounded fin corners. The inhibited casing is lifted above every iso level so only the burning front is meshed, and the curve is sampled above level 0 (which is degenerate on the voxelized initial face) and held back to web 0.

Validation:
- Uninhibited length-equal-to-diameter tube: initial burn area now matches full BATES (core plus two faces) to 0.1 percent (was 0.42 times).
- Inhibited tube: stays core-only and tracks the analytical lateral area across the whole web.
- A CAD finocyl (12 inch long, 4 inch outer diameter, exposed ends): the initial burning surface (port walls plus end faces) matches the CAD value to +0.1 to +0.9 percent across map dimensions 100 to 200, and the total exposed surface to within 0.4 percent.
- Curve build stays in the 1 to 4 second range (map dimension 100 to 150), competitive with the per-slice method it replaces.

Stacked on #404. Fixes #401.
