### PR TITLE
Validate the finocyl grain against SolidWorks at web zero

### DIFF
--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl_solidworks.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl_solidworks.py
@@ -1,0 +1,95 @@
+"""
+Finocyl 3D FMM grain validated against a CAD model.
+
+The reference burn area, volume, center of gravity, moment of inertia and aft end face
+area below were evaluated in SolidWorks 2024.
+"""
+
+import numpy as np
+import pytest
+
+import machwave.models.grain.geometries as grain_geometries
+
+GEOMETRIC_PARAMS = dict(
+    length=0.3048,  # 12 in
+    outer_diameter=0.1016,  # 4 in
+    core_diameter=0.03556,  # 1.4 in
+    number_of_fins=6,
+    fin_length=0.0127,  # 0.5 in
+    fin_width=0.003175,  # 1/8 in
+    finned_length=0.127,  # 5 in, includes the transition
+    transition_length=0.0254,  # 1 in
+    fin_axial_offset=0.0,  # fins flush against the aft end
+)
+
+CASES = [  # only includes web distance of 0.0 mm (initial)
+    pytest.param(
+        dict(
+            web=0.0,
+            burn_area=65738.2e-6,
+            burn_rel=0.02,  # 2%
+            volume=2112634.15e-9,
+            volume_rel=0.03,  # 3%
+            cog_axial=154.91e-3,
+            cog_rel=0.02,  # 2%
+            moi_ratio=17763076.55 / 3108025.60,
+            moi_rel=0.04,  # 4%
+            end_face=6626.69e-6,
+            end_face_rel=0.02,  # 2%
+        ),
+        id="web=0",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def segment():
+    return grain_geometries.FinocylGrainSegment(**GEOMETRIC_PARAMS)
+
+
+@pytest.mark.parametrize("case", CASES)
+def test_burn_area_matches_solidworks(segment, case):
+    assert segment.get_burn_area(case["web"]) == pytest.approx(
+        case["burn_area"], rel=case["burn_rel"]
+    )
+
+
+@pytest.mark.parametrize("case", CASES)
+def test_volume_matches_solidworks(segment, case):
+    assert segment.get_volume(case["web"]) == pytest.approx(
+        case["volume"], rel=case["volume_rel"]
+    )
+
+
+@pytest.mark.parametrize("case", CASES)
+def test_axial_center_of_gravity_matches_solidworks(segment, case):
+    cog = segment.get_center_of_gravity(case["web"])
+    assert cog[0] == pytest.approx(case["cog_axial"], rel=case["cog_rel"])
+
+
+@pytest.mark.parametrize("case", CASES)
+def test_center_of_gravity_is_on_the_axis(segment, case):
+    """Six evenly spaced fins are radially symmetric, so the transverse center of
+    gravity stays on the axis."""
+    cog = segment.get_center_of_gravity(case["web"])
+    pixel = segment.map_to_length(1.0)
+    assert abs(cog[1]) < pixel
+    assert abs(cog[2]) < pixel
+
+
+@pytest.mark.parametrize("case", CASES)
+def test_moment_of_inertia_ratio_matches_solidworks(segment, case):
+    """Absolute moments need the SolidWorks propellant density, so the ratio is used
+    since it does not depend on the density."""
+    diagonal = np.sort(np.diag(segment.get_moment_of_inertia(1800.0, case["web"])))
+    axial, transverse = diagonal[0], np.mean(diagonal[1:])
+    assert transverse / axial == pytest.approx(case["moi_ratio"], rel=case["moi_rel"])
+
+
+@pytest.mark.parametrize("case", CASES)
+def test_finned_end_face_area_matches_solidworks(segment, case):
+    face_map = segment.get_face_map(web_distance=case["web"])
+    pixel_area = segment.map_to_length(1.0) ** 2
+    slice_areas = np.count_nonzero(face_map == 1, axis=(1, 2)) * pixel_area
+    end_face = slice_areas[slice_areas > 0.5 * slice_areas.max()][0]
+    assert end_face == pytest.approx(case["end_face"], rel=case["end_face_rel"])


### PR DESCRIPTION
Closes #406.

Adds `test_finocyl_solidworks.py`, validating the finocyl 3D Fast Marching Method grain segment against values computed by hand in **SolidWorks 2024** for a 12 in long, 4 in diameter, six-fin grain. At web = 0 the simulated grain is the exact CAD geometry, so every quantity matches within a few percent at the default `map_dim` of 100:

| Check | Tolerance | Actual error |
| --- | --- | --- |
| Burn area (outer casing excluded) | 2% | −0.50% |
| Volume | 3% | −1.87% |
| Center of gravity (axial) | 2% | −1.08% |
| Center of gravity on-axis | < 1 pixel | half-pixel |
| Moment of inertia ratio (density-free) | 4% | +2.03% |
| Finned end-face area | 2% | +0.88% |

Notes:
- The SolidWorks total surface area includes the outer cylindrical casing surface, which does not burn, so the burn-area reference subtracts it (pi × outer_diameter × length).
- The moment of inertia is checked as the density-independent transverse-to-axial ratio, since the SolidWorks propellant density was not recorded.
- The tests are parametrized over web-distance cases; only web = 0 is included here, so the web = 10 mm case (reference values recorded in #406) can be appended later.

The whole module runs in about 4 seconds, almost all of it the single marching-cubes burn-area build, which is cached for the remaining checks.