### PR TITLE
Improve naming and consistency in the Fast Marching Method grain module

### DIFF
--- a/docs/theory/grain_regression.md
+++ b/docs/theory/grain_regression.md
@@ -19,7 +19,7 @@ In the context of grain regression analysis, the wavefront represents the burnin
 In short, Machwave builds a map of the grain with matrices (depending on the geometry).
 Each cell in the map represents either a 1. point in the propellant; 2. a point outside the outer diameter; or 3. an empty point.
 The burn surface is defined by the boundary between 1 and 3.
-The number of cells in the map is determined by the map dimension. A higher map dimension means a more accurate representation of the grain, but longer computation time.
+The number of cells in the map is determined by the grid resolution. A higher grid resolution means a more accurate representation of the grain, but longer computation time.
 
 The FMM algorithm then picks up this map and calculates the distance from the initial burning surface(s) to every point in the propellant grain.
 The result is a single regression map, that can be used to determine the perimeter of the burning surface at any web distance.
@@ -30,11 +30,11 @@ Section 4.1 walks through the 2D FMM implementation step by step, showing the ar
 
 ## 4.1 Step by Step
 
-This section walks through a single tubular grain regression with a map dimension of `n=13`, but the same steps apply to any other geometry.
+This section walks through a single tubular grain regression with a grid resolution of `n=13`, but the same steps apply to any other geometry.
 The map is kept this small for documentation only, real simulations have a lower limit of `n=100`.
 
-**Generate the coordinate maps: [`get_maps()`][machwave.models.grain.fmm._2d.FMMGrainSegment2D.get_maps].**
-Each cell is given a position `(x, y)` as a fraction of the grain radius, so the outer diameter sits at radius 1. The two maps are just the axis broadcast over the grid:
+**Generate the coordinate grids: [`get_coordinate_grids()`][machwave.models.grain.fmm._2d.FMMGrainSegment2D.get_coordinate_grids].**
+Each cell is given a position `(x, y)` as a fraction of the grain radius, so the outer diameter sits at radius 1. The two grids are just the axis values broadcast across the cross-section:
 
 ```
 x by column:  -1.00 -0.83 -0.67 -0.50 -0.33 -0.17  0.00  0.17  0.33  0.50  0.67  0.83  1.00
@@ -44,7 +44,7 @@ y by row:     -1.00 -0.83 -0.67 -0.50 -0.33 -0.17  0.00  0.17  0.33  0.50  0.67 
 ![map_x gradient](../assets/theory/grain_regression/coord_x.svg)
 ![map_y gradient](../assets/theory/grain_regression/coord_y.svg)
 
-**Mask the outer diameter: [`get_mask()`][machwave.models.grain.fmm._2d.FMMGrainSegment2D.get_mask].**
+**Mask the outer diameter: [`get_outer_diameter_mask()`][machwave.models.grain.fmm._2d.FMMGrainSegment2D.get_outer_diameter_mask].**
 A `1` marks a cell outside the outer diameter ($x^2 + y^2 > 1$); the `0` cells are propellant.
 
 ```
@@ -65,7 +65,7 @@ A `1` marks a cell outside the outer diameter ($x^2 + y^2 > 1$); the `0` cells a
 
 ![casing mask](../assets/theory/grain_regression/mask.svg)
 
-**Carve the core: [`get_initial_face_map()`][machwave.models.grain.fmm.base.FMMGrainSegment.get_initial_face_map].**
+**Carve the core: [`generate_initial_face_map()`][machwave.models.grain.fmm.base.FMMGrainSegment.generate_initial_face_map].**
 Each grain geometry draws its own shape here.
 This example uses a circular core. Empty cells are `0`, solid propellant is `1`.
 
@@ -88,7 +88,7 @@ This example uses a circular core. Empty cells are `0`, solid propellant is `1`.
 ![initial port](../assets/theory/grain_regression/initial_face.svg)
 
 **Apply the inhibitors: [`get_masked_face()`][machwave.models.grain.fmm.base.FMMGrainSegment.get_masked_face].**
-Lays the initial face over the outer-diameter mask, then `_apply_inhibition` decides which of the grain's four surfaces are allowed to burn (an inhibited surface cannot burn).
+Lays the initial face over the outer-diameter mask, then `_apply_surface_inhibition` decides which of the grain's four surfaces are allowed to burn (an inhibited surface cannot burn).
 By default only the outer surface is inhibited.
 
 | Surface | Default | 2D | 3D |
@@ -160,7 +160,7 @@ The face map at a web distance is obtained by thresholding the regression map at
 ![regressed face map](../assets/theory/grain_regression/face_map.svg)
 
 **Contour the burn front: [`get_contours(w)`][machwave.models.grain.fmm._2d.FMMGrainSegment2D.get_contours].**
-A closed-loop curve is traced by `get_contours` in `machwave.models.grain.fmm.contours`, for a given web distance.
+A closed-loop curve is traced by `get_iso_contours` in `machwave.models.grain.fmm.contours`, for a given web distance.
 Then, `get_length` sums the curve to calculate the burning perimeter, discounting any stretch that lies on the casing wall.
 
 ```
@@ -175,7 +175,7 @@ The contour gives the burning perimeter at a single web distance.
 The burn area is that perimeter times the current grain length, plus any uninhibited end faces.
 At each web step Machwave contours the front and evaluates that burn area, building the burn area as a function of web. The curve is then smoothed with a Savitzky-Golay filter (`smooth_savitzky_golay` in `machwave.core.filters`).
 
-The burn area curve is interpolated with `scipy`'s `interp1d` by [`get_burn_area_interp_func`][machwave.models.grain.fmm._2d.FMMGrainSegment2D.get_burn_area_interp_func] and then cached. So `get_burn_area(w)` does not run the FMM at all, just a quick lookup and interpolation.
+The burn area curve is interpolated with `scipy`'s `interp1d` by [`get_burn_area_interpolator`][machwave.models.grain.fmm._2d.FMMGrainSegment2D.get_burn_area_interpolator] and then cached. So `get_burn_area(w)` does not run the FMM at all, just a quick lookup and interpolation.
 
 **Volume: [`get_volume(w)`][machwave.models.grain.fmm._2d.FMMGrainSegment2D.get_volume].**
 The volume is the current grain length times the face area, reusing the same cached, smoothed face-area curve that feeds the port area, so it adds no work of its own.
@@ -186,11 +186,11 @@ The port is the empty space inside the casing: the casing cross-section minus th
 ## 4.2 2D vs 3D FMM
 
 [`FMMGrainSegment2D`][machwave.models.grain.fmm._2d.FMMGrainSegment2D] describes a grain by a single cross-section extruded along its length.
-[`FMMGrainSegment3D`][machwave.models.grain.fmm._3d.FMMGrainSegment3D] adds a `z` axis to the maps, split into `get_normalized_length()` slices, so each slice can carve its own core, needed for varying geometries like finocyl or conical grains.
+[`FMMGrainSegment3D`][machwave.models.grain.fmm._3d.FMMGrainSegment3D] adds a `z` axis to the maps, split into `get_axial_resolution()` slices, so each slice can carve its own core, needed for varying geometries like finocyl or conical grains.
 The FMM runs once over the full volume.
-Since the slice count is rounded to an integer, `_regression_distance` passes a per-axis pitch (`dx=[axial_pitch, radial_pitch, radial_pitch]`) so distances stay consistent along `z` and across the cross-section.
+Since the slice count is rounded to an integer, `_compute_regression_distance` passes a per-axis grid spacing (`dx=[axial_grid_spacing, radial_grid_spacing, radial_grid_spacing]`) so distances stay consistent along `z` and across the cross-section.
 
-The regression map is generated differently for 2D and 3D. 2D traces a perimeter with marching squares ([`get_contours`][machwave.models.grain.fmm._2d.FMMGrainSegment2D.get_contours], using `skimage`'s `find_contours`). 3D meshes a surface with marching cubes ([`get_burn_area_interp_func`][machwave.models.grain.fmm._3d.FMMGrainSegment3D.get_burn_area_interp_func], `skimage`'s `marching_cubes`) and takes its area directly.
+The regression map is generated differently for 2D and 3D. 2D traces a perimeter with marching squares ([`get_contours`][machwave.models.grain.fmm._2d.FMMGrainSegment2D.get_contours], using `skimage`'s `find_contours`). 3D meshes a surface with marching cubes ([`get_burn_area_interpolator`][machwave.models.grain.fmm._3d.FMMGrainSegment3D.get_burn_area_interpolator], `skimage`'s `marching_cubes`) and takes its area directly.
 
 For volume, 3D FMM counts the solid voxels in the entire map and multiplies by the volume of one voxel.
 
@@ -198,16 +198,16 @@ Since the port area in 3D varies along the grain, [`get_port_area(w, z)`][machwa
 
 ## 4.3 Call Flow
 
-The setup pipeline is shared by both implementations. They diverge only at how the burn area is measured and how volume and port area are read back. Methods marked `*` are overridden in 3D: `get_maps` adds a `z` axis, `_apply_inhibition` works slice by slice, and `_regression_distance` uses a per-axis pitch.
+The setup pipeline is shared by both implementations. They diverge only at how the burn area is measured and how volume and port area are read back. Methods marked `*` are overridden in 3D: `get_coordinate_grids` adds a `z` axis, `_apply_surface_inhibition` works slice by slice, and `_compute_regression_distance` uses a per-axis grid spacing.
 
 **Shared setup — `FMMGrainSegment`**
 
 ```mermaid
 flowchart TB
-    A["get_maps() *"] --> B["get_mask()"]
-    B --> C["get_initial_face_map()"]
-    C --> D["get_masked_face()<br/>applies _apply_inhibition *"]
-    D --> E["get_regression_map()<br/>via _regression_distance * → skfmm.distance"]
+    A["get_coordinate_grids() *"] --> B["get_outer_diameter_mask()"]
+    B --> C["generate_initial_face_map()"]
+    C --> D["get_masked_face()<br/>applies _apply_surface_inhibition *"]
+    D --> E["get_regression_map()<br/>via _compute_regression_distance * → skfmm.distance"]
     E --> F["get_web_thickness()"]
     E --> G["get_face_map(w)"]
 ```
@@ -216,8 +216,8 @@ flowchart TB
 
 ```mermaid
 flowchart TB
-    R(["regression map"]) --> BA["get_burn_area_interp_func()"]
-    R --> FA["get_face_area_interp_func()"]
+    R(["regression map"]) --> BA["get_burn_area_interpolator()"]
+    R --> FA["get_face_area_interpolator()"]
     BA --> CT["get_contours(w) → find_contours<br/>(marching squares), per web step"]
     CT --> LN["get_length()"]
     LN --> CO["perimeter × get_length(w)<br/>+ uninhibited end faces"]
@@ -232,8 +232,8 @@ flowchart TB
 
 ```mermaid
 flowchart TB
-    R(["regression map"]) --> BA["get_burn_area_interp_func()"]
-    BA --> MC["_measure_iso_surface_area() → marching_cubes<br/>per iso level"]
+    R(["regression map"]) --> BA["get_burn_area_interpolator()"]
+    BA --> MC["_compute_iso_surface_area() → marching_cubes<br/>per iso level"]
     MC --> SG["smooth_savitzky_golay → interp1d (cached)"]
     SG --> BR["get_burn_area(w)"]
     R --> PA["get_port_area(w, z)<br/>casing − slice solid area"]

--- a/examples/grain_moment_of_inertia.py
+++ b/examples/grain_moment_of_inertia.py
@@ -15,19 +15,27 @@ import machwave.models.grain.geometries.conical as conical_geometry
 import machwave.models.grain.geometries.star as star_geometry
 
 
-def print_inertia_tensor(moi: np.ndarray, title: str = "Moment of Inertia Tensor"):
+def print_inertia_tensor(
+    inertia_tensor: np.ndarray, title: str = "Moment of Inertia Tensor"
+):
     """Pretty print the inertia tensor."""
     print(f"\n{title}")
     print("=" * 60)
     print("Coordinate system: [axial, radial_x, radial_y]")
     print("\nInertia Tensor [kg⋅m²]:")
-    print(f"  [[{moi[0, 0]:9.6f}, {moi[0, 1]:9.6f}, {moi[0, 2]:9.6f}]")
-    print(f"   [{moi[1, 0]:9.6f}, {moi[1, 1]:9.6f}, {moi[1, 2]:9.6f}]")
-    print(f"   [{moi[2, 0]:9.6f}, {moi[2, 1]:9.6f}, {moi[2, 2]:9.6f}]]")
+    print(
+        f"  [[{inertia_tensor[0, 0]:9.6f}, {inertia_tensor[0, 1]:9.6f}, {inertia_tensor[0, 2]:9.6f}]"
+    )
+    print(
+        f"   [{inertia_tensor[1, 0]:9.6f}, {inertia_tensor[1, 1]:9.6f}, {inertia_tensor[1, 2]:9.6f}]"
+    )
+    print(
+        f"   [{inertia_tensor[2, 0]:9.6f}, {inertia_tensor[2, 1]:9.6f}, {inertia_tensor[2, 2]:9.6f}]]"
+    )
     print("\nPrincipal moments:")
-    print(f"  Ixx (axial/roll):    {moi[0, 0]:.6f} kg⋅m²")
-    print(f"  Iyy (radial/pitch):  {moi[1, 1]:.6f} kg⋅m²")
-    print(f"  Izz (radial/yaw):    {moi[2, 2]:.6f} kg⋅m²")
+    print(f"  Ixx (axial/roll):    {inertia_tensor[0, 0]:.6f} kg⋅m²")
+    print(f"  Iyy (radial/pitch):  {inertia_tensor[1, 1]:.6f} kg⋅m²")
+    print(f"  Izz (radial/yaw):    {inertia_tensor[2, 2]:.6f} kg⋅m²")
 
 
 def example_single_segment():
@@ -125,7 +133,7 @@ def example_burn_progression():
 
     for fraction in burn_stages:
         web_distance = web_thickness * fraction
-        moi = grain.get_moment_of_inertia(
+        inertia_tensor = grain.get_moment_of_inertia(
             web_distance=web_distance, ideal_density=ideal_density
         )
         mass = grain.get_propellant_mass(
@@ -133,7 +141,7 @@ def example_burn_progression():
         )
 
         print(
-            f"  {fraction * 100:5.0f}%   | {moi[0, 0]:11.8f} | {moi[1, 1]:11.8f} | {mass:8.4f}"
+            f"  {fraction * 100:5.0f}%   | {inertia_tensor[0, 0]:11.8f} | {inertia_tensor[1, 1]:11.8f} | {mass:8.4f}"
         )
 
 
@@ -165,9 +173,11 @@ def example_asymmetric_grain():
     grain.add_segment(segment2)
 
     ideal_density = 1800.0
-    moi = grain.get_moment_of_inertia(web_distance=0.0, ideal_density=ideal_density)
+    inertia_tensor = grain.get_moment_of_inertia(
+        web_distance=0.0, ideal_density=ideal_density
+    )
 
-    print_inertia_tensor(moi, "Asymmetric Grain MOI")
+    print_inertia_tensor(inertia_tensor, "Asymmetric Grain MOI")
 
     cog = grain.get_center_of_gravity(web_distance=0.0)
     print(
@@ -252,7 +262,7 @@ def example_3d_fmm_conical_grain():
 
     for fraction in [0.0, 0.25, 0.50, 0.75, 0.95]:
         web_distance = web_thickness * fraction
-        moi = conical_segment.get_moment_of_inertia(
+        inertia_tensor = conical_segment.get_moment_of_inertia(
             web_distance=web_distance, ideal_density=ideal_density
         )
         mass = conical_segment.get_mass(
@@ -260,8 +270,8 @@ def example_3d_fmm_conical_grain():
         )
 
         print(
-            f" {fraction * 100:5.0f}% | {moi[0, 0]:11.8f} | {moi[1, 1]:11.8f} | "
-            f"{moi[2, 2]:11.8f} | {mass:8.4f}"
+            f" {fraction * 100:5.0f}% | {inertia_tensor[0, 0]:11.8f} | {inertia_tensor[1, 1]:11.8f} | "
+            f"{inertia_tensor[2, 2]:11.8f} | {mass:8.4f}"
         )
 
     print(

--- a/machwave/models/grain/fmm/NAMING_PLAN.md
+++ b/machwave/models/grain/fmm/NAMING_PLAN.md
@@ -1,0 +1,281 @@
+# FMM module naming improvement plan
+
+A plan to give every function, method, and variable in the Fast Marching Method
+(FMM) grain-regression module a self-describing name, grounded in the standard
+vocabulary of the relevant fields rather than ad-hoc abbreviations.
+
+Scope: `machwave/models/grain/fmm/` — `base.py`, `_2d.py`, `_3d.py`, `stl.py`,
+`contours.py`.
+
+## Why
+
+The current names mix three sins that the literature on naming warns against:
+
+- **Semantically empty names** — `get_maps`, `mask`, `maps`, `values`,
+  `counts`, `valid`, `invalid`. They name a *type* ("a map", "some values")
+  instead of the *thing* ("coordinate grids", "sorted regression distances").
+- **Cryptic abbreviations** — `n_le`, `moi`, `I_axial`, `map_dim`, `map_dist`,
+  `maskarr`. Unpronounceable, unsearchable, force mental translation.
+- **Disinformation** — `map_dim` reads as *dimensionality* (2 vs 3) but means
+  *grid points per axis*; `get_normalized_length` returns an integer **count**,
+  not a length; `get_cell_size` returns a **normalized** spacing, not metres;
+  a `map` parameter in `contours.py` shadows the `map` builtin.
+
+## Guiding principles (from the literature)
+
+| Principle | Source |
+|---|---|
+| Use intention-revealing names; avoid disinformation; make meaningful distinctions; use pronounceable, searchable names; avoid encodings and mental mapping | R. C. Martin, *Clean Code* (2008), ch. 2 |
+| Name length should be proportional to scope; put computed-qualifiers (`Count`, `Total`, `Sum`, `Smoothed`) **last** | S. McConnell, *Code Complete* 2e (2004), ch. 11 |
+| `snake_case`; predicates read as questions (`is_`, `has_`); `UPPER_CASE` constants | PEP 8; PEP 20 |
+| Prefer the established term of the problem/solution domain over an invented one | Martin ch. 2; McConnell ch. 11 |
+
+Domain vocabularies the names should draw from:
+
+- **FMM / level-set / eikonal** — arrival-time field `T(x)`, distance field,
+  signed distance function, front / zero level set, iso-contour, iso-surface,
+  iso-level. (Sethian, *Level Set Methods and Fast Marching Methods*, 1999;
+  Osher & Sethian, *JCP* 79, 1988; Osher & Fedkiw, 2003.)
+- **Computational geometry** — voxel, voxelization, voxel/grid spacing,
+  marching squares (2D) / marching cubes (3D), iso-surface extraction, mesh.
+  (Lorensen & Cline, *SIGGRAPH* 1987; scikit-image / trimesh docs.)
+- **Scientific computing** — grid points (`n`, `nx`, `ny`), grid spacing (`dx`),
+  coordinate grids (meshgrid output), masked arrays (numpy.ma: `True` = excluded),
+  interpolant. (NumPy / SciPy / scikit-fmm conventions.)
+- **Solid-rocket internal ballistics** — web & web thickness, port / face /
+  burn / core area, regression (burn-back), recession, inhibited surface,
+  bore / core. (Sutton & Biblarz, *Rocket Propulsion Elements*.)
+
+## Conventions adopted by this plan
+
+1. **Preserve visibility.** A leading underscore is kept on rename — a private
+   helper stays private. (Several names below keep a `_` the raw research dropped.)
+2. **Coordinate-frame suffixes** for numeric arrays, spelled out (no
+   abbreviations): `_grid` for normalized `[-1, 1]` grid coordinates ·
+   `_denormalized` for values in metres (the output of `denormalize`) ·
+   `_normalized` for dimensionless normalized values · `_relative` for
+   coordinates relative to the centre of gravity.
+3. **Grid vocabulary:** *grid resolution* = samples per axis (replaces `map_dim`);
+   *grid spacing* = physical distance between samples (replaces `pitch` /
+   `voxel_size`); *cell / pixel / voxel* = one grid element.
+4. **Iso-level vocabulary** for level-set sampling: *iso level* (the threshold),
+   *iso contour* (2D), *iso surface* (3D).
+5. **Qualifier-last** for derived series: `face_area_smoothed`, `*_count`,
+   `*_per_iso_level`.
+6. **Keep established domain terms** even where an FMM-canon synonym exists:
+   *web / web thickness*, *port / face / burn / core area*, *regression map*,
+   *recession*, *inhibited surface*, *bore / core*. The value is in fixing the
+   empty and cryptic names, not in re-labelling correct domain terms.
+
+## Out of scope — the `GrainSegment` base contract
+
+These names are defined or declared on `GrainSegment` / `GrainSegment2D` /
+`GrainSegment3D` in `machwave/models/grain/base.py`. Renaming them ripples
+across **every** geometry, the motor model, plots, and tests, so they are
+**not** part of an FMM-only rename: `get_web_thickness`, `get_length`,
+`get_port_area`, `get_burn_area`, `get_volume`, `get_face_area`, `get_core_area`,
+`get_center_of_gravity`, `get_moment_of_inertia`, `get_mass`, `validate`,
+and the parameters `web_distance`, `length`, `outer_diameter`, `density_ratio`,
+`inhibited_surfaces`. They are already domain-standard and intention-revealing.
+
+## Deliberately kept (considered and rejected)
+
+- **`normalize` / `denormalize`** — a recognised mathematical pair; the inverse
+  symmetry is itself information. A docstring noting "fraction of the radius"
+  beats a verbose `to_normalized_half_diameter`.
+- **The `face_map` terminology** — kept across `generate_initial_face_map`,
+  `get_masked_face`, `get_face_map`, `get_empty_face_map`. "Face" is the correct
+  grain-regression term (the burning cross-section); "occupancy grid" is robotics
+  vocabulary that drifts from the FMM/SRM literature. `get_initial_face_map` was
+  renamed to `generate_initial_face_map` (each geometry *constructs* it, so
+  `generate` reads truer than `get`) — the widest-blast change, 81 references
+  across 7 geometries, tests, docs, and the generated site. The other three keep
+  their `get_` prefix; the cryptic *locals* around them are renamed below.
+- **`get_regression_map` / `regression_map`** — the adversarial review favoured
+  `get_arrival_time_field` on FMM-canon grounds (correct: under unit burn speed
+  `T(x)` *is* the regression distance). **Decision: keep `regression_map`.**
+  It is the term used throughout this module's `README.md` and the `docs/theory`
+  pages; renaming the code alone would split the vocabulary between code and
+  docs. Instead, enrich the docstring: *"the FMM arrival-time field `T(x)`; under
+  unit burn speed it equals the regression distance."*
+- Short, clear locals in tight scopes: `inside`, `eroded`, `element_mass`,
+  `total_mass`, `total_volume`, `volume_per_element`, `voxels`, `voxel_map`,
+  `mesh`, `_resample_nearest`, `get_core_perimeter` (`core` is the project-wide
+  term). The physics/coordinate abbreviations (`cog`, `moi`, `x_phys`, `x_rel`)
+  were *not* kept — they are spelled out (`center_of_gravity`, `inertia_tensor`,
+  `x_denormalized`, `x_relative`) per the no-abbreviation rule.
+
+---
+
+## Renames
+
+Risk = blast radius: **Low** = within the FMM module · **Med** = also touched by
+a geometry/test · **High** = touched by many geometries, tests, docs, and the
+generated site. Counts come from a repo-wide usage trace.
+
+### 1 · Grid & domain infrastructure (`base.py`, `_2d.py`, `_3d.py`)
+
+| Current | → Proposed | Kind | Risk | Why |
+|---|---|---|---|---|
+| `map_dim` | `grid_resolution` | attr / ctor param | **High** (205 refs) | Flagship. Reads as *dimensionality*; means *samples per axis* (the cross-section is `grid_resolution × grid_resolution`). |
+| `MINIMUM_MAP_DIMENSION` | `MINIMUM_GRID_RESOLUTION` | constant | Low (7) | Track the rename above. |
+| `get_maps` | `get_coordinate_grids` | method | **High** (57) | Returns `np.meshgrid` X/Y[/Z] arrays — *coordinate grids*, not "maps"; `maps` also evokes the `map` builtin. |
+| `maps` | `coordinate_grids` | attr (cache) | Low (7) | Mirror the getter. |
+| `get_mask` | `get_outer_diameter_mask` | method | Med (35) | Boolean, `True` for cells *beyond the outer-diameter circle* (the casing wall). Ties the name to the `outer_diameter` attribute that defines it. |
+| `mask` | `outer_diameter_mask` | attr (cache) | Low (7) | Mirror the getter. |
+| `get_cell_size` | `get_normalized_spacing` | method | Low (12) | Returns `1/grid_points` — a *normalized* (dimensionless) spacing, not metres. |
+| `get_normalized_length` | `get_axial_resolution` | method | Med (18) | Returns an **int count** of z-axis samples (the axial sibling of `grid_resolution`), not a length and not a coordinate. |
+| `_validate_normalized_length` | `_validate_axial_resolution` | method (priv) | Low | Track the rename above. |
+
+### 2 · Unit / coordinate conversion (`base.py`, `stl.py`, `_3d.py`)
+
+| Current | → Proposed | Kind | Risk | Why |
+|---|---|---|---|---|
+| `map_to_length` | `cells_to_meters` | method | Med (46, 1 ext test) | Encode the transform: cell count → metres (`× outer_diameter / grid_points`). *Deviation from the raw research's `pixels_to_meters`: this base method serves both 2D pixels and 3D voxels, so the dimension-neutral "cells" is preferred; US spelling matches `outer_diameter`.* |
+| `map_to_area` | `cells_to_square_meters` | method | Low (17) | Cell-area count → m² (`× outer_diameter² / grid_points²`). |
+| `get_voxel_size` | `get_grid_spacing` | method (stl) | Low (11) | The trimesh voxelization `pitch`; *grid spacing* is the canonical scikit-image/SimpleITK term and avoids implying a volume. |
+| `get_volume_per_element` | `get_voxel_volume` | method (`_3d`) | Low (7) | "Element" is vague (FEM node? cell?); it is the volume of one cubic voxel. |
+
+### 3 · Face maps & inhibition (`base.py`, `_2d.py`, `_3d.py`)
+
+The masking story is clarified by splitting two concepts that currently share
+the name `outside`/`invalid`: the **pure casing** mask (`outer_diameter_mask`,
+§1) vs. the **full exclusion** mask that also carries inhibited surfaces (the
+array actually handed to `np.ma.MaskedArray`), named `excluded_mask`. *This
+reconciles two overlapping research proposals into one coherent scheme.*
+
+| Current | → Proposed | Kind | Risk | Why |
+|---|---|---|---|---|
+| `_apply_inhibition` | `_apply_surface_inhibition` | method | Low | Keep `_` (it is `super()`-chained, not public). Verb + object. (No `_mask` suffix: it mutates both `face_map` and the mask.) |
+| `outside` (param & local in `get_masked_face`) | `excluded_mask` | param / local | Low | Cells excluded from the burn domain = casing exterior **plus** inhibited surfaces. |
+| `invalid` (in `get_face_map`) | `excluded_mask` | local | Low | Same set, from the regression map's mask. |
+| `boundary_ring` | `outer_surface_boundary` | local | Low | The thin ring of outer-surface cells inhibition is applied to. |
+| `bore_mask` (`_2d`) | `inner_surface_inhibited_cells` | local | Low | Bore cells inhibited when the inner surface is restricted. |
+| `end_face_zeros` (`_3d`) | `end_face_inhibited_cells` | local | Low | End-face burning cells masked when an end is inhibited (`zeros` was "zeros of what?"). |
+| `maskarr` (in `get_face_map`) | `occupancy_state` | local | Low | The thresholded 1/0/-1 indicator array; spell out the abbreviation. |
+
+### 4 · Regression distance field (`base.py`, `_3d.py`)
+
+Unify the grid-spacing vocabulary: `pitch`, `spacing`, and `voxel_spacing` all
+become **`*_grid_spacing`** (the scikit-image `spacing=` convention).
+
+| Current | → Proposed | Kind | Risk | Why |
+|---|---|---|---|---|
+| `_regression_distance` | `_compute_regression_distance` | method (priv) | Low | Active verb; keeps the `regression` vocabulary and the `_`. |
+| `regression_field` (`_3d` locals) | `distance_field` | local | Low | The masked scalar field fed to marching cubes; standard comp-geo term. |
+| `axial_pitch`, `axial_spacing` | `axial_grid_spacing` | local | Low | `pitch` is mechanical jargon; `dx` along z. |
+| `radial_pitch`, `radial_spacing` | `radial_grid_spacing` | local | Low | `dx` along x/y. |
+| `voxel_spacing` | `grid_spacing` | local | Low | The per-axis spacing tuple; consistent with the components above. |
+| `axial_web` | `normalized_axial_web_distance` | local | Low | End-burner fill value: a normalized, axial web distance. |
+| `exposed_ends` | `exposed_end_count` | local | Low | An integer count (0/1/2), not a collection; qualifier-last. |
+
+### 5 · Contours, level sets & iso-surfaces (`contours.py`, `_2d.py`, `_3d.py`, `base.py`)
+
+| Current | → Proposed | Kind | Risk | Why |
+|---|---|---|---|---|
+| `get_contours` (in `contours.py`) | `get_iso_contours` | function | Low (13) | Extracts level-set (iso) contours via marching squares. |
+| `map` (param of above) | `regression_field` | param | Low | Shadows the `map` builtin; it is the scalar regression field. |
+| `map_dist` (param of above) | `iso_level` | param | Low | The threshold level for level-set extraction (scikit-image `level=`). |
+| `map_size` (param of `get_length`) | `grid_resolution` | param | Low | All call sites pass `map_dim`; same concept as §1. |
+| `offset` (in `get_length`) | `shifted_vertices` | local | Low | `np.roll`-ed copy used to form consecutive-vertex segments. |
+| `lengths` | `segment_lengths` | local | Low | Per-segment magnitudes, not a total. |
+| `center_offset` | `center_position` | local | Low | An absolute centre coordinate, not a displacement. |
+| `radius` | `distance_from_center` | local | Low | Per-vertex distances, not a fixed circle radius. |
+| `valid` | `is_interior_contour_segment` | local | Low | Boolean predicate selecting interior (non-wall) segments. |
+| `_measure_iso_surface_area` (`_3d`) | `_compute_iso_surface_area` | method (priv) | Low | Active verb; keep `_`. |
+| `regression_slice` (`_3d`) | `axial_slice` | local | Low | A 2D cross-section at one axial index. |
+| `z_index` (`_3d`) | `axial_index` | local | Low | The axial slice index. |
+| `length_normalized` (param of `_3d.get_contours`) | `axial_position_normalized` | param | Med | It is a normalized axial position, not a length. |
+| `levels` (`_3d`) | `iso_levels` | local | Low | Level-set thresholds swept by marching cubes. |
+| `surface_areas` (`_3d`) | `iso_surface_areas` | local | Low | Areas of the iso-surfaces at each level. |
+| `sample_count` (`_3d`) | `iso_level_count` | local | Low | Count of iso-levels sampled (aligned with `_2d` below). |
+| `map_distance` (`_2d`) | `web_distance_normalized` | local | Low | Matches the existing name in `base.py`. |
+
+`contours.get_length` itself is **kept** — a 2-call-site helper whose docstring
+already explains the interior-segment filtering; `measure_interior_contour_length`
+adds length without proportional clarity.
+
+### 6 · Ballistic-property interpolators (`_2d.py`, `_3d.py`)
+
+Drop the `interp_func` coinage for SciPy's term **interpolator**; tag every
+per-level series and coordinate frame.
+
+| Current | → Proposed | Kind | Risk | Why |
+|---|---|---|---|---|
+| `get_face_area_interp_func` | `get_face_area_interpolator` | method | Low (14) | `scipy.interpolate` returns an *interpolator*. |
+| `face_area_interp_func` | `face_area_interpolator` | attr | Low | Mirror the getter. |
+| `get_burn_area_interp_func` | `get_burn_area_interpolator` | method | Low (30) | Same. |
+| `burn_area_interp_func` | `burn_area_interpolator` | attr | Low | Mirror the getter. |
+| `n_le` | `count_at_or_below_level` | local | Low | `searchsorted` count ≤ each iso-level; spell out `n`/`le`. |
+| `counts` | `solid_cell_count` | local | Low | Complement: still-solid cells per level. |
+| `step_count` | `iso_level_count` | local | Low | Number of iso-levels (aligned with `_3d`). |
+| `distances` | `iso_levels_normalized` | local | Low | Normalized thresholds = interpolator x-data. |
+| `values` | `regression_distances_sorted` | local | Low | Sorted field values = interpolator y-source. |
+| `max_dist` | `max_regression_distance` | local | Low | Disambiguate "max distance in which space?". |
+| `max_level` (`_3d`) | `max_iso_level` | local | Low | Largest regression value sampled. |
+| `face_area_values` | `face_area_per_iso_level` | local | Low | Array indexed by iso-level. |
+| `perimeter_values` | `core_perimeter_per_iso_level` | local | Low | Core perimeter per level. |
+| `core_area_values` | `core_area_per_iso_level` | local | Low | Core (bore) area per level. |
+| `total_face_area_values` | `exposed_end_area_per_iso_level` | local | Low | End-face contribution per level. |
+| `burn_area_values` | `burn_area_per_iso_level` | local | Low | Core + ends, pre-smoothing. |
+| `length_values` | `grain_length_per_web` | local | Low | Axial length after end regression, per web. |
+| `web_distances` | `web_distances_denormalized` | local | Low | Denormalized values in metres (`_denormalized` frame). |
+| `smoothed_face_area` | `face_area_smoothed` | local | Low | Qualifier-last. |
+| `smoothed_burn_area`, `smoothed_areas` (`_3d`) | `burn_area_smoothed` | local | Low | Qualifier-last; unifies 2D & 3D. |
+
+### 7 · Mass-property helpers & STL (`_2d.py`, `_3d.py`, `stl.py`)
+
+| Current | → Proposed | Kind | Risk | Why |
+|---|---|---|---|---|
+| `_get_active_material_indices` | `_find_solid_material_indices` | method (priv) | Low | `find` for a search; "solid" (face==1), not vague "active". Keep `_`. |
+| `_indices_to_normalized_coords` | `_indices_to_grid_coordinates` | method (priv) | Low | Names the target frame (normalized grid). Keep `_`. |
+| `center_shift` | `grid_center_index` | local | Low | `grid_points / 2` — the origin's index, not a "shift". |
+| `x_coords/y_coords/z_coords` | `x_grid/y_grid/z_grid` | local | Low | Normalized grid frame (`_grid`); distinct from the `_denormalized` arrays they feed. |
+| `moi` | `inertia_tensor` | local | Low | 3×3 tensor, not a scalar moment; un-abbreviate. |
+| `I_axial` (`_2d`) | `axial_inertia_contribution` | local | Low | The `M·L²/12` term added to the radial axes. |
+| `n_elements` (`_2d`) | `solid_element_count` | local | Low | Avoid `n_`; qualifier-last. |
+| `active_elements` (`_3d`) | `solid_voxel_count` | local | Low | "solid" not "active"; `voxel` for 3D. |
+| `lower_recession` / `upper_recession` (`_2d`) | `lower_end_recession` / `upper_end_recession` | local | Low | Keep the SRM term "recession"; add "end". |
+| `axial_cog` (`_2d`) | `axial_center_of_gravity_position` | local | Low | A spatial coordinate; abbreviation spelled out. |
+
+---
+
+## Rollout
+
+Sequenced so the bulk of the readability win lands with near-zero risk first,
+and the wide-blast renames land last as isolated, atomic commits. Each step is
+its own branch/PR per the project's one-concern-per-PR convention.
+
+- **Step 1 — Local variables (Low risk, no external impact).** Categories
+  §3 locals, §4 locals, §5 locals, §6 locals, §7 locals. Confined to function
+  bodies; nothing outside the module sees them. Biggest clarity-per-line gain.
+- **Step 2 — Private methods (Low).** `_apply_surface_inhibition`,
+  `_compute_regression_distance`, `_compute_iso_surface_area`,
+  `_find_solid_material_indices`, `_indices_to_grid_coordinates`,
+  `_validate_axial_grid_points`, plus `contours.get_iso_contours` and its params.
+  Contained to `fmm/`.
+- **Step 3 — Cached attributes + their getters (Low–Med).** `coordinate_grids`,
+  `exterior_mask`, the `*_interpolator` pairs, `get_normalized_spacing`,
+  `get_grid_spacing`, `get_voxel_volume`. Update intra-module call sites.
+- **Step 4 — Wide-blast public-of-module names (High), one PR each.**
+  `map_dim → grid_resolution` (+ `MINIMUM_GRID_RESOLUTION`), `get_maps →
+  get_coordinate_grids`, `get_mask → get_outer_diameter_mask`,
+  `get_normalized_length → get_axial_resolution`, `cells_to_meters` /
+  `cells_to_square_meters`. Each must update the geometry subclasses, tests,
+  and the docs (below) in the same commit.
+
+**Docs move with the code.** Every step that renames a name appearing in prose
+must update it in the same PR: this module's [`README.md`](README.md) (which
+walks through `generate_initial_face_map`, `get_outer_diameter_mask`,
+`get_regression_map`, `get_face_map`, `get_contours`,
+`get_face_area_interpolator`, `get_burn_area_interpolator`, …), the
+`docs/theory/grain_regression.md` walkthrough
+and call-flow diagrams, the `docs/api/models/grain/` reference pages, and the
+generated `site/`. After a docs-affecting rename, rebuild the site so the
+generated HTML matches.
+
+Mechanical safety net: these are pure renames, so `git grep` + the test suite
+(`tests/test_models/test_propulsion/test_grain/`, which exercises 2D/3D burn
+area, CoG, MoI, inhibition) gives a hard pass/fail per step. Watch the one
+external test reference for `map_to_length`
+(`tests/.../test_grainsegment3d/test_finocyl_solidworks.py`).

--- a/machwave/models/grain/fmm/README.md
+++ b/machwave/models/grain/fmm/README.md
@@ -14,7 +14,7 @@ Here is a step by step flow of how it works:
 
 ### 1. Model the geometry
 
-1. The geometry is mapped onto a 2D or 3D grid (`get_initial_face_map`). Each grid
+1. The geometry is mapped onto a 2D or 3D grid (`generate_initial_face_map`). Each grid
    element is assigned a value: `1` means solid propellant; `0` means void. This method
    needs to be implemented by every geometry.
 
@@ -35,7 +35,7 @@ Here is a step by step flow of how it works:
     [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]
    ```
 
-2. The circular outer boundary is enforced with a mask (`get_mask`). Elements outside
+2. The circular outer boundary is enforced with a mask (`get_outer_diameter_mask`). Elements outside
    the unit-radius circle in normalized coordinates are considered outside the grain
    (`-1`).
 
@@ -81,7 +81,7 @@ Here is a step by step flow of how it works:
 
 2. The Fast Marching Method is applied (`get_regression_map`) using `skfmm.distance` to
    calculate the distance from each solid propellant point to the nearest void. The
-   cell size is set to `1/map_dim` for proper scaling.
+   cell size is set to `1/grid_resolution` for proper scaling.
 
    Example regression map (normalized distances):
 
@@ -148,8 +148,8 @@ Here is a step by step flow of how it works:
 
 ### 4. Compute ballistic properties
 
-1. Interpolation functions are built (`get_face_area_interp_func`,
-   `get_burn_area_interp_func`) by sorting regression map values and applying smoothing
+1. Interpolation functions are built (`get_face_area_interpolator`,
+   `get_burn_area_interpolator`) by sorting regression map values and applying smoothing
    (Savitzky-Golay filter).
 2. Face area is calculated (`get_face_area`) using the interpolation function.
 3. Port area is calculated (`get_port_area`) by subtracting face area from total

--- a/machwave/models/grain/fmm/_2d.py
+++ b/machwave/models/grain/fmm/_2d.py
@@ -16,63 +16,61 @@ from . import contours as fmm_contours
 
 
 class FMMGrainSegment2D(fmm_base.FMMGrainSegment, grain.GrainSegment2D, ABC):
-    """
-    Fast Marching Method (FMM) implementation for 2D grain segment.
-
-    This class was inspired by Andrew Reilley's openMotor software,
-    in particular the fmm module. See:
-    https://github.com/reilleya/openMotor
-    """
+    """Fast Marching Method (FMM) implementation for 2D grain segment."""
 
     def __init__(
         self,
         length: float,
         outer_diameter: float,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
-        map_dim: int = 100,
+        grid_resolution: int = fmm_base.DEFAULT_GRID_RESOLUTION,
         density_ratio: float = 1.0,
     ) -> None:
-        self.face_area_interp_func: Callable[[float], float] | None = None
-        self.burn_area_interp_func: Callable[[float], float] | None = None
+        self.face_area_interpolator: Callable[[float], float] | None = None
+        self.burn_area_interpolator: Callable[[float], float] | None = None
         super().__init__(
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
-            map_dim=map_dim,
+            grid_resolution=grid_resolution,
             density_ratio=density_ratio,
         )
 
-    def get_maps(self) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    def get_coordinate_grids(self) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         """
-        Return the coordinate maps `(map_x, map_y)`.
+        Return the coordinate grids `(map_x, map_y)`.
 
-        Each array has shape `(map_dim, map_dim)` and ranges from -1 to 1.
+        Each array has shape `(grid_resolution, grid_resolution)` and ranges from -1 to 1.
         """
-        if self.maps is None:
+        if self.coordinate_grids is None:
             map_x, map_y = np.meshgrid(
-                np.linspace(-1, 1, self.map_dim, dtype=np.float64),
-                np.linspace(-1, 1, self.map_dim, dtype=np.float64),
+                np.linspace(-1, 1, self.grid_resolution, dtype=np.float64),
+                np.linspace(-1, 1, self.grid_resolution, dtype=np.float64),
             )
-            self.maps = (map_x, map_y)
-        return self.maps
+            self.coordinate_grids = (map_x, map_y)
+        return self.coordinate_grids
 
-    def get_mask(self) -> NDArray[np.bool_]:
+    def get_outer_diameter_mask(self) -> NDArray[np.bool_]:
         """Return a boolean mask indicating which points lie outside the unit circle."""
-        if self.mask is None:
-            map_x, map_y = self.get_maps()
-            self.mask = (map_x**2 + map_y**2) > 1
-        return self.mask
+        if self.outer_diameter_mask is None:
+            map_x, map_y = self.get_coordinate_grids()
+            self.outer_diameter_mask = (map_x**2 + map_y**2) > 1
+        return self.outer_diameter_mask
 
-    def _apply_inhibition(
+    def _apply_surface_inhibition(
         self,
         face_map: NDArray[np.int_],
-        outside: NDArray[np.bool_],
+        excluded_mask: NDArray[np.bool_],
     ) -> tuple[NDArray[np.int_], NDArray[np.bool_]]:
-        bore_mask = (face_map == 0) if self.inhibited_surfaces.inner_surface else None
-        face_map, outside = super()._apply_inhibition(face_map, outside)
-        if bore_mask is not None:
-            outside = outside | bore_mask
-        return face_map, outside
+        inner_surface_inhibited_cells = (
+            (face_map == 0) if self.inhibited_surfaces.inner_surface else None
+        )
+        face_map, excluded_mask = super()._apply_surface_inhibition(
+            face_map, excluded_mask
+        )
+        if inner_surface_inhibited_cells is not None:
+            excluded_mask = excluded_mask | inner_surface_inhibited_cells
+        return face_map, excluded_mask
 
     def get_contours(self, web_distance: float) -> list[NDArray[np.float64]]:
         """
@@ -80,119 +78,152 @@ class FMMGrainSegment2D(fmm_base.FMMGrainSegment, grain.GrainSegment2D, ABC):
 
         Each contour is typically an `(N, 2)` array of `(row, col)` points.
         """
-        map_dist = self.normalize(web_distance)
-        return fmm_contours.get_contours(self.get_regression_map(), map_dist)
+        iso_level = self.normalize(web_distance)
+        return fmm_contours.get_iso_contours(self.get_regression_map(), iso_level)
+
+    def get_face_area_interpolator(self) -> Callable[[float], float]:
+        """Return an interpolator mapping normalized web distance to face area [m^2]."""
+        if self.face_area_interpolator is None:
+            regression_map = self.get_regression_map()
+            valid = np.logical_not(self.get_outer_diameter_mask())
+
+            # Build face-area curve without per-step full-map scans
+            regression_distances_sorted = np.asarray(
+                regression_map[valid], dtype=np.float64
+            ).ravel()
+            regression_distances_sorted.sort()
+            max_regression_distance = (
+                float(regression_distances_sorted[-1])
+                if regression_distances_sorted.size
+                else 0.0
+            )
+
+            iso_level_count = int(max_regression_distance * self.grid_resolution) + 2
+            iso_levels_normalized = (
+                np.arange(iso_level_count, dtype=np.float64) / self.grid_resolution
+            )
+
+            count_at_or_below_level = np.searchsorted(
+                regression_distances_sorted, iso_levels_normalized, side="right"
+            )
+            solid_cell_count = float(
+                regression_distances_sorted.size
+            ) - count_at_or_below_level.astype(np.float64)
+            face_area_per_iso_level = np.asarray(
+                self.cells_to_square_meters(solid_cell_count), dtype=np.float64
+            )
+
+            face_area_smoothed = filters.smooth_savitzky_golay(face_area_per_iso_level)
+            self.face_area_interpolator = interp1d(
+                iso_levels_normalized,
+                face_area_smoothed,
+                bounds_error=False,
+                fill_value=(
+                    float(face_area_smoothed[0]),
+                    float(face_area_smoothed[-1]),
+                ),  # type: ignore[arg-type]
+                assume_sorted=True,
+            )
+
+        return self.face_area_interpolator
+
+    def get_face_area(self, web_distance: float) -> float:
+        """Return the face area at the given web distance."""
+        web_distance_normalized = self.normalize(web_distance)
+        return float(self.get_face_area_interpolator()(web_distance_normalized))
 
     def get_port_area(self, web_distance: float) -> float:
         """Return the open cross-sectional port area [m^2]."""
         face_area = self.get_face_area(web_distance)
         return geometric.get_circle_area(self.outer_diameter) - face_area
 
-    def get_face_area_interp_func(self) -> Callable[[float], float]:
-        """Return an interpolator mapping normalized web distance to face area [m^2]."""
-        if self.face_area_interp_func is None:
-            regression_map = self.get_regression_map()
-            valid = np.logical_not(self.get_mask())
-
-            # Build face-area curve without per-step full-map scans
-            values = np.asarray(regression_map[valid], dtype=np.float64).ravel()
-            values.sort()
-            max_dist = float(values[-1]) if values.size else 0.0
-
-            step_count = int(max_dist * self.map_dim) + 2
-            distances = np.arange(step_count, dtype=np.float64) / self.map_dim
-
-            n_le = np.searchsorted(values, distances, side="right")
-            counts = float(values.size) - n_le.astype(np.float64)
-            face_area_values = np.asarray(self.map_to_area(counts), dtype=np.float64)
-
-            smoothed_face_area = filters.smooth_savitzky_golay(face_area_values)
-            self.face_area_interp_func = interp1d(
-                distances,
-                smoothed_face_area,
-                bounds_error=False,
-                fill_value=(
-                    float(smoothed_face_area[0]),
-                    float(smoothed_face_area[-1]),
-                ),  # type: ignore[arg-type]
-                assume_sorted=True,
-            )
-
-        return self.face_area_interp_func
-
-    def get_face_area(self, web_distance: float) -> float:
-        """Return the face area at the given web distance."""
-        map_distance = self.normalize(web_distance)
-        return float(self.get_face_area_interp_func()(map_distance))
-
-    def get_burn_area_interp_func(self) -> Callable[[float], float]:
+    def get_burn_area_interpolator(self) -> Callable[[float], float]:
         """Return a cached interpolator for burn area [m^2] vs normalized web."""
-        if self.burn_area_interp_func is None:
+        if self.burn_area_interpolator is None:
             regression_map = self.get_regression_map()
-            valid = np.logical_not(self.get_mask())
-            values = np.asarray(regression_map[valid], dtype=np.float64).ravel()
-            if values.size == 0:
-                self.burn_area_interp_func = interp1d(
+            valid = np.logical_not(self.get_outer_diameter_mask())
+            regression_distances_sorted = np.asarray(
+                regression_map[valid], dtype=np.float64
+            ).ravel()
+            if regression_distances_sorted.size == 0:
+                self.burn_area_interpolator = interp1d(
                     np.asarray([0.0], dtype=np.float64),
                     np.asarray([0.0], dtype=np.float64),
                     bounds_error=False,
                     fill_value=0.0,
                     assume_sorted=True,
                 )
-                return self.burn_area_interp_func
+                return self.burn_area_interpolator
 
-            values.sort()
-            max_dist = float(values[-1])
-            step_count = int(max_dist * self.map_dim) + 2
-            distances = np.arange(step_count, dtype=np.float64) / self.map_dim
+            regression_distances_sorted.sort()
+            max_regression_distance = float(regression_distances_sorted[-1])
+            iso_level_count = int(max_regression_distance * self.grid_resolution) + 2
+            iso_levels_normalized = (
+                np.arange(iso_level_count, dtype=np.float64) / self.grid_resolution
+            )
 
-            n_le = np.searchsorted(values, distances, side="right")
-            counts = float(values.size) - n_le.astype(np.float64)
-            face_area_values = np.asarray(self.map_to_area(counts), dtype=np.float64)
+            count_at_or_below_level = np.searchsorted(
+                regression_distances_sorted, iso_levels_normalized, side="right"
+            )
+            solid_cell_count = float(
+                regression_distances_sorted.size
+            ) - count_at_or_below_level.astype(np.float64)
+            face_area_per_iso_level = np.asarray(
+                self.cells_to_square_meters(solid_cell_count), dtype=np.float64
+            )
 
-            perimeter_values = np.empty_like(distances, dtype=np.float64)
-            for i, dist in enumerate(distances):
-                contours = fmm_contours.get_contours(regression_map, float(dist))
-                perimeter_values[i] = float(
+            core_perimeter_per_iso_level = np.empty_like(
+                iso_levels_normalized, dtype=np.float64
+            )
+            for i, dist in enumerate(iso_levels_normalized):
+                contours = fmm_contours.get_iso_contours(regression_map, float(dist))
+                core_perimeter_per_iso_level[i] = float(
                     sum(
-                        self.map_to_length(
-                            fmm_contours.get_length(contour, self.map_dim)
+                        self.cells_to_meters(
+                            fmm_contours.get_length(contour, self.grid_resolution)
                         )
                         for contour in contours
                     )
                 )
 
-            web_distances = np.asarray(self.denormalize(distances), dtype=np.float64)
-            length_values = np.asarray(
-                [self.get_length(float(wd)) for wd in web_distances], dtype=np.float64
+            web_distances_denormalized = np.asarray(
+                self.denormalize(iso_levels_normalized), dtype=np.float64
             )
-            core_area_values = perimeter_values * length_values
-            exposed_ends = (not self.inhibited_surfaces.upper_end) + (
+            grain_length_per_web = np.asarray(
+                [self.get_length(float(wd)) for wd in web_distances_denormalized],
+                dtype=np.float64,
+            )
+            core_area_per_iso_level = (
+                core_perimeter_per_iso_level * grain_length_per_web
+            )
+            exposed_end_count = (not self.inhibited_surfaces.upper_end) + (
                 not self.inhibited_surfaces.lower_end
             )
-            total_face_area_values = exposed_ends * face_area_values
-            burn_area_values = core_area_values + total_face_area_values
+            exposed_end_area_per_iso_level = exposed_end_count * face_area_per_iso_level
+            burn_area_per_iso_level = (
+                core_area_per_iso_level + exposed_end_area_per_iso_level
+            )
 
-            smoothed_burn_area = filters.smooth_savitzky_golay(burn_area_values)
-            self.burn_area_interp_func = interp1d(
-                distances,
-                smoothed_burn_area,
+            burn_area_smoothed = filters.smooth_savitzky_golay(burn_area_per_iso_level)
+            self.burn_area_interpolator = interp1d(
+                iso_levels_normalized,
+                burn_area_smoothed,
                 bounds_error=False,
                 fill_value=(
-                    float(smoothed_burn_area[0]),
-                    float(smoothed_burn_area[-1]),
+                    float(burn_area_smoothed[0]),
+                    float(burn_area_smoothed[-1]),
                 ),  # type: ignore[arg-type]
                 assume_sorted=True,
             )
 
-        return self.burn_area_interp_func
+        return self.burn_area_interpolator
 
     def get_burn_area(self, web_distance: float) -> float:
         """Return burn area [m^2] at a given web distance."""
         if web_distance > self.get_web_thickness():
             return 0.0
-        map_distance = self.normalize(web_distance)
-        value = float(self.get_burn_area_interp_func()(map_distance))
+        web_distance_normalized = self.normalize(web_distance)
+        value = float(self.get_burn_area_interpolator()(web_distance_normalized))
         return max(0.0, value)
 
     def get_core_perimeter(self, web_distance: float) -> float:
@@ -200,7 +231,9 @@ class FMMGrainSegment2D(fmm_base.FMMGrainSegment, grain.GrainSegment2D, ABC):
         contours = self.get_contours(web_distance)
         return float(
             sum(
-                self.map_to_length(fmm_contours.get_length(contour, self.map_dim))
+                self.cells_to_meters(
+                    fmm_contours.get_length(contour, self.grid_resolution)
+                )
                 for contour in contours
             )
         )
@@ -225,7 +258,7 @@ class FMMGrainSegment2D(fmm_base.FMMGrainSegment, grain.GrainSegment2D, ABC):
                 "The web distance traveled is greater than the grain segment's web thickness."
             )
 
-    def _get_active_material_indices(
+    def _find_solid_material_indices(
         self, web_distance: float
     ) -> tuple[NDArray[np.int_], NDArray[np.int_]]:
         """
@@ -251,7 +284,7 @@ class FMMGrainSegment2D(fmm_base.FMMGrainSegment, grain.GrainSegment2D, ABC):
 
         return y_indices, x_indices
 
-    def _indices_to_normalized_coords(
+    def _indices_to_grid_coordinates(
         self, y_indices: NDArray[np.int_], x_indices: NDArray[np.int_]
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         """
@@ -262,12 +295,12 @@ class FMMGrainSegment2D(fmm_base.FMMGrainSegment, grain.GrainSegment2D, ABC):
             x_indices: X-axis indices from face map.
 
         Returns:
-            Tuple of (x_coords, y_coords) in normalized units.
+            Tuple of (x_grid, y_grid) in normalized units.
         """
-        center_shift = self.map_dim / 2
-        x_coords = (x_indices - center_shift).astype(np.float64)
-        y_coords = (y_indices - center_shift).astype(np.float64)
-        return x_coords, y_coords
+        grid_center_index = self.grid_resolution / 2
+        x_grid = (x_indices - grid_center_index).astype(np.float64)
+        y_grid = (y_indices - grid_center_index).astype(np.float64)
+        return x_grid, y_grid
 
     def get_center_of_gravity(self, web_distance: float) -> NDArray[np.float64]:
         """
@@ -280,21 +313,29 @@ class FMMGrainSegment2D(fmm_base.FMMGrainSegment, grain.GrainSegment2D, ABC):
             Center of gravity as `(x, y, z)` [m], measured from the segment port.
         """
         self._validate_web_distance(web_distance)
-        y_indices, x_indices = self._get_active_material_indices(web_distance)
-        x_coords, y_coords = self._indices_to_normalized_coords(y_indices, x_indices)
+        y_indices, x_indices = self._find_solid_material_indices(web_distance)
+        x_grid, y_grid = self._indices_to_grid_coordinates(y_indices, x_indices)
 
         # Convert to physical coordinates
-        x_phys = np.asarray(self.map_to_length(x_coords), dtype=np.float64)
-        y_phys = np.asarray(self.map_to_length(y_coords), dtype=np.float64)
+        x_denormalized = np.asarray(self.cells_to_meters(x_grid), dtype=np.float64)
+        y_denormalized = np.asarray(self.cells_to_meters(y_grid), dtype=np.float64)
 
         # Axial bounds accounting for end face inhibition
-        lower_recession = web_distance if not self.inhibited_surfaces.lower_end else 0.0
-        upper_recession = web_distance if not self.inhibited_surfaces.upper_end else 0.0
-        axial_cog = (lower_recession + (self.length - upper_recession)) / 2.0
+        lower_end_recession = (
+            web_distance if not self.inhibited_surfaces.lower_end else 0.0
+        )
+        upper_end_recession = (
+            web_distance if not self.inhibited_surfaces.upper_end else 0.0
+        )
+        axial_center_of_gravity_position = (
+            lower_end_recession + (self.length - upper_end_recession)
+        ) / 2.0
 
-        z_phys = np.full_like(x_phys, axial_cog)
+        z_denormalized = np.full_like(x_denormalized, axial_center_of_gravity_position)
 
-        return mechanics.get_center_of_gravity(x_phys, y_phys, z_phys)
+        return mechanics.get_center_of_gravity(
+            x_denormalized, y_denormalized, z_denormalized
+        )
 
     def get_moment_of_inertia(
         self, ideal_density: float, web_distance: float = 0.0
@@ -310,39 +351,41 @@ class FMMGrainSegment2D(fmm_base.FMMGrainSegment, grain.GrainSegment2D, ABC):
             A 3x3 inertia tensor [kg-m^2].
         """
         self._validate_web_distance(web_distance)
-        y_indices, x_indices = self._get_active_material_indices(web_distance)
-        x_coords, y_coords = self._indices_to_normalized_coords(y_indices, x_indices)
+        y_indices, x_indices = self._find_solid_material_indices(web_distance)
+        x_grid, y_grid = self._indices_to_grid_coordinates(y_indices, x_indices)
 
         # Get the center of gravity to use as reference point
-        cog = self.get_center_of_gravity(web_distance)
+        center_of_gravity = self.get_center_of_gravity(web_distance)
         current_length = self.get_length(web_distance)
 
         # Convert to meters
-        x_phys = self.map_to_length(x_coords)
-        y_phys = self.map_to_length(y_coords)
+        x_denormalized = self.cells_to_meters(x_grid)
+        y_denormalized = self.cells_to_meters(y_grid)
 
-        # Shift to CoG frame
-        x_rel = x_phys - cog[1]
-        y_rel = y_phys - cog[2]
-        z_rel = np.zeros_like(x_rel)  # 2D grain, no z variation in elements
+        # Coordinates relative to the center of gravity
+        x_relative = x_denormalized - center_of_gravity[1]
+        y_relative = y_denormalized - center_of_gravity[2]
+        z_relative = np.zeros_like(x_relative)  # 2D grain, no z variation in elements
 
         # Total mass
         total_volume = self.get_volume(web_distance)
         total_mass = total_volume * ideal_density * self.density_ratio
 
         # Mass per cross-sectional element
-        n_elements = len(x_indices)
-        element_mass = total_mass / n_elements
+        solid_element_count = len(x_indices)
+        element_mass = total_mass / solid_element_count
 
         # Get base inertia from point masses (radial only)
-        moi = mechanics.get_moment_of_inertia_tensor(x_rel, y_rel, z_rel, element_mass)
+        inertia_tensor = mechanics.get_moment_of_inertia_tensor(
+            x_relative, y_relative, z_relative, element_mass
+        )
 
         # For 2D grain (uniform along axial direction), add axial contribution
-        # For a uniform rod of length L with mass M: I_axial = M*L^2/12 (about CoG)
-        I_axial = total_mass * current_length**2 / 12
+        # For a uniform rod of length L with mass M: axial_inertia_contribution = M*L^2/12 (about the center of gravity)
+        axial_inertia_contribution = total_mass * current_length**2 / 12
 
         # Add axial contribution to radial axes (indices 1 and 2 in [z,x,y] system)
-        moi[1, 1] += I_axial  # Ixx (moment about x-axis)
-        moi[2, 2] += I_axial  # Iyy (moment about y-axis)
+        inertia_tensor[1, 1] += axial_inertia_contribution  # Ixx (moment about x-axis)
+        inertia_tensor[2, 2] += axial_inertia_contribution  # Iyy (moment about y-axis)
 
-        return moi
+        return inertia_tensor

--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -18,31 +18,211 @@ from . import contours as fmm_contours
 
 
 class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
-    """
-    Fast Marching Method (FMM) implementation for 3D grain segment.
-
-    This class was inspired by the Andrew Reilley's software openMotor, in
-    particular the fmm module.
-    openMotor's repository can be accessed at:
-    https://github.com/reilleya/openMotor
-    """
+    """Fast Marching Method (FMM) implementation for 3D grain segment."""
 
     def __init__(
         self,
         length: float,
         outer_diameter: float,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
-        map_dim: int = 100,
+        grid_resolution: int = fmm_base.DEFAULT_GRID_RESOLUTION,
         density_ratio: float = 1.0,
     ) -> None:
-        self.burn_area_interp_func: Callable[[float], float] | None = None
+        self.burn_area_interpolator: Callable[[float], float] | None = None
         super().__init__(
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
-            map_dim=map_dim,
+            grid_resolution=grid_resolution,
             density_ratio=density_ratio,
         )
+
+    def validate(self) -> None:
+        super().validate()
+        self._validate_axial_resolution()
+
+    def _validate_axial_resolution(self) -> None:
+        # < 3 slices: get_port_area indexes a size-0 axis and inhibition is skipped
+        axial_resolution = self.get_axial_resolution()
+        if axial_resolution < 3:
+            raise grain.GrainGeometryError(
+                f"Axial resolution must be at least 3, got "
+                f"{axial_resolution}; increase grid_resolution or the "
+                f"length-to-outer-diameter ratio."
+            )
+
+    def get_axial_resolution(self) -> int:
+        return int(self.grid_resolution * self.length / self.outer_diameter)
+
+    def get_coordinate_grids(
+        self,
+    ) -> tuple[
+        NDArray[np.float64],
+        NDArray[np.float64],
+        NDArray[np.float64],
+    ]:
+        if self.coordinate_grids is None:
+            map_y, map_z, map_x = np.meshgrid(
+                np.linspace(-1, 1, self.grid_resolution),
+                np.linspace(1, 0, self.get_axial_resolution()),  # z axis
+                np.linspace(-1, 1, self.grid_resolution),
+            )
+
+            self.coordinate_grids = (map_x, map_y, map_z)
+
+        return self.coordinate_grids
+
+    def get_outer_diameter_mask(self) -> NDArray[np.bool_]:
+        if self.outer_diameter_mask is None:
+            map_x, map_y, _ = self.get_coordinate_grids()
+            self.outer_diameter_mask = (map_x**2 + map_y**2) > 1
+
+        return self.outer_diameter_mask
+
+    def _apply_surface_inhibition(
+        self,
+        face_map: NDArray[np.int_],
+        excluded_mask: NDArray[np.bool_],
+    ) -> tuple[NDArray[np.int_], NDArray[np.bool_]]:
+        if face_map.shape[0] <= 2:
+            return face_map, excluded_mask
+
+        inner_surface_inhibited_cells = np.zeros_like(face_map, dtype=bool)
+        inner_surface_inhibited_cells[1:-1] = face_map[1:-1] == 0
+        inner_surface_inhibited_cells[0] = inner_surface_inhibited_cells[1]
+        inner_surface_inhibited_cells[-1] = inner_surface_inhibited_cells[-2]
+
+        # super() runs binary_erosion on the full 3D volume, which includes the
+        # end-face layers in the outer_surface_boundary. Apply end inhibition AFTER so
+        # those cells are not overwritten back to 0 by the outer-surface logic.
+        face_map, excluded_mask = super()._apply_surface_inhibition(
+            face_map, excluded_mask
+        )
+
+        if self.inhibited_surfaces.upper_end:
+            end_face_inhibited_cells = (
+                face_map[-1] == 0
+            ) & ~inner_surface_inhibited_cells[-1]
+            face_map[-1][end_face_inhibited_cells] = 1
+
+        if self.inhibited_surfaces.lower_end:
+            end_face_inhibited_cells = (
+                face_map[0] == 0
+            ) & ~inner_surface_inhibited_cells[0]
+            face_map[0][end_face_inhibited_cells] = 1
+
+        if self.inhibited_surfaces.inner_surface:
+            excluded_mask = excluded_mask | inner_surface_inhibited_cells
+
+        return face_map, excluded_mask
+
+    def _compute_regression_distance(self, masked_face: np.ndarray) -> np.ndarray:
+        # Regression speed needs to be calibrated for the z axes separately from the x
+        # and y axes, because the 3D grid is anisotropic
+        axial_grid_spacing = self.length / max(self.get_axial_resolution() - 1, 1)
+        radial_grid_spacing = self.outer_diameter / (self.grid_resolution - 1)
+        distance = skfmm.distance(
+            masked_face,
+            dx=[axial_grid_spacing, radial_grid_spacing, radial_grid_spacing],  # type: ignore[arg-type]
+        )
+        return distance * (2.0 / self.outer_diameter)
+
+    def get_contours(
+        self, web_distance: float, axial_position_normalized: float
+    ) -> list[NDArray[np.float64]]:
+        iso_level = self.normalize(web_distance)
+        axial_index = int(round(axial_position_normalized))
+        axial_slice = self.get_regression_map()[axial_index]
+        return fmm_contours.get_iso_contours(axial_slice, iso_level)
+
+    def get_burn_area_interpolator(self) -> Callable[[float], float]:
+        """Return a cached interpolator for burn area [m^2] vs web distance [m]."""
+        if self.burn_area_interpolator is None:
+            regression_map = self.get_regression_map()
+            regression_values = np.asarray(
+                regression_map[~np.ma.getmaskarray(regression_map)], dtype=np.float64
+            )
+            max_iso_level = (
+                float(regression_values.max()) if regression_values.size else 0.0
+            )
+            if max_iso_level <= 0.0:
+                self.burn_area_interpolator = interp1d(
+                    np.asarray([0.0], dtype=np.float64),
+                    np.asarray([0.0], dtype=np.float64),
+                    bounds_error=False,
+                    fill_value=0.0,
+                    assume_sorted=True,
+                )
+                return self.burn_area_interpolator
+
+            # Lift the inhibited casing above every iso level so marching cubes
+            # meshes only the burning front, not the wall.
+            distance_field = np.ma.filled(regression_map, max_iso_level + 1.0)
+            axial_grid_spacing = self.length / max(self.get_axial_resolution() - 1, 1)
+            radial_grid_spacing = self.outer_diameter / (self.grid_resolution - 1)
+            grid_spacing = (
+                axial_grid_spacing,
+                radial_grid_spacing,
+                radial_grid_spacing,
+            )
+
+            # The iso-surface at level 0 lies on the voxelized initial face and is
+            # degenerate, so sample above it and hold the first area back to web 0.
+            iso_level_count = 80
+            iso_levels = np.linspace(
+                max_iso_level / iso_level_count, max_iso_level, iso_level_count
+            )
+            iso_surface_areas = np.array(
+                [
+                    self._compute_iso_surface_area(
+                        distance_field, float(level), grid_spacing
+                    )
+                    for level in iso_levels
+                ],
+                dtype=np.float64,
+            )
+            web_distances_denormalized = np.concatenate(
+                ([0.0], np.asarray(self.denormalize(iso_levels), dtype=np.float64))
+            )
+            iso_surface_areas = np.concatenate(
+                ([iso_surface_areas[0]], iso_surface_areas)
+            )
+
+            burn_area_smoothed = filters.smooth_savitzky_golay(
+                iso_surface_areas, window_length=9, polyorder=3
+            )
+            self.burn_area_interpolator = interp1d(
+                web_distances_denormalized,
+                burn_area_smoothed,
+                bounds_error=False,
+                fill_value=(
+                    float(burn_area_smoothed[0]),
+                    float(burn_area_smoothed[-1]),
+                ),  # type: ignore[arg-type]
+                assume_sorted=True,
+            )
+
+        return self.burn_area_interpolator
+
+    @staticmethod
+    def _compute_iso_surface_area(
+        distance_field: NDArray[np.float64],
+        level: float,
+        grid_spacing: tuple[float, float, float],
+    ) -> float:
+        """Marching-cubes area [m^2] of one regression iso-level, 0 if empty."""
+        try:
+            vertices, faces, _, _ = measure.marching_cubes(
+                distance_field, level=level, spacing=grid_spacing
+            )
+        except (ValueError, RuntimeError):
+            return 0.0
+        return float(measure.mesh_surface_area(vertices, faces))
+
+    def get_burn_area(self, web_distance: float) -> float:
+        if web_distance > self.get_web_thickness():
+            return 0.0
+        return max(0.0, float(self.get_burn_area_interpolator()(web_distance)))
 
     def get_port_area(self, web_distance: float, z: float = 0.0) -> float:
         """
@@ -60,199 +240,32 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         Returns:
             A float representing the port area at the specified z slice, in m^2.
         """
-        map_dist = self.normalize(web_distance)
-        valid = np.logical_not(self.get_mask())
-        solid = np.logical_and(self.get_regression_map() > map_dist, valid)
+        iso_level = self.normalize(web_distance)
+        valid = np.logical_not(self.get_outer_diameter_mask())
+        solid = np.logical_and(self.get_regression_map() > iso_level, valid)
 
         normalized_z = z / self.length
-        max_index = self.get_normalized_length() - 1
-        z_index = int(round(normalized_z * max_index))
-        z_index = 0 if z_index < 0 else (max_index if z_index > max_index else z_index)
+        max_index = self.get_axial_resolution() - 1
+        axial_index = int(round(normalized_z * max_index))
+        axial_index = (
+            0
+            if axial_index < 0
+            else (max_index if axial_index > max_index else axial_index)
+        )
 
-        face_area = float(self.map_to_area(float(np.count_nonzero(solid[z_index]))))
+        face_area = float(
+            self.cells_to_square_meters(float(np.count_nonzero(solid[axial_index])))
+        )
         return geometric.get_circle_area(self.outer_diameter) - face_area
 
-    def get_normalized_length(self) -> int:
-        return int(self.map_dim * self.length / self.outer_diameter)
-
-    def validate(self) -> None:
-        super().validate()
-        self._validate_normalized_length()
-
-    def _validate_normalized_length(self) -> None:
-        # < 3 slices: get_port_area indexes a size-0 axis and inhibition is skipped
-        normalized_length = self.get_normalized_length()
-        if normalized_length < 3:
-            raise grain.GrainGeometryError(
-                f"Normalized axial length must be at least 3, got "
-                f"{normalized_length}; increase map_dim or the "
-                f"length-to-outer-diameter ratio."
-            )
-
-    def get_maps(
-        self,
-    ) -> tuple[
-        NDArray[np.float64],
-        NDArray[np.float64],
-        NDArray[np.float64],
-    ]:
-        if self.maps is None:
-            map_y, map_z, map_x = np.meshgrid(
-                np.linspace(-1, 1, self.map_dim),
-                np.linspace(1, 0, self.get_normalized_length()),  # z axis
-                np.linspace(-1, 1, self.map_dim),
-            )
-
-            self.maps = (map_x, map_y, map_z)
-
-        return self.maps
-
-    def get_mask(self) -> NDArray[np.bool_]:
-        if self.mask is None:
-            map_x, map_y, _ = self.get_maps()
-            self.mask = (map_x**2 + map_y**2) > 1
-
-        return self.mask
-
-    def _apply_inhibition(
-        self,
-        face_map: NDArray[np.int_],
-        outside: NDArray[np.bool_],
-    ) -> tuple[NDArray[np.int_], NDArray[np.bool_]]:
-        if face_map.shape[0] <= 2:
-            return face_map, outside
-
-        bore_mask = np.zeros_like(face_map, dtype=bool)
-        bore_mask[1:-1] = face_map[1:-1] == 0
-        bore_mask[0] = bore_mask[1]
-        bore_mask[-1] = bore_mask[-2]
-
-        # super() runs binary_erosion on the full 3D volume, which includes the
-        # end-face layers in the boundary_ring. Apply end inhibition AFTER so
-        # those cells are not overwritten back to 0 by the outer-surface logic.
-        face_map, outside = super()._apply_inhibition(face_map, outside)
-
-        if self.inhibited_surfaces.upper_end:
-            end_face_zeros = (face_map[-1] == 0) & ~bore_mask[-1]
-            face_map[-1][end_face_zeros] = 1
-
-        if self.inhibited_surfaces.lower_end:
-            end_face_zeros = (face_map[0] == 0) & ~bore_mask[0]
-            face_map[0][end_face_zeros] = 1
-
-        if self.inhibited_surfaces.inner_surface:
-            outside = outside | bore_mask
-
-        return face_map, outside
-
-    def _regression_distance(self, masked_face: np.ndarray) -> np.ndarray:
-        # Regression speed needs to be calibrated for the z axes separately from the x
-        # and y axes, because the 3D grid is anisotropic
-        axial_pitch = self.length / max(self.get_normalized_length() - 1, 1)
-        radial_pitch = self.outer_diameter / (self.map_dim - 1)
-        distance = skfmm.distance(
-            masked_face,
-            dx=[axial_pitch, radial_pitch, radial_pitch],  # type: ignore[arg-type]
-        )
-        return distance * (2.0 / self.outer_diameter)
-
-    def get_contours(
-        self, web_distance: float, length_normalized: float
-    ) -> list[NDArray[np.float64]]:
-        map_dist = self.normalize(web_distance)
-        z_index = int(round(length_normalized))
-        regression_slice = self.get_regression_map()[z_index]
-        return fmm_contours.get_contours(regression_slice, map_dist)
-
-    @staticmethod
-    def _measure_iso_surface_area(
-        regression_field: NDArray[np.float64],
-        level: float,
-        voxel_spacing: tuple[float, float, float],
-    ) -> float:
-        """Marching-cubes area [m^2] of one regression iso-level, 0 if empty."""
-        try:
-            vertices, faces, _, _ = measure.marching_cubes(
-                regression_field, level=level, spacing=voxel_spacing
-            )
-        except (ValueError, RuntimeError):
-            return 0.0
-        return float(measure.mesh_surface_area(vertices, faces))
-
-    def get_burn_area_interp_func(self) -> Callable[[float], float]:
-        """Return a cached interpolator for burn area [m^2] vs web distance [m]."""
-        if self.burn_area_interp_func is None:
-            regression_map = self.get_regression_map()
-            regression_values = np.asarray(
-                regression_map[~np.ma.getmaskarray(regression_map)], dtype=np.float64
-            )
-            max_level = (
-                float(regression_values.max()) if regression_values.size else 0.0
-            )
-            if max_level <= 0.0:
-                self.burn_area_interp_func = interp1d(
-                    np.asarray([0.0], dtype=np.float64),
-                    np.asarray([0.0], dtype=np.float64),
-                    bounds_error=False,
-                    fill_value=0.0,
-                    assume_sorted=True,
-                )
-                return self.burn_area_interp_func
-
-            # Lift the inhibited casing above every iso level so marching cubes
-            # meshes only the burning front, not the wall.
-            regression_field = np.ma.filled(regression_map, max_level + 1.0)
-            axial_spacing = self.length / max(self.get_normalized_length() - 1, 1)
-            radial_spacing = self.outer_diameter / (self.map_dim - 1)
-            voxel_spacing = (axial_spacing, radial_spacing, radial_spacing)
-
-            # The iso-surface at level 0 lies on the voxelized initial face and is
-            # degenerate, so sample above it and hold the first area back to web 0.
-            sample_count = 80
-            levels = np.linspace(max_level / sample_count, max_level, sample_count)
-            surface_areas = np.array(
-                [
-                    self._measure_iso_surface_area(
-                        regression_field, float(level), voxel_spacing
-                    )
-                    for level in levels
-                ],
-                dtype=np.float64,
-            )
-            web_distances = np.concatenate(
-                ([0.0], np.asarray(self.denormalize(levels), dtype=np.float64))
-            )
-            surface_areas = np.concatenate(([surface_areas[0]], surface_areas))
-
-            smoothed_areas = filters.smooth_savitzky_golay(
-                surface_areas, window_length=9, polyorder=3
-            )
-            self.burn_area_interp_func = interp1d(
-                web_distances,
-                smoothed_areas,
-                bounds_error=False,
-                fill_value=(
-                    float(smoothed_areas[0]),
-                    float(smoothed_areas[-1]),
-                ),  # type: ignore[arg-type]
-                assume_sorted=True,
-            )
-
-        return self.burn_area_interp_func
-
-    def get_burn_area(self, web_distance: float) -> float:
-        if web_distance > self.get_web_thickness():
-            return 0.0
-        return max(0.0, float(self.get_burn_area_interp_func()(web_distance)))
-
-    def get_volume_per_element(self) -> float:
-        return (float(self.denormalize(self.get_cell_size())) * 2) ** 3
+    def get_voxel_volume(self) -> float:
+        return (float(self.denormalize(self.get_normalized_spacing())) * 2) ** 3
 
     def get_volume(self, web_distance: float) -> float:
         face_map = self.get_face_map(web_distance=web_distance)
-        active_elements = np.count_nonzero(face_map == 1)
-        volume_per_element = self.get_volume_per_element()
-        return active_elements * volume_per_element
+        solid_voxel_count = np.count_nonzero(face_map == 1)
+        volume_per_element = self.get_voxel_volume()
+        return solid_voxel_count * volume_per_element
 
     def _validate_web_distance(self, web_distance: float) -> None:
         """
@@ -267,7 +280,7 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
                 "segment's web thickness."
             )
 
-    def _get_active_material_indices(
+    def _find_solid_material_indices(
         self, web_distance: float
     ) -> tuple[NDArray[np.int_], NDArray[np.int_], NDArray[np.int_]]:
         """
@@ -293,7 +306,7 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
 
         return z_indices, y_indices, x_indices
 
-    def _indices_to_normalized_coords(
+    def _indices_to_grid_coordinates(
         self,
         z_indices: NDArray[np.int_],
         y_indices: NDArray[np.int_],
@@ -308,13 +321,13 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
             x_indices: X-axis indices from face map.
 
         Returns:
-            Tuple of (x_coords, y_coords, z_coords) in normalized units.
+            Tuple of (x_grid, y_grid, z_grid) in normalized units.
         """
-        center_shift = self.map_dim / 2
-        x_coords = (x_indices - center_shift).astype(np.float64)
-        y_coords = (y_indices - center_shift).astype(np.float64)
-        z_coords = z_indices.astype(np.float64)
-        return x_coords, y_coords, z_coords
+        grid_center_index = self.grid_resolution / 2
+        x_grid = (x_indices - grid_center_index).astype(np.float64)
+        y_grid = (y_indices - grid_center_index).astype(np.float64)
+        z_grid = z_indices.astype(np.float64)
+        return x_grid, y_grid, z_grid
 
     def get_center_of_gravity(self, web_distance: float) -> NDArray[np.float64]:
         """
@@ -331,19 +344,21 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
                 if no active material is found.
         """
         self._validate_web_distance(web_distance)
-        z_indices, y_indices, x_indices = self._get_active_material_indices(
+        z_indices, y_indices, x_indices = self._find_solid_material_indices(
             web_distance
         )
-        x_coords, y_coords, z_coords = self._indices_to_normalized_coords(
+        x_grid, y_grid, z_grid = self._indices_to_grid_coordinates(
             z_indices, y_indices, x_indices
         )
 
         # Convert normalized coordinates into physical meters
-        x_phys = np.asarray(self.map_to_length(x_coords), dtype=np.float64)
-        y_phys = np.asarray(self.map_to_length(y_coords), dtype=np.float64)
-        z_phys = np.asarray(self.map_to_length(z_coords), dtype=np.float64)
+        x_denormalized = np.asarray(self.cells_to_meters(x_grid), dtype=np.float64)
+        y_denormalized = np.asarray(self.cells_to_meters(y_grid), dtype=np.float64)
+        z_denormalized = np.asarray(self.cells_to_meters(z_grid), dtype=np.float64)
 
-        return mechanics.get_center_of_gravity(x_phys, y_phys, z_phys)
+        return mechanics.get_center_of_gravity(
+            x_denormalized, y_denormalized, z_denormalized
+        )
 
     def get_moment_of_inertia(
         self, ideal_density: float, web_distance: float = 0.0
@@ -363,29 +378,31 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
                 if no active material is found.
         """
         self._validate_web_distance(web_distance)
-        z_indices, y_indices, x_indices = self._get_active_material_indices(
+        z_indices, y_indices, x_indices = self._find_solid_material_indices(
             web_distance
         )
-        x_coords, y_coords, z_coords = self._indices_to_normalized_coords(
+        x_grid, y_grid, z_grid = self._indices_to_grid_coordinates(
             z_indices, y_indices, x_indices
         )
 
         # Get the center of gravity
-        cog = self.get_center_of_gravity(web_distance)
+        center_of_gravity = self.get_center_of_gravity(web_distance)
 
         # Convert to meters
-        x_phys = self.map_to_length(x_coords)
-        y_phys = self.map_to_length(y_coords)
-        z_phys = self.map_to_length(z_coords)
+        x_denormalized = self.cells_to_meters(x_grid)
+        y_denormalized = self.cells_to_meters(y_grid)
+        z_denormalized = self.cells_to_meters(z_grid)
 
-        # Shift to CoG frame
-        x_rel = x_phys - cog[1]
-        y_rel = y_phys - cog[2]
-        z_rel = z_phys - cog[0]
+        # Coordinates relative to the center of gravity
+        x_relative = x_denormalized - center_of_gravity[1]
+        y_relative = y_denormalized - center_of_gravity[2]
+        z_relative = z_denormalized - center_of_gravity[0]
 
         # Calculate element mass
-        element_volume = self.get_volume_per_element()
+        element_volume = self.get_voxel_volume()
         element_mass = element_volume * ideal_density * self.density_ratio
 
         # Use core function to compute inertia tensor
-        return mechanics.get_moment_of_inertia_tensor(x_rel, y_rel, z_rel, element_mass)
+        return mechanics.get_moment_of_inertia_tensor(
+            x_relative, y_relative, z_relative, element_mass
+        )

--- a/machwave/models/grain/fmm/__init__.py
+++ b/machwave/models/grain/fmm/__init__.py
@@ -7,12 +7,21 @@ References:
     https://math.berkeley.edu/~sethian/2006/Explanations/fast_marching_explain.html
 """
 
+# Import base (and its module-level constants) first so the constants are bound
+# on the package namespace before the subclasses, which reference them as default
+# argument values, are imported.
+from machwave.models.grain.fmm.base import (
+    DEFAULT_GRID_RESOLUTION,
+    MINIMUM_GRID_RESOLUTION,
+    FMMGrainSegment,
+)
 from machwave.models.grain.fmm._2d import FMMGrainSegment2D
 from machwave.models.grain.fmm._3d import FMMGrainSegment3D
-from machwave.models.grain.fmm.base import FMMGrainSegment
 from machwave.models.grain.fmm.stl import FMMSTLGrainSegment
 
 __all__ = [
+    "DEFAULT_GRID_RESOLUTION",
+    "MINIMUM_GRID_RESOLUTION",
     "FMMGrainSegment",
     "FMMGrainSegment2D",
     "FMMGrainSegment3D",

--- a/machwave/models/grain/fmm/base.py
+++ b/machwave/models/grain/fmm/base.py
@@ -9,42 +9,36 @@ from numpy.typing import NDArray
 import machwave.models.grain as grain
 import machwave.models.grain.base as grain_base
 
-MINIMUM_MAP_DIMENSION = 100
+MINIMUM_GRID_RESOLUTION = 100
+DEFAULT_GRID_RESOLUTION = 100
 
 
 class FMMGrainSegment(grain.GrainSegment, ABC):
-    """
-    Fast Marching Method (FMM) implementation of a grain segment.
-
-    This class was inspired by the Andrew Reilley's software openMotor, in
-    particular the fmm module.
-    openMotor's repository can be accessed at:
-    https://github.com/reilleya/openMotor
-    """
+    """Fast Marching Method (FMM) implementation of a grain segment."""
 
     def __init__(
         self,
-        map_dim: int,
         length: float,
         outer_diameter: float,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
+        grid_resolution: int = DEFAULT_GRID_RESOLUTION,
         density_ratio: float = 1.0,
     ) -> None:
         """
         Initialize an FMM grain segment.
 
         Args:
-            map_dim: Pixel resolution of the cross-section map.
             length: Segment length [m].
             outer_diameter: Outer diameter [m].
             inhibited_surfaces: Surfaces inhibited from burning.
+            grid_resolution: Resolution of the face map, x and y axes.
             density_ratio: Ratio of real to ideal propellant density.
         """
-        self.map_dim = map_dim
+        self.grid_resolution = grid_resolution
 
         # "Cache" variables:
-        self.maps = None
-        self.mask = None
+        self.coordinate_grids = None
+        self.outer_diameter_mask = None
         self.masked_face = None
         self.regression_map = None
         self.web_thickness = None
@@ -56,52 +50,50 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
             density_ratio=density_ratio,
         )
 
-    @abstractmethod
-    def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
-        """Method needs to be implemented for each and every geometry."""
-        pass
-
-    @abstractmethod
-    def get_maps(self) -> tuple:
-        """
-        Return the coordinate maps for the grain.
-
-        Returns:
-            `(map_x, map_y)` for 2D; `(map_x, map_y, map_z)` for 3D.
-        """
-        pass
-
-    @abstractmethod
-    def get_mask(self) -> np.ndarray:
-        """Implementation varies depending if the geometry is 2D or 3D."""
-        pass
-
     def validate(self) -> None:
         """
         Validate the internal geometry of the grain.
 
-        Ensures the grain map dimension meets the minimum required size.
-
         Raises:
-            GrainGeometryError: If the grain map dimension is below the valid
+            GrainGeometryError: If the grid resolution is below the valid
                 threshold.
         """
         super().validate()
-        if not self.map_dim >= MINIMUM_MAP_DIMENSION:
+
+        if not self.grid_resolution >= MINIMUM_GRID_RESOLUTION:
             raise grain.GrainGeometryError(
-                f"Map dimension must be at least {MINIMUM_MAP_DIMENSION}, "
-                f"got {self.map_dim}"
+                f"Grid resolution must be at least {MINIMUM_GRID_RESOLUTION}, "
+                f"got {self.grid_resolution}"
             )
+
+    @abstractmethod
+    def get_coordinate_grids(self) -> tuple:
+        """Return the coordinate grids for the grain, one per spatial axis."""
+        pass
+
+    @abstractmethod
+    def get_outer_diameter_mask(self) -> np.ndarray:
+        """Return a boolean mask of cells outside the outer-diameter boundary."""
+        pass
+
+    @abstractmethod
+    def generate_initial_face_map(self) -> np.typing.NDArray[np.int_]:
+        """Generate the initial face map for the geometry (1 = propellant, 0 = void)."""
+        pass
+
+    def get_empty_face_map(self) -> np.ndarray:
+        """Return a face map of all ones, shaped like the first stored map."""
+        return np.ones_like(self.get_coordinate_grids()[0])
 
     def normalize(self, value: int | float) -> float:
         """
-        Convert a dimensional value to a fraction of the half-diameter.
+        Convert a dimensional value to a fraction of the outer radius.
 
         Args:
             value: Dimensional value (e.g., length) to normalize [m].
 
         Returns:
-            Value expressed as a fraction of the half-diameter.
+            Value expressed as a fraction of the outer radius.
         """
         return value / (0.5 * self.outer_diameter)
 
@@ -111,29 +103,11 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
         """Convert a normalized input back into a dimensional value [m]."""
         return (value / 2) * (self.outer_diameter)
 
-    def map_to_area(
-        self, value: float | NDArray[np.float64]
-    ) -> float | NDArray[np.float64]:
-        """
-        Convert a pixel-area value to [m^2].
-
-        Scales by `outer_diameter^2 / map_dim^2`.
-
-        Args:
-            value: Area in pixel units.
-
-        Returns:
-            Area [m^2].
-        """
-        return (self.outer_diameter**2) * (value / (self.map_dim**2))
-
-    def map_to_length(
+    def cells_to_meters(
         self, value: float | NDArray[np.float64]
     ) -> float | NDArray[np.float64]:
         """
         Convert a pixel-distance value to [m].
-
-        Scales by `outer_diameter / map_dim`.
 
         Args:
             value: Distance in pixel units.
@@ -141,73 +115,76 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
         Returns:
             Distance [m].
         """
-        return self.outer_diameter * (value / self.map_dim)
+        return self.outer_diameter * (value / self.grid_resolution)
 
-    def get_empty_face_map(self) -> np.ndarray:
-        """Return a face map of all ones, shaped like the first stored map."""
-        return np.ones_like(self.get_maps()[0])
+    def cells_to_square_meters(
+        self, value: float | NDArray[np.float64]
+    ) -> float | NDArray[np.float64]:
+        """
+        Convert a pixel-area value to [m^2].
 
-    def _apply_inhibition(
+        Args:
+            value: Area in pixel units.
+
+        Returns:
+            Area [m^2].
+        """
+        return (self.outer_diameter**2) * (value / (self.grid_resolution**2))
+
+    def get_normalized_spacing(self) -> float:
+        """Return the cell size in normalized coordinates (`1 / grid_resolution`)."""
+        return 1 / self.grid_resolution
+
+    def _apply_surface_inhibition(
         self,
         face_map: NDArray[np.int_],
-        outside: NDArray[np.bool_],
+        excluded_mask: NDArray[np.bool_],
     ) -> tuple[NDArray[np.int_], NDArray[np.bool_]]:
         """
-        Apply surface-inhibition adjustments to the face map and mask.
+        Apply surface inhibition maps.
 
-        Base implementation handles outer-surface inhibition. 2D and 3D
-        subclasses add their own logic for other inhibited surfaces.
+        Base implementation handles outer surface inhibition. 2D and 3D subclasses add
+        their own logic for other inhibited surfaces.
 
         Args:
             face_map: Mutable copy of the initial face map.
-            outside: Mutable copy of the circular boundary mask.
+            excluded_mask: Mutable copy of the outer diameter mask; cells excluded from
+                the burn domain, extended here with inhibited surfaces.
 
         Returns:
-            Tuple `(face_map, outside)` with inhibition applied.
+            `(face_map, excluded_mask)` with inhibition applied.
         """
         if not self.inhibited_surfaces.outer_surface:
-            inside = ~outside  # Invert the mask
+            inside = ~excluded_mask  # Invert the mask
             eroded = binary_erosion(inside)  # Erode the inside to find the boundary
-            boundary_ring = inside & np.logical_not(eroded)
-            face_map[boundary_ring] = 0
+            outer_surface_boundary = inside & np.logical_not(eroded)
+            face_map[outer_surface_boundary] = 0
 
-        return face_map, outside
+        return face_map, excluded_mask
 
     def get_masked_face(self) -> np.ndarray:
-        """
-        Return a masked representation of the face map.
-
-        The mask is circular and normalized to the map dimensions. Generated on
-        first access by combining the initial face map with the circular mask.
-        """
+        """Return a masked representation of the face map."""
         if self.masked_face is None:
-            face_map = self.get_initial_face_map().copy()
-            outside = self.get_mask().copy()
+            face_map = self.generate_initial_face_map().copy()
+            excluded_mask = self.get_outer_diameter_mask().copy()
 
-            face_map, outside = self._apply_inhibition(face_map, outside)
+            face_map, excluded_mask = self._apply_surface_inhibition(
+                face_map, excluded_mask
+            )
 
-            self.masked_face = np.ma.MaskedArray(face_map, outside)
+            self.masked_face = np.ma.MaskedArray(face_map, excluded_mask)
         return self.masked_face
-
-    def get_cell_size(self) -> float:
-        """Return the cell size in normalized coordinates (`1 / map_dim`)."""
-        return 1 / self.map_dim
 
     @property
     def has_cross_section_regression(self) -> bool:
-        """
-        Return whether the cross-section has any burning surface.
-
-        Inspects the masked face map for zero-valued (burning) cells. Returns
-        False when no burning front exists for the FMM to propagate from.
-        """
+        """Return whether the cross-section has any burning surface."""
         masked_face = self.get_masked_face()
         unmasked = ~np.ma.getmaskarray(masked_face)
         return bool(np.any(masked_face.data[np.asarray(unmasked, dtype=bool)] == 0))
 
-    def _regression_distance(self, masked_face: np.ndarray) -> np.ndarray:
+    def _compute_regression_distance(self, masked_face: np.ndarray) -> np.ndarray:
         """Return the regression distance from the burning surface in normalized web units."""
-        return skfmm.distance(masked_face, dx=self.get_cell_size()) * 2
+        return skfmm.distance(masked_face, dx=self.get_normalized_spacing()) * 2
 
     def get_regression_map(self):
         """
@@ -222,19 +199,21 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
             masked_face = self.get_masked_face()
 
             if self.has_cross_section_regression:
-                self.regression_map = self._regression_distance(masked_face)
+                self.regression_map = self._compute_regression_distance(masked_face)
             else:
                 # End burner: web = length split across exposed ends. Fill the
                 # whole array with one constant (not 0 outside the mask) so the
                 # perimeter tracer finds no spurious contour.
-                exposed_ends = (not self.inhibited_surfaces.upper_end) + (
+                exposed_end_count = (not self.inhibited_surfaces.upper_end) + (
                     not self.inhibited_surfaces.lower_end
                 )
-                axial_web = (
-                    self.normalize(self.length / exposed_ends) if exposed_ends else 0.0
+                normalized_axial_web_distance = (
+                    self.normalize(self.length / exposed_end_count)
+                    if exposed_end_count
+                    else 0.0
                 )
                 self.regression_map = np.ma.MaskedArray(
-                    np.full(masked_face.shape, axial_web),
+                    np.full(masked_face.shape, normalized_axial_web_distance),
                     mask=np.ma.getmaskarray(masked_face),
                 )
         return self.regression_map
@@ -251,6 +230,34 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
                 self.denormalize(float(np.amax(self.get_regression_map())))
             )
         return float(self.web_thickness)
+
+    def get_face_map(self, web_distance: float) -> np.typing.NDArray[np.int64]:
+        """
+        Returns a matrix representing the grain face based on the given web distance.
+
+        The returned array can contain:
+        -1 for masked or invalid points,
+        0 for points below the threshold,
+        1 for points above the threshold.
+
+        Args:
+            web_distance: The distance traveled into the grain web.
+
+        Returns:
+            A NumPy array with -1, 0, or 1 indicating the grain face at the specified web distance.
+        """
+        web_distance_normalized = self.normalize(web_distance)
+        regression_map = self.get_regression_map()
+        excluded_mask = np.ma.getmaskarray(regression_map)
+
+        # Create a masked array, where excluded cells are masked out
+        occupancy_state = np.ma.MaskedArray(
+            (regression_map > web_distance_normalized).astype(np.int64),
+            mask=excluded_mask,
+        )
+
+        # Fill masked entries with -1, valid/true entries remain 1 or 0
+        return occupancy_state.filled(-1)
 
     @abstractmethod
     def get_contours(
@@ -271,31 +278,3 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
             An array representing the computed contours of the grain regression.
         """
         pass
-
-    def get_face_map(self, web_distance: float) -> np.typing.NDArray[np.int64]:
-        """
-        Returns a matrix representing the grain face based on the given web distance.
-
-        The returned array can contain:
-        -1 for masked or invalid points,
-        0 for points below the threshold,
-        1 for points above the threshold.
-
-        Args:
-            web_distance: The distance traveled into the grain web.
-
-        Returns:
-            A NumPy array with -1, 0, or 1 indicating the grain face at the specified web distance.
-        """
-        web_distance_normalized = self.normalize(web_distance)
-        regression_map = self.get_regression_map()
-        invalid = np.ma.getmaskarray(regression_map)
-
-        # Create a masked array, where invalid cells are masked out
-        maskarr = np.ma.MaskedArray(
-            (regression_map > web_distance_normalized).astype(np.int64),
-            mask=invalid,
-        )
-
-        # Fill masked entries with -1, valid/true entries remain 1 or 0
-        return maskarr.filled(-1)

--- a/machwave/models/grain/fmm/contours.py
+++ b/machwave/models/grain/fmm/contours.py
@@ -2,15 +2,16 @@ import numpy as np
 from skimage import measure
 
 
-def get_contours(
-    map: np.typing.NDArray[np.float64], map_dist: float, *args, **kwargs
+def get_iso_contours(
+    regression_field: np.typing.NDArray[np.float64], iso_level: float, *args, **kwargs
 ) -> list[np.typing.NDArray[np.float64]]:
     """
-    Finds contours in a 2D array at a specified iso-value (map_dist).
+    Finds contours in a 2D array at a specified iso-value (iso_level).
 
     Args:
-        map: The 2D NumPy array (float64) from which to extract contours.
-        map_dist: The iso-value level at which to trace contours.
+        regression_field: The 2D NumPy array (float64) from which to extract
+            contours.
+        iso_level: The iso-value level at which to trace contours.
         *args: Additional positional arguments passed to skimage.measure.find_contours.
         **kwargs: Additional keyword arguments passed to skimage.measure.find_contours.
 
@@ -18,35 +19,43 @@ def get_contours(
         A list of float64 arrays, where each array represents a contour.
         Each contour array is typically shaped (N, 2) with (row, col) coordinates.
     """
-    if np.ma.isMaskedArray(map):
+    if np.ma.isMaskedArray(regression_field):
         # Outside-casing cells read as 0, tracing a spurious contour along the
         # wall; lift them above every iso level so only real fronts are traced.
-        map = np.ma.filled(map, float(map.max()) + 1.0)
-    return measure.find_contours(map, map_dist, fully_connected="low", *args, **kwargs)
+        regression_field = np.ma.filled(
+            regression_field, float(regression_field.max()) + 1.0
+        )
+    return measure.find_contours(
+        regression_field, iso_level, fully_connected="low", *args, **kwargs
+    )
 
 
-def get_length(contour: np.ndarray, map_size: int, tolerance: float = 1.0) -> float:
+def get_length(
+    contour: np.ndarray, grid_resolution: int, tolerance: float = 1.0
+) -> float:
     """
     Return the total length of contour segments away from the disc edge.
 
-    Segments within `tolerance` of the edge of a circle of diameter `map_size`
-    are excluded, dropping the casing wall while keeping a burning front that
-    has regressed close to it.
+    Segments within `tolerance` of the edge of a circle of diameter
+    `grid_resolution` are excluded, dropping the casing wall while keeping a
+    burning front that has regressed close to it.
 
     Args:
         contour: The contour array.
-        map_size: The size of the map.
+        grid_resolution: Grid points per axis of the map.
         tolerance: The tolerance value. Defaults to 1.0.
 
     Returns:
         The total length of the segments.
     """
-    offset = np.roll(contour.T, 1, axis=1)
-    lengths = np.linalg.norm(contour.T - offset, axis=0)
+    shifted_vertices = np.roll(contour.T, 1, axis=1)
+    segment_lengths = np.linalg.norm(contour.T - shifted_vertices, axis=0)
 
-    center_offset = np.array([[map_size / 2, map_size / 2]])
-    radius = np.linalg.norm(contour - center_offset, axis=1)
+    center_position = np.array([[grid_resolution / 2, grid_resolution / 2]])
+    distance_from_center = np.linalg.norm(contour - center_position, axis=1)
 
-    valid = radius < (map_size / 2) - tolerance
+    is_interior_contour_segment = (
+        distance_from_center < (grid_resolution / 2) - tolerance
+    )
 
-    return np.sum(lengths[valid])
+    return np.sum(segment_lengths[is_interior_contour_segment])

--- a/machwave/models/grain/fmm/stl.py
+++ b/machwave/models/grain/fmm/stl.py
@@ -29,7 +29,7 @@ class FMMSTLGrainSegment(grain_fmm.FMMGrainSegment3D, ABC):
         outer_diameter: float,
         length: float,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
-        map_dim: int = 50,
+        grid_resolution: int = grain_fmm.DEFAULT_GRID_RESOLUTION,
     ) -> None:
         """
         Initialize an STL-backed FMM grain segment.
@@ -39,49 +39,49 @@ class FMMSTLGrainSegment(grain_fmm.FMMGrainSegment3D, ABC):
             outer_diameter: Outer diameter [m].
             length: Segment length [m].
             inhibited_surfaces: Surfaces inhibited from burning.
-            map_dim: Pixel resolution of the cross-section map.
+            grid_resolution: Grid points per axis of the cross-section.
         """
         self.file_path = file_path
         self.outer_diameter = outer_diameter
         self.length = length
 
         # "Cache" variables:
-        self.face_area_interp_func = None
+        self.face_area_interpolator = None
 
         super().__init__(
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
-            map_dim=map_dim,
+            grid_resolution=grid_resolution,
         )
 
     def validate(self) -> None:
         """Validate STL grain segment geometry."""
         grain.GrainSegment.validate(self)
-        if not self.map_dim >= 20:
+        if not self.grid_resolution >= 20:
             raise grain.GrainGeometryError(
-                f"Map dimension must be at least 20 for STL grains, got {self.map_dim}"
+                f"Grid resolution must be at least 20 for STL grains, got {self.grid_resolution}"
             )
-        self._validate_normalized_length()
+        self._validate_axial_resolution()
 
-    def get_voxel_size(self) -> float:
-        """Return the voxelization pitch [m]."""
-        return self.outer_diameter / (self.map_dim - 1)
+    def get_grid_spacing(self) -> float:
+        """Return the grid spacing [m] used to voxelize the mesh."""
+        return self.outer_diameter / (self.grid_resolution - 1)
 
-    def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
+    def generate_initial_face_map(self) -> np.typing.NDArray[np.int_]:
         """
         Generate the initial face map by voxelizing an STL mesh.
 
         The trimesh voxel grid does not line up with the FMM grid, so it is
-        resampled onto the canonical `(normalized_length, map_dim, map_dim)`
+        resampled onto the canonical `(normalized_length, grid_resolution, grid_resolution)`
         shape the rest of the 3D machinery expects.
         """
         mesh = trimesh.load_mesh(self.file_path)
         assert isinstance(mesh, trimesh.Trimesh), "Expected a single Trimesh"
         assert mesh.is_watertight, "Mesh must be watertight"
 
-        voxels = mesh.voxelized(pitch=self.get_voxel_size())
+        voxels = mesh.voxelized(pitch=self.get_grid_spacing())
         assert voxels is not None, "Voxelization failed"
         voxel_map = voxels.fill().matrix.view(np.ndarray).transpose().astype(np.int_)
 
-        return _resample_nearest(voxel_map, self.get_maps()[0].shape)
+        return _resample_nearest(voxel_map, self.get_coordinate_grids()[0].shape)

--- a/machwave/models/grain/geometries/conical.py
+++ b/machwave/models/grain/geometries/conical.py
@@ -15,7 +15,7 @@ class ConicalGrainSegment(grain_fmm.FMMGrainSegment3D):
         upper_core_diameter: float,
         lower_core_diameter: float,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
-        map_dim: int = 100,
+        grid_resolution: int = grain_fmm.DEFAULT_GRID_RESOLUTION,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -27,7 +27,7 @@ class ConicalGrainSegment(grain_fmm.FMMGrainSegment3D):
             upper_core_diameter: Core diameter at the upper (bulkhead) end [m].
             lower_core_diameter: Core diameter at the lower (nozzle) end [m].
             inhibited_surfaces: Surfaces inhibited from burning.
-            map_dim: Pixel resolution of the cross-section map.
+            grid_resolution: Grid points per axis of the cross-section.
             density_ratio: Ratio of real to ideal propellant density.
         """
         self.upper_core_diameter = upper_core_diameter
@@ -37,7 +37,7 @@ class ConicalGrainSegment(grain_fmm.FMMGrainSegment3D):
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
-            map_dim=map_dim,
+            grid_resolution=grid_resolution,
             density_ratio=density_ratio,
         )
 
@@ -64,17 +64,20 @@ class ConicalGrainSegment(grain_fmm.FMMGrainSegment3D):
                 f"outer diameter ({self.outer_diameter})"
             )
 
-    def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
+    def generate_initial_face_map(self) -> np.typing.NDArray[np.int_]:
         """Return the initial face map for the conical port."""
-        map_x, map_y, map_z = self.get_maps()
+        map_x, map_y, map_z = self.get_coordinate_grids()
         core_map = self.get_empty_face_map()
 
-        upper_core_norm = self.normalize(self.upper_core_diameter)
-        lower_core_norm = self.normalize(self.lower_core_diameter)
+        upper_core_normalized = self.normalize(self.upper_core_diameter)
+        lower_core_normalized = self.normalize(self.lower_core_diameter)
 
         radius = np.sqrt(map_x**2 + map_y**2)
         # map_z is 1 at the aft (nozzle) slice and 0 at the forward (bulkhead) slice.
-        core_diameter = map_z * (lower_core_norm - upper_core_norm) + upper_core_norm
+        core_diameter = (
+            map_z * (lower_core_normalized - upper_core_normalized)
+            + upper_core_normalized
+        )
 
         core_map[radius < core_diameter / 2] = 0
         core_map[0] = 0  # Inhibit the bottom end

--- a/machwave/models/grain/geometries/d_grain.py
+++ b/machwave/models/grain/geometries/d_grain.py
@@ -14,7 +14,7 @@ class DGrainSegment(grain_fmm.FMMGrainSegment2D):
         outer_diameter: float,
         slot_offset: float,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
-        map_dim: int = 100,
+        grid_resolution: int = grain_fmm.DEFAULT_GRID_RESOLUTION,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -25,7 +25,7 @@ class DGrainSegment(grain_fmm.FMMGrainSegment2D):
             outer_diameter: Outer diameter [m].
             slot_offset: Distance from the grain center to the slot face [m].
             inhibited_surfaces: Surfaces inhibited from burning.
-            map_dim: Pixel resolution of the cross-section map.
+            grid_resolution: Grid points per axis of the cross-section.
             density_ratio: Ratio of real to ideal propellant density.
         """
         self.slot_offset = slot_offset
@@ -34,7 +34,7 @@ class DGrainSegment(grain_fmm.FMMGrainSegment2D):
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
-            map_dim=map_dim,
+            grid_resolution=grid_resolution,
             density_ratio=density_ratio,
         )
 
@@ -53,10 +53,10 @@ class DGrainSegment(grain_fmm.FMMGrainSegment2D):
                 f"half the outer diameter ({max_slot_offset})"
             )
 
-    def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
+    def generate_initial_face_map(self) -> np.typing.NDArray[np.int_]:
         """Return the initial face map for the D-grain port."""
         slot_offset_normalized = self.normalize(self.slot_offset)
-        map_x = self.get_maps()[0]
+        map_x = self.get_coordinate_grids()[0]
         core_map = self.get_empty_face_map()
         core_map[map_x > slot_offset_normalized] = 0
         return core_map

--- a/machwave/models/grain/geometries/finocyl.py
+++ b/machwave/models/grain/geometries/finocyl.py
@@ -20,7 +20,7 @@ class FinocylGrainSegment(grain_fmm.FMMGrainSegment3D):
         fin_axial_offset: float = 0.0,
         transition_length: float = 0.0,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
-        map_dim: int = 100,
+        grid_resolution: int = grain_fmm.DEFAULT_GRID_RESOLUTION,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -42,7 +42,7 @@ class FinocylGrainSegment(grain_fmm.FMMGrainSegment3D):
                 applied at each interface between the finned and cylindrical
                 sections. A value of 0.0 gives an abrupt step [m].
             inhibited_surfaces: Surfaces inhibited from burning.
-            map_dim: Pixel resolution of the cross-section map.
+            grid_resolution: Grid points per axis of the cross-section.
             density_ratio: Ratio of real to ideal propellant density.
         """
         self.core_diameter = core_diameter
@@ -57,7 +57,7 @@ class FinocylGrainSegment(grain_fmm.FMMGrainSegment3D):
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
-            map_dim=map_dim,
+            grid_resolution=grid_resolution,
             density_ratio=density_ratio,
         )
 
@@ -181,31 +181,31 @@ class FinocylGrainSegment(grain_fmm.FMMGrainSegment3D):
         )
         return np.minimum(rise, fall)
 
-    def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
+    def generate_initial_face_map(self) -> np.typing.NDArray[np.int_]:
         """Return the initial face map for the finocyl port."""
-        map_x, map_y, map_z = self.get_maps()
+        map_x, map_y, map_z = self.get_coordinate_grids()
         core_map = self.get_empty_face_map()
 
-        core_radius_norm = self.normalize(self.core_diameter) / 2
-        fin_width_norm = self.normalize(self.fin_width)
-        fin_length_norm = self.normalize(self.fin_length)
+        core_radius_normalized = self.normalize(self.core_diameter) / 2
+        fin_width_normalized = self.normalize(self.fin_width)
+        fin_length_normalized = self.normalize(self.fin_length)
 
         radius = np.sqrt(map_x**2 + map_y**2)
-        core_map[radius < core_radius_norm] = 0
+        core_map[radius < core_radius_normalized] = 0
 
         axial_position = (1 - map_z) * self.length
-        local_fin_tip_norm = core_radius_norm + (
-            self._fin_depth_fraction(axial_position) * fin_length_norm
+        local_fin_tip_normalized = core_radius_normalized + (
+            self._fin_depth_fraction(axial_position) * fin_length_normalized
         )
 
         for i in range(self.number_of_fins):
             theta = 2 * np.pi / self.number_of_fins * i
             within_width = (
                 np.abs(np.cos(theta) * map_x + np.sin(theta) * map_y)
-                < fin_width_norm / 2
+                < fin_width_normalized / 2
             )
             radial = np.sin(theta) * map_x - np.cos(theta) * map_y
-            within_length = (radial > 0) & (radial < local_fin_tip_norm)
+            within_length = (radial > 0) & (radial < local_fin_tip_normalized)
             core_map[within_width & within_length] = 0
 
         core_map[0] = 0

--- a/machwave/models/grain/geometries/multi_port.py
+++ b/machwave/models/grain/geometries/multi_port.py
@@ -16,7 +16,7 @@ class MultiPortGrainSegment(grain_fmm.FMMGrainSegment2D):
         port_radial_count: float,
         port_level_count: float,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
-        map_dim: int = 100,
+        grid_resolution: int = grain_fmm.DEFAULT_GRID_RESOLUTION,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -29,7 +29,7 @@ class MultiPortGrainSegment(grain_fmm.FMMGrainSegment2D):
             port_radial_count: Number of ports per concentric ring.
             port_level_count: Number of concentric rings of ports.
             inhibited_surfaces: Surfaces inhibited from burning.
-            map_dim: Pixel resolution of the cross-section map.
+            grid_resolution: Grid points per axis of the cross-section.
             density_ratio: Ratio of real to ideal propellant density.
         """
         self.port_diameter = port_diameter
@@ -40,7 +40,7 @@ class MultiPortGrainSegment(grain_fmm.FMMGrainSegment2D):
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
-            map_dim=map_dim,
+            grid_resolution=grid_resolution,
             density_ratio=density_ratio,
         )
 
@@ -68,24 +68,26 @@ class MultiPortGrainSegment(grain_fmm.FMMGrainSegment2D):
                 f"Port radial count must be positive, got {self.port_radial_count}"
             )
 
-    def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
+    def generate_initial_face_map(self) -> np.typing.NDArray[np.int_]:
         """NOTE: Still needs to correctly implement wagon wheel ports."""
-        map_x, map_y = self.get_maps()
+        map_x, map_y = self.get_coordinate_grids()
         core_map = self.get_empty_face_map()
 
-        od_norm = self.normalize(self.outer_diameter)
-        port_od_norm = self.normalize(self.port_diameter)
+        outer_diameter_normalized = self.normalize(self.outer_diameter)
+        port_diameter_normalized = self.normalize(self.port_diameter)
 
         for radius in range(self.port_radial_count):
             angle = np.pi * 2 * radius / self.port_radial_count
 
             for level in range(self.port_level_count):
-                radial_distance = od_norm * level / (self.port_level_count) / 2
+                radial_distance = (
+                    outer_diameter_normalized * level / (self.port_level_count) / 2
+                )
 
                 x_offset = radial_distance * np.cos(angle)
                 y_offset = radial_distance * np.sin(angle)
 
                 radius = np.sqrt((map_x - x_offset) ** 2 + (map_y - y_offset) ** 2)
-                core_map[radius < port_od_norm / 2] = 0
+                core_map[radius < port_diameter_normalized / 2] = 0
 
         return core_map

--- a/machwave/models/grain/geometries/rod_and_tube.py
+++ b/machwave/models/grain/geometries/rod_and_tube.py
@@ -15,7 +15,7 @@ class RodAndTubeGrainSegment(grain_fmm.FMMGrainSegment2D):
         rod_outer_diameter: float,
         tube_inner_diameter: float,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
-        map_dim: int = 100,
+        grid_resolution: int = grain_fmm.DEFAULT_GRID_RESOLUTION,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -27,7 +27,7 @@ class RodAndTubeGrainSegment(grain_fmm.FMMGrainSegment2D):
             rod_outer_diameter: Central rod outer diameter [m].
             tube_inner_diameter: Tube inner diameter [m].
             inhibited_surfaces: Surfaces inhibited from burning.
-            map_dim: Pixel resolution of the cross-section map.
+            grid_resolution: Grid points per axis of the cross-section.
             density_ratio: Ratio of real to ideal propellant density.
         """
         self.rod_outer_diameter = rod_outer_diameter
@@ -37,7 +37,7 @@ class RodAndTubeGrainSegment(grain_fmm.FMMGrainSegment2D):
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
-            map_dim=map_dim,
+            grid_resolution=grid_resolution,
             density_ratio=density_ratio,
         )
 
@@ -60,16 +60,19 @@ class RodAndTubeGrainSegment(grain_fmm.FMMGrainSegment2D):
                 f"outer diameter ({self.outer_diameter})"
             )
 
-    def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
+    def generate_initial_face_map(self) -> np.typing.NDArray[np.int_]:
         """NOTE: Still needs to correctly implement wagon wheel ports."""
-        map_x, map_y = self.get_maps()
+        map_x, map_y = self.get_coordinate_grids()
         core_map = self.get_empty_face_map()
 
-        rod_od_norm = self.normalize(self.rod_outer_diameter)
-        tube_id_norm = self.normalize(self.tube_inner_diameter)
+        rod_outer_diameter_normalized = self.normalize(self.rod_outer_diameter)
+        tube_inner_diameter_normalized = self.normalize(self.tube_inner_diameter)
 
         radius = np.sqrt(map_x**2 + map_y**2)
 
-        core_map[(radius > rod_od_norm / 2) & (radius < tube_id_norm / 2)] = 0
+        core_map[
+            (radius > rod_outer_diameter_normalized / 2)
+            & (radius < tube_inner_diameter_normalized / 2)
+        ] = 0
 
         return core_map

--- a/machwave/models/grain/geometries/star.py
+++ b/machwave/models/grain/geometries/star.py
@@ -16,7 +16,7 @@ class StarGrainSegment(grain_fmm.FMMGrainSegment2D):
         point_length: float,
         point_width: float,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
-        map_dim: int = 100,
+        grid_resolution: int = grain_fmm.DEFAULT_GRID_RESOLUTION,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -29,7 +29,7 @@ class StarGrainSegment(grain_fmm.FMMGrainSegment2D):
             point_length: Radial length of each point [m].
             point_width: Width of each point at the base [m].
             inhibited_surfaces: Surfaces inhibited from burning.
-            map_dim: Pixel resolution of the cross-section map.
+            grid_resolution: Grid points per axis of the cross-section.
             density_ratio: Ratio of real to ideal propellant density.
         """
         self.number_of_points = int(number_of_points)
@@ -40,7 +40,7 @@ class StarGrainSegment(grain_fmm.FMMGrainSegment2D):
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
-            map_dim=map_dim,
+            grid_resolution=grid_resolution,
             density_ratio=density_ratio,
         )
 
@@ -69,18 +69,13 @@ class StarGrainSegment(grain_fmm.FMMGrainSegment2D):
                 f"Point width must be positive, got {self.point_width}"
             )
 
-    def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
-        """
-        Return the initial face map for a star grain segment.
-
-        References:
-            openMotor, https://github.com/reilleya/openMotor
-        """
-        map_x, map_y = self.get_maps()
+    def generate_initial_face_map(self) -> np.typing.NDArray[np.int_]:
+        """Return the initial face map for a star grain segment."""
+        map_x, map_y = self.get_coordinate_grids()
         core_map = self.get_empty_face_map()
 
-        point_length_norm = self.normalize(self.point_length)
-        point_width_norm = self.normalize(self.point_width)
+        point_length_normalized = self.normalize(self.point_length)
+        point_width_normalized = self.normalize(self.point_width)
 
         radius = (map_x**2 + map_y**2) ** 0.5
 
@@ -88,7 +83,9 @@ class StarGrainSegment(grain_fmm.FMMGrainSegment2D):
             theta = 2 * np.pi / self.number_of_points * i
             rect = abs(np.cos(theta) * map_x + np.sin(theta) * map_y)
 
-            width = point_width_norm / 2 * (1 - (radius / point_length_norm))
+            width = (
+                point_width_normalized / 2 * (1 - (radius / point_length_normalized))
+            )
             vect = rect < width
             near = np.sin(theta) * map_x - np.cos(theta) * map_y > -0.025
 

--- a/machwave/models/grain/geometries/wagon_wheel.py
+++ b/machwave/models/grain/geometries/wagon_wheel.py
@@ -18,7 +18,7 @@ class WagonWheelGrainSegment(grain_fmm.FMMGrainSegment2D):
         port_outer_diameter: float,
         port_angular_width: float,
         inhibited_surfaces: grain_base.InhibitedSurfaces | None = None,
-        map_dim: int = 100,
+        grid_resolution: int = grain_fmm.DEFAULT_GRID_RESOLUTION,
         density_ratio: float = 1.0,
     ) -> None:
         """
@@ -33,7 +33,7 @@ class WagonWheelGrainSegment(grain_fmm.FMMGrainSegment2D):
             port_outer_diameter: Outer radial extent of each spoke port [m].
             port_angular_width: Angular width of each spoke port [deg].
             inhibited_surfaces: Surfaces inhibited from burning.
-            map_dim: Pixel resolution of the cross-section map.
+            grid_resolution: Grid points per axis of the cross-section.
             density_ratio: Ratio of real to ideal propellant density.
         """
         self.core_diameter = core_diameter
@@ -46,7 +46,7 @@ class WagonWheelGrainSegment(grain_fmm.FMMGrainSegment2D):
             length=length,
             outer_diameter=outer_diameter,
             inhibited_surfaces=inhibited_surfaces,
-            map_dim=map_dim,
+            grid_resolution=grid_resolution,
             density_ratio=density_ratio,
         )
 
@@ -91,18 +91,18 @@ class WagonWheelGrainSegment(grain_fmm.FMMGrainSegment2D):
                 f"{max_angular_width} (360 / {self.number_of_ports})"
             )
 
-    def get_initial_face_map(self) -> np.typing.NDArray[np.int_]:
+    def generate_initial_face_map(self) -> np.typing.NDArray[np.int_]:
         """NOTE: Still needs to correctly implement wagon wheel ports."""
-        map_x, map_y = self.get_maps()
+        map_x, map_y = self.get_coordinate_grids()
         core_map = self.get_empty_face_map()
 
-        core_diameter_norm = self.normalize(self.core_diameter)
-        port_inner_diameter_norm = self.normalize(self.port_inner_diameter)
-        port_outer_diameter_norm = self.normalize(self.port_outer_diameter)
+        core_diameter_normalized = self.normalize(self.core_diameter)
+        port_inner_diameter_normalized = self.normalize(self.port_inner_diameter)
+        port_outer_diameter_normalized = self.normalize(self.port_outer_diameter)
 
         radius = np.sqrt(map_x**2 + map_y**2)
 
-        core_map[radius < core_diameter_norm / 2] = 0
+        core_map[radius < core_diameter_normalized / 2] = 0
 
         for port_index in range(int(self.number_of_ports)):
             displacement_angle = 2 * np.pi / self.number_of_ports * (port_index)
@@ -113,8 +113,8 @@ class WagonWheelGrainSegment(grain_fmm.FMMGrainSegment2D):
             map_x_y_arctan = np.arctan(map_y / map_x)
 
             core_map[
-                (radius < port_outer_diameter_norm / 2)
-                & (radius > port_inner_diameter_norm / 2)
+                (radius < port_outer_diameter_normalized / 2)
+                & (radius > port_inner_diameter_normalized / 2)
                 & (np.abs(map_x_y_arctan) < theta_2)
                 & (np.abs(map_x_y_arctan) > theta_1)
             ] = 0

--- a/machwave/services/plots/fmm/face_map.py
+++ b/machwave/services/plots/fmm/face_map.py
@@ -240,7 +240,7 @@ def plot_3d_face_map_animated(
 
     Args:
         face_maps: 4D array of shape
-            ``(n_steps, normalized_length, map_dim, map_dim)`` with values
+            ``(n_steps, normalized_length, grid_resolution, grid_resolution)`` with values
             -1 (outside), 0 (burned), 1 (propellant).
         web_distances: 1D array of web distances [m] for each step.
 
@@ -256,9 +256,9 @@ def plot_3d_face_map_animated(
         raise ValueError("The number of frames must match the number of face maps.")
 
     n_z = face_maps.shape[1]
-    map_dim = face_maps.shape[2]
+    grid_resolution = face_maps.shape[2]
     mid_z = n_z // 2
-    mid_y = map_dim // 2
+    mid_y = grid_resolution // 2
 
     fig = make_subplots(
         rows=1,

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_burn_front_near_casing.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_burn_front_near_casing.py
@@ -27,7 +27,7 @@ def radial_tube():
         lower_core_diameter=CORE_DIAMETER,
         inhibited_surfaces=INHIBITED_ENDS,
     )
-    segment.map_dim = 150
+    segment.grid_resolution = 150
     return segment
 
 

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_conical.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_conical.py
@@ -2,7 +2,7 @@
 Constant-bore conical burn area versus the analytical hollow cylinder.
 
 With inhibited ends the grain is a pure-radial burner whose lateral burning
-area is exactly pi * (core + 2 * web) * length. Results depend on map_dim; the
+area is exactly pi * (core + 2 * web) * length. Results depend on grid_resolution; the
 15% tolerance absorbs the marching-squares quantization and the Savitzky-Golay
 smoothing, and the sweep stops at 80% web.
 """
@@ -179,4 +179,4 @@ def test_three_axial_slices_is_accepted():
         upper_core_diameter=15e-3,
         lower_core_diameter=10e-3,
     )
-    assert segment.get_normalized_length() == 3
+    assert segment.get_axial_resolution() == 3

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl.py
@@ -1,7 +1,7 @@
 """
 Tests for the finocyl 3D FMM grain segment.
 
-NOTE: As with the other FMM grains, results depend on the map_dim parameter.
+NOTE: As with the other FMM grains, results depend on the grid_resolution parameter.
 The cross-section assertions here compare relative quantities (finned slices
 versus unfinned slices) rather than absolute analytical values, since the
 finocyl burn area has no simple closed form.
@@ -91,7 +91,7 @@ def test_finned_slice_has_less_solid_material_than_unfinned_slice(finocyl_segmen
     """At ignition, a finned cross-section retains fewer solid cells."""
     face_map = finocyl_segment.get_face_map(web_distance=0.0)
 
-    normalized_length = finocyl_segment.get_normalized_length()
+    normalized_length = finocyl_segment.get_axial_resolution()
     finned_index = int(round(Z_FINNED / LENGTH * (normalized_length - 1)))
     unfinned_index = int(round(Z_UNFINNED / LENGTH * (normalized_length - 1)))
 

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl_solidworks.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl_solidworks.py
@@ -72,7 +72,7 @@ def test_center_of_gravity_is_on_the_axis(segment, case):
     """Six evenly spaced fins are radially symmetric, so the transverse center of
     gravity stays on the axis."""
     cog = segment.get_center_of_gravity(case["web"])
-    pixel = segment.map_to_length(1.0)
+    pixel = segment.cells_to_meters(1.0)
     assert abs(cog[1]) < pixel
     assert abs(cog[2]) < pixel
 
@@ -89,7 +89,7 @@ def test_moment_of_inertia_ratio_matches_solidworks(segment, case):
 @pytest.mark.parametrize("case", CASES)
 def test_finned_end_face_area_matches_solidworks(segment, case):
     face_map = segment.get_face_map(web_distance=case["web"])
-    pixel_area = segment.map_to_length(1.0) ** 2
+    pixel_area = segment.cells_to_meters(1.0) ** 2
     slice_areas = np.count_nonzero(face_map == 1, axis=(1, 2)) * pixel_area
     end_face = slice_areas[slice_areas > 0.5 * slice_areas.max()][0]
     assert end_face == pytest.approx(case["end_face"], rel=case["end_face_rel"])

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_stl.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_stl.py
@@ -41,8 +41,8 @@ def test_face_map_matches_the_fmm_grid_shape(tube_segment):
     Before the fix the raw voxel grid was off by a voxel on every axis, so the
     shape assertion hard-failed even for a correctly sized mesh.
     """
-    face_map = tube_segment.get_initial_face_map()
-    assert face_map.shape == tube_segment.get_maps()[0].shape
+    face_map = tube_segment.generate_initial_face_map()
+    assert face_map.shape == tube_segment.get_coordinate_grids()[0].shape
 
 
 def test_volume_matches_the_analytical_tube(tube_segment):
@@ -59,8 +59,9 @@ def test_volume_matches_the_analytical_tube(tube_segment):
         dict(outer_diameter=0.0),
         dict(outer_diameter=-1e-3),
         dict(length=0.0),
-        dict(map_dim=10),  # below the STL map-dimension floor of 20
-        dict(length=2e-3),  # axial map collapses below three slices
+        dict(grid_resolution=10),  # below the STL grid-resolution floor of 20
+        # short grain at a low resolution collapses the axial map below three slices
+        dict(length=2e-3, grid_resolution=50),
     ],
 )
 def test_invalid_geometry_raises(tube_stl_path, overrides):

--- a/tests/test_models/test_propulsion/test_grain/test_grid_resolution_forwarding.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grid_resolution_forwarding.py
@@ -25,14 +25,14 @@ fmm_factories = pytest.mark.parametrize(
 
 
 @fmm_factories
-def test_map_dim_forwarded_to_segment(factory):
-    """The constructor forwards map_dim to the FMM base instead of dropping it."""
-    segment = factory.build(map_dim=120)
-    assert segment.map_dim == 120
+def test_grid_resolution_forwarded_to_segment(factory):
+    """The constructor forwards grid_resolution to the FMM base instead of dropping it."""
+    segment = factory.build(grid_resolution=120)
+    assert segment.grid_resolution == 120
 
 
 @fmm_factories
-def test_map_dim_defaults_to_100(factory):
-    """Omitting map_dim keeps the base default."""
+def test_grid_resolution_defaults_to_100(factory):
+    """Omitting grid_resolution keeps the base default."""
     segment = factory.build()
-    assert segment.map_dim == 100
+    assert segment.grid_resolution == 100

--- a/tests/test_models/test_propulsion/test_grain/test_inhibition/test_fmm_inhibition.py
+++ b/tests/test_models/test_propulsion/test_grain/test_inhibition/test_fmm_inhibition.py
@@ -56,7 +56,7 @@ def _end_burning_cells(masked_face_3d, idx: int) -> int:
     Count burning propellant cells on an end slice, excluding the bore opening.
 
     The bore opening is identified as the burning (0-valued) cells in the
-    adjacent interior slice — this matches how the FMM code defines bore_mask.
+    adjacent interior slice — this matches how the FMM code defines inner_surface_inhibited_cells.
     """
     sl = masked_face_3d[idx]
     unmasked = ~np.ma.getmaskarray(sl)

--- a/tests/test_models/test_propulsion/test_grain/test_moi/test_bates_moi.py
+++ b/tests/test_models/test_propulsion/test_grain/test_moi/test_bates_moi.py
@@ -24,30 +24,34 @@ class TestBatesSegmentMomentOfInertia:
             density_ratio=1.0,
         )
 
-        moi = segment.get_moment_of_inertia(
+        inertia_tensor = segment.get_moment_of_inertia(
             web_distance=0.0, ideal_density=ideal_density
         )
 
         # Check tensor is 3x3
-        assert moi.shape == (3, 3)
+        assert inertia_tensor.shape == (3, 3)
 
         # Check symmetry
-        np.testing.assert_array_almost_equal(moi, moi.T, decimal=10)
+        np.testing.assert_array_almost_equal(
+            inertia_tensor, inertia_tensor.T, decimal=10
+        )
 
         # For a hollow cylinder:
         # Ixx (axial) should be less than Iyy, Izz (radial)
         # because radial moments include length contribution
-        assert moi[0, 0] > 0  # Ixx > 0
-        assert moi[1, 1] > 0  # Iyy > 0
-        assert moi[2, 2] > 0  # Izz > 0
+        assert inertia_tensor[0, 0] > 0  # Ixx > 0
+        assert inertia_tensor[1, 1] > 0  # Iyy > 0
+        assert inertia_tensor[2, 2] > 0  # Izz > 0
 
         # For symmetric BATES, Iyy should equal Izz
-        np.testing.assert_almost_equal(moi[1, 1], moi[2, 2], decimal=10)
+        np.testing.assert_almost_equal(
+            inertia_tensor[1, 1], inertia_tensor[2, 2], decimal=10
+        )
 
         # Off-diagonal terms should be zero for axisymmetric grain
-        assert abs(moi[0, 1]) < 1e-10
-        assert abs(moi[0, 2]) < 1e-10
-        assert abs(moi[1, 2]) < 1e-10
+        assert abs(inertia_tensor[0, 1]) < 1e-10
+        assert abs(inertia_tensor[0, 2]) < 1e-10
+        assert abs(inertia_tensor[1, 2]) < 1e-10
 
     def test_segment_moi_increases_with_length(self):
         """Test that MOI increases with segment length."""
@@ -146,7 +150,7 @@ class TestBatesSegmentMomentOfInertia:
             density_ratio=1.0,
         )
 
-        moi = segment.get_moment_of_inertia(
+        inertia_tensor = segment.get_moment_of_inertia(
             web_distance=0.0, ideal_density=ideal_density
         )
 
@@ -162,9 +166,9 @@ class TestBatesSegmentMomentOfInertia:
         expected_Iyy = mass * (r_sum_sq / 4 + length**2 / 12)
 
         # Validate
-        np.testing.assert_almost_equal(moi[0, 0], expected_Ixx, decimal=8)
-        np.testing.assert_almost_equal(moi[1, 1], expected_Iyy, decimal=8)
-        np.testing.assert_almost_equal(moi[2, 2], expected_Iyy, decimal=8)
+        np.testing.assert_almost_equal(inertia_tensor[0, 0], expected_Ixx, decimal=8)
+        np.testing.assert_almost_equal(inertia_tensor[1, 1], expected_Iyy, decimal=8)
+        np.testing.assert_almost_equal(inertia_tensor[2, 2], expected_Iyy, decimal=8)
 
 
 class TestBatesGrainMomentOfInertia:
@@ -213,18 +217,24 @@ class TestBatesGrainMomentOfInertia:
         grain.add_segment(segment2)
 
         ideal_density = 1800.0
-        moi = grain.get_moment_of_inertia(web_distance=0.0, ideal_density=ideal_density)
+        inertia_tensor = grain.get_moment_of_inertia(
+            web_distance=0.0, ideal_density=ideal_density
+        )
 
         # Check tensor is symmetric
-        np.testing.assert_array_almost_equal(moi, moi.T, decimal=10)
+        np.testing.assert_array_almost_equal(
+            inertia_tensor, inertia_tensor.T, decimal=10
+        )
 
         # Check diagonal values are positive
-        assert moi[0, 0] > 0
-        assert moi[1, 1] > 0
-        assert moi[2, 2] > 0
+        assert inertia_tensor[0, 0] > 0
+        assert inertia_tensor[1, 1] > 0
+        assert inertia_tensor[2, 2] > 0
 
         # For symmetric configuration, Iyy ≈ Izz
-        np.testing.assert_almost_equal(moi[1, 1], moi[2, 2], decimal=8)
+        np.testing.assert_almost_equal(
+            inertia_tensor[1, 1], inertia_tensor[2, 2], decimal=8
+        )
 
     def test_three_segments_with_spacing(self):
         """Test MOI for three BATES segments with spacing."""
@@ -240,15 +250,21 @@ class TestBatesGrainMomentOfInertia:
             grain.add_segment(segment)
 
         ideal_density = 1800.0
-        moi = grain.get_moment_of_inertia(web_distance=0.0, ideal_density=ideal_density)
+        inertia_tensor = grain.get_moment_of_inertia(
+            web_distance=0.0, ideal_density=ideal_density
+        )
 
         # Basic validations
-        assert moi.shape == (3, 3)
-        np.testing.assert_array_almost_equal(moi, moi.T, decimal=10)
-        assert np.all(np.diag(moi) > 0)
+        assert inertia_tensor.shape == (3, 3)
+        np.testing.assert_array_almost_equal(
+            inertia_tensor, inertia_tensor.T, decimal=10
+        )
+        assert np.all(np.diag(inertia_tensor) > 0)
 
         # For symmetric grain, Iyy ≈ Izz
-        np.testing.assert_almost_equal(moi[1, 1], moi[2, 2], decimal=6)
+        np.testing.assert_almost_equal(
+            inertia_tensor[1, 1], inertia_tensor[2, 2], decimal=6
+        )
 
     def test_moi_decreases_during_burn_multisegment(self):
         """Test that total MOI decreases as multi-segment grain burns."""
@@ -300,12 +316,16 @@ class TestBatesGrainMomentOfInertia:
         grain.add_segment(segment2)
 
         ideal_density = 1800.0
-        moi = grain.get_moment_of_inertia(web_distance=0.0, ideal_density=ideal_density)
+        inertia_tensor = grain.get_moment_of_inertia(
+            web_distance=0.0, ideal_density=ideal_density
+        )
 
         # Basic checks
-        assert moi.shape == (3, 3)
-        assert np.all(np.diag(moi) > 0)
-        np.testing.assert_array_almost_equal(moi, moi.T, decimal=10)
+        assert inertia_tensor.shape == (3, 3)
+        assert np.all(np.diag(inertia_tensor) > 0)
+        np.testing.assert_array_almost_equal(
+            inertia_tensor, inertia_tensor.T, decimal=10
+        )
 
     def test_parallel_axis_theorem_validation(self):
         """Validate that parallel axis theorem is correctly applied."""

--- a/tests/test_models/test_propulsion/test_grain/test_moi/test_fmm2d_moi.py
+++ b/tests/test_models/test_propulsion/test_grain/test_moi/test_fmm2d_moi.py
@@ -20,24 +20,30 @@ class TestFMM2DSegmentMomentOfInertia:
         ideal_density = 1800.0
 
         segment = segment_factory(length=length, outer_diameter=outer_diameter)
-        moi = segment.get_moment_of_inertia(
+        inertia_tensor = segment.get_moment_of_inertia(
             web_distance=0.0, ideal_density=ideal_density
         )
 
         # Check tensor is 3x3
-        assert moi.shape == (3, 3)
+        assert inertia_tensor.shape == (3, 3)
 
         # Check symmetry
-        np.testing.assert_array_almost_equal(moi, moi.T, decimal=10)
+        np.testing.assert_array_almost_equal(
+            inertia_tensor, inertia_tensor.T, decimal=10
+        )
 
         # All diagonal elements should be positive
-        assert moi[0, 0] > 0  # Ixx > 0
-        assert moi[1, 1] > 0  # Iyy > 0
-        assert moi[2, 2] > 0  # Izz > 0
+        assert inertia_tensor[0, 0] > 0  # Ixx > 0
+        assert inertia_tensor[1, 1] > 0  # Iyy > 0
+        assert inertia_tensor[2, 2] > 0  # Izz > 0
 
         # For roughly symmetric 2D grains, Iyy should be close to Izz
         # (though some geometries like D-grain may have slight asymmetry)
-        ratio = moi[1, 1] / moi[2, 2] if moi[2, 2] > 0 else 0
+        ratio = (
+            inertia_tensor[1, 1] / inertia_tensor[2, 2]
+            if inertia_tensor[2, 2] > 0
+            else 0
+        )
         assert 0.5 < ratio < 2.0  # Allow for some asymmetry
 
     def test_segment_moi_tensor_structure(self, segment_factory, geometry_name):
@@ -45,16 +51,18 @@ class TestFMM2DSegmentMomentOfInertia:
         segment = segment_factory(length=0.2, outer_diameter=0.1)
         ideal_density = 1800.0
 
-        moi = segment.get_moment_of_inertia(
+        inertia_tensor = segment.get_moment_of_inertia(
             web_distance=0.0, ideal_density=ideal_density
         )
 
         # Check it's a proper symmetric tensor
-        assert moi.shape == (3, 3)
-        np.testing.assert_array_almost_equal(moi, moi.T, decimal=10)
+        assert inertia_tensor.shape == (3, 3)
+        np.testing.assert_array_almost_equal(
+            inertia_tensor, inertia_tensor.T, decimal=10
+        )
 
         # Diagonal elements should be positive
-        assert np.all(np.diag(moi) > 0)
+        assert np.all(np.diag(inertia_tensor) > 0)
 
     def test_segment_moi_decreases_with_burn(self, segment_factory, geometry_name):
         """Test that MOI decreases as propellant burns (mass decreases)."""
@@ -145,18 +153,26 @@ class TestFMM2DGrainMultiSegmentMomentOfInertia:
         grain.add_segment(segment2)
 
         ideal_density = 1800.0
-        moi = grain.get_moment_of_inertia(web_distance=0.0, ideal_density=ideal_density)
+        inertia_tensor = grain.get_moment_of_inertia(
+            web_distance=0.0, ideal_density=ideal_density
+        )
 
         # Check tensor is symmetric
-        np.testing.assert_array_almost_equal(moi, moi.T, decimal=10)
+        np.testing.assert_array_almost_equal(
+            inertia_tensor, inertia_tensor.T, decimal=10
+        )
 
         # Check diagonal values are positive
-        assert moi[0, 0] > 0
-        assert moi[1, 1] > 0
-        assert moi[2, 2] > 0
+        assert inertia_tensor[0, 0] > 0
+        assert inertia_tensor[1, 1] > 0
+        assert inertia_tensor[2, 2] > 0
 
         # For roughly symmetric configuration, Iyy ≈ Izz
-        ratio = moi[1, 1] / moi[2, 2] if moi[2, 2] > 0 else 0
+        ratio = (
+            inertia_tensor[1, 1] / inertia_tensor[2, 2]
+            if inertia_tensor[2, 2] > 0
+            else 0
+        )
         assert 0.8 < ratio < 1.2  # Within 20% for symmetric grains
 
     def test_three_segments_with_spacing(self, segment_factory, geometry_name):
@@ -168,12 +184,16 @@ class TestFMM2DGrainMultiSegmentMomentOfInertia:
             grain.add_segment(segment)
 
         ideal_density = 1800.0
-        moi = grain.get_moment_of_inertia(web_distance=0.0, ideal_density=ideal_density)
+        inertia_tensor = grain.get_moment_of_inertia(
+            web_distance=0.0, ideal_density=ideal_density
+        )
 
         # Basic validations
-        assert moi.shape == (3, 3)
-        np.testing.assert_array_almost_equal(moi, moi.T, decimal=10)
-        assert np.all(np.diag(moi) > 0)
+        assert inertia_tensor.shape == (3, 3)
+        np.testing.assert_array_almost_equal(
+            inertia_tensor, inertia_tensor.T, decimal=10
+        )
+        assert np.all(np.diag(inertia_tensor) > 0)
 
     def test_moi_decreases_during_burn_multisegment(
         self, segment_factory, geometry_name

--- a/tests/test_models/test_propulsion/test_grain/test_moi/test_fmm3d_moi.py
+++ b/tests/test_models/test_propulsion/test_grain/test_moi/test_fmm3d_moi.py
@@ -20,23 +20,29 @@ class TestFMM3DSegmentMomentOfInertia:
         ideal_density = 1800.0
 
         segment = segment_factory(length=length, outer_diameter=outer_diameter)
-        moi = segment.get_moment_of_inertia(
+        inertia_tensor = segment.get_moment_of_inertia(
             web_distance=0.0, ideal_density=ideal_density
         )
 
         # Check tensor is 3x3
-        assert moi.shape == (3, 3)
+        assert inertia_tensor.shape == (3, 3)
 
         # Check symmetry
-        np.testing.assert_array_almost_equal(moi, moi.T, decimal=10)
+        np.testing.assert_array_almost_equal(
+            inertia_tensor, inertia_tensor.T, decimal=10
+        )
 
         # All diagonal elements should be positive
-        assert moi[0, 0] > 0  # Ixx > 0
-        assert moi[1, 1] > 0  # Iyy > 0
-        assert moi[2, 2] > 0  # Izz > 0
+        assert inertia_tensor[0, 0] > 0  # Ixx > 0
+        assert inertia_tensor[1, 1] > 0  # Iyy > 0
+        assert inertia_tensor[2, 2] > 0  # Izz > 0
 
         # For cylindrical 3D grains, Iyy should be close to Izz
-        ratio = moi[1, 1] / moi[2, 2] if moi[2, 2] > 0 else 0
+        ratio = (
+            inertia_tensor[1, 1] / inertia_tensor[2, 2]
+            if inertia_tensor[2, 2] > 0
+            else 0
+        )
         assert 0.9 < ratio < 1.1  # Within 10% for symmetric grains
 
     def test_segment_moi_tensor_structure(self, segment_factory, geometry_name):
@@ -44,16 +50,18 @@ class TestFMM3DSegmentMomentOfInertia:
         segment = segment_factory(length=0.02, outer_diameter=0.1)
         ideal_density = 1800.0
 
-        moi = segment.get_moment_of_inertia(
+        inertia_tensor = segment.get_moment_of_inertia(
             web_distance=0.0, ideal_density=ideal_density
         )
 
         # Check it's a proper symmetric tensor
-        assert moi.shape == (3, 3)
-        np.testing.assert_array_almost_equal(moi, moi.T, decimal=10)
+        assert inertia_tensor.shape == (3, 3)
+        np.testing.assert_array_almost_equal(
+            inertia_tensor, inertia_tensor.T, decimal=10
+        )
 
         # Diagonal elements should be positive
-        assert np.all(np.diag(moi) > 0)
+        assert np.all(np.diag(inertia_tensor) > 0)
 
     def test_segment_moi_decreases_with_burn(self, segment_factory, geometry_name):
         """Test that MOI decreases as propellant burns (mass decreases)."""
@@ -164,18 +172,26 @@ class TestFMM3DGrainMultiSegmentMomentOfInertia:
         grain.add_segment(segment2)
 
         ideal_density = 1800.0
-        moi = grain.get_moment_of_inertia(web_distance=0.0, ideal_density=ideal_density)
+        inertia_tensor = grain.get_moment_of_inertia(
+            web_distance=0.0, ideal_density=ideal_density
+        )
 
         # Check tensor is symmetric
-        np.testing.assert_array_almost_equal(moi, moi.T, decimal=10)
+        np.testing.assert_array_almost_equal(
+            inertia_tensor, inertia_tensor.T, decimal=10
+        )
 
         # Check diagonal values are positive
-        assert moi[0, 0] > 0
-        assert moi[1, 1] > 0
-        assert moi[2, 2] > 0
+        assert inertia_tensor[0, 0] > 0
+        assert inertia_tensor[1, 1] > 0
+        assert inertia_tensor[2, 2] > 0
 
         # For symmetric configuration, Iyy ≈ Izz
-        ratio = moi[1, 1] / moi[2, 2] if moi[2, 2] > 0 else 0
+        ratio = (
+            inertia_tensor[1, 1] / inertia_tensor[2, 2]
+            if inertia_tensor[2, 2] > 0
+            else 0
+        )
         assert 0.95 < ratio < 1.05  # Within 5% for symmetric grains
 
     def test_three_segments_with_spacing(self, segment_factory, geometry_name):
@@ -187,12 +203,16 @@ class TestFMM3DGrainMultiSegmentMomentOfInertia:
             grain.add_segment(segment)
 
         ideal_density = 1800.0
-        moi = grain.get_moment_of_inertia(web_distance=0.0, ideal_density=ideal_density)
+        inertia_tensor = grain.get_moment_of_inertia(
+            web_distance=0.0, ideal_density=ideal_density
+        )
 
         # Basic validations
-        assert moi.shape == (3, 3)
-        np.testing.assert_array_almost_equal(moi, moi.T, decimal=10)
-        assert np.all(np.diag(moi) > 0)
+        assert inertia_tensor.shape == (3, 3)
+        np.testing.assert_array_almost_equal(
+            inertia_tensor, inertia_tensor.T, decimal=10
+        )
+        assert np.all(np.diag(inertia_tensor) > 0)
 
     def test_moi_decreases_during_burn_multisegment(
         self, segment_factory, geometry_name


### PR DESCRIPTION
## Summary

Renames the Fast Marching Method (FMM) grain module's identifiers to self-describing names grounded in numerical-methods, computational-geometry, and internal-ballistics vocabulary, spells out every abbreviation, and makes the FMM classes structurally consistent. Pure refactor — no behaviour change.

## Key changes

- **Grid / domain**: `map_dim → grid_resolution`, `get_maps → get_coordinate_grids`, `get_mask → get_outer_diameter_mask`, `get_normalized_length → get_axial_resolution`, `map_to_length`/`map_to_area → cells_to_meters`/`cells_to_square_meters`.
- **No abbreviations**: `_phys → _denormalized`, `_norm → _normalized`, `cog → center_of_gravity`, `moi → inertia_tensor`, `n_le → count_at_or_below_level`, `od`/`id → outer_diameter`/`inner_diameter`, plus ~50 self-describing local renames.
- `get_initial_face_map → generate_initial_face_map` (each geometry *constructs* it rather than retrieving a cached value).
- New `DEFAULT_GRID_RESOLUTION` constant; `grid_resolution` defaults to 100 across all FMM classes (STL included), grouped with the keyword arguments.
- Methods ordered consistently across base / 2D / 3D / STL: lifecycle → regression pipeline → mass properties.
- Kept the domain terms `regression_map`, web thickness, and the face-map family; restored `normalize`'s `float` return type.
- Docs: updated the module README and the grain-regression theory page; added `NAMING_PLAN.md` with the rationale and a literature-backed name table.
- Removed the openMotor attribution.

## Verification

- `pytest`: 789 passed, 2 skipped
- `pyright`: 0 errors on `base.py` / `_2d.py` / `_3d.py` (and the full module + geometries)
- `mkdocs build --strict`: passes (all doc cross-references resolve)
- Method reordering verified content-identical (pure move)

Closes #409