### PR TITLE
Cache the thresholded solid mask per web distance in fast marching method grain segments

### DIFF
--- a/docs/theory/grain_regression.md
+++ b/docs/theory/grain_regression.md
@@ -159,6 +159,9 @@ The face map at a web distance is obtained by thresholding the regression map at
 
 ![regressed face map](../assets/theory/grain_regression/face_map.svg)
 
+**Solid cells at a web distance: `_get_solid_mask(w)`.**
+The `-1`/`0`/`1` face map above is for display. The per-timestep reads that only need *which cells are still solid* take a plain boolean mask of the `1` cells instead, `(regression map > w) & ~casing`. The center of gravity and moment of inertia read from this mask in both 2D and 3D, and the volume reads from it in 3D (2D volume stays analytic). Several of these run at the same web distance on a single timestep, so the boolean mask, and the solid-cell indices extracted from it, are cached per web distance: the regression map is thresholded once per step and every consumer reuses the result. The web distance only grows over a burn, so a single-entry cache is enough. The mask is a plain boolean array rather than the masked integer face map, which is also why it is cheaper to build and store.
+
 **Contour the burn front: [`get_contours(w)`][machwave.models.grain.fmm._2d.FMMGrainSegment2D.get_contours].**
 A closed-loop curve is traced by `get_iso_contours` in `machwave.models.grain.fmm.contours`, for a given web distance.
 Then, `get_length` sums the curve to calculate the burning perimeter, discounting any stretch that lies on the casing wall.
@@ -192,7 +195,7 @@ Since the slice count is rounded to an integer, `_compute_regression_distance` p
 
 The regression map is generated differently for 2D and 3D. 2D traces a perimeter with marching squares ([`get_contours`][machwave.models.grain.fmm._2d.FMMGrainSegment2D.get_contours], using `skimage`'s `find_contours`). 3D meshes a surface with marching cubes ([`get_burn_area_interpolator`][machwave.models.grain.fmm._3d.FMMGrainSegment3D.get_burn_area_interpolator], `skimage`'s `marching_cubes`) and takes its area directly.
 
-For volume, 3D FMM counts the solid voxels in the entire map and multiplies by the volume of one voxel.
+For volume, 3D FMM counts the solid voxels in the cached solid mask and multiplies by the volume of one voxel. The center of gravity and moment of inertia read the same cached mask and its solid-cell indices, so the per-timestep mass properties all share a single threshold of the regression map instead of rebuilding it for each read.
 
 Since the port area in 3D varies along the grain, [`get_port_area(w, z)`][machwave.models.grain.fmm._3d.FMMGrainSegment3D.get_port_area] slices the cross-section at axial height `z` and subtracts the solid area from the outer diameter exterior.
 
@@ -236,8 +239,10 @@ flowchart TB
     BA --> MC["_compute_iso_surface_area() → marching_cubes<br/>per iso level"]
     MC --> SG["smooth_savitzky_golay → interp1d (cached)"]
     SG --> BR["get_burn_area(w)"]
+    R --> SM["_get_solid_mask(w)<br/>boolean threshold, cached per web"]
+    SM --> VO["get_volume(w) = solid voxels × cell volume"]
+    SM --> MP["center of gravity, moment of inertia<br/>via cached solid-cell indices"]
     R --> PA["get_port_area(w, z)<br/>casing − slice solid area"]
-    R --> VO["get_volume(w) = solid voxels × cell volume"]
 ```
 
 # References

--- a/docs/theory/grain_regression.md
+++ b/docs/theory/grain_regression.md
@@ -159,8 +159,7 @@ The face map at a web distance is obtained by thresholding the regression map at
 
 ![regressed face map](../assets/theory/grain_regression/face_map.svg)
 
-**Solid cells at a web distance: `_get_solid_mask(w)`.**
-The `-1`/`0`/`1` face map above is for display. The per-timestep reads that only need *which cells are still solid* take a plain boolean mask of the `1` cells instead, `(regression map > w) & ~casing`. The center of gravity and moment of inertia read from this mask in both 2D and 3D, and the volume reads from it in 3D (2D volume stays analytic). Several of these run at the same web distance on a single timestep, so the boolean mask, and the solid-cell indices extracted from it, are cached per web distance: the regression map is thresholded once per step and every consumer reuses the result. The web distance only grows over a burn, so a single-entry cache is enough. The mask is a plain boolean array rather than the masked integer face map, which is also why it is cheaper to build and store.
+The mass-property reads, volume in 3D plus the center of gravity and moment of inertia in both 2D and 3D, need only the solid (`1`) cells of this map. They take those as a plain boolean mask from `_get_solid_mask`, cheaper to build and store than the masked integer map, which together with the solid-cell indices it feeds is cached per web distance. Several of these reads share one web distance on a single timestep, so the regression map is thresholded once and every consumer reuses the result. The web distance only grows over a burn, so a single-entry cache is enough.
 
 **Contour the burn front: [`get_contours(w)`][machwave.models.grain.fmm._2d.FMMGrainSegment2D.get_contours].**
 A closed-loop curve is traced by `get_iso_contours` in `machwave.models.grain.fmm.contours`, for a given web distance.

--- a/machwave/models/grain/fmm/_2d.py
+++ b/machwave/models/grain/fmm/_2d.py
@@ -273,9 +273,7 @@ class FMMGrainSegment2D(fmm_base.FMMGrainSegment, grain.GrainSegment2D, ABC):
         Raises:
             GrainGeometryError: If no active material is found.
         """
-        face_map = self.get_face_map(web_distance)
-        mask = face_map == 1  # active material only
-        y_indices, x_indices = np.where(mask)
+        y_indices, x_indices = self._get_solid_indices(web_distance)
 
         if len(x_indices) == 0 or len(y_indices) == 0:
             raise grain.GrainGeometryError(
@@ -354,13 +352,17 @@ class FMMGrainSegment2D(fmm_base.FMMGrainSegment, grain.GrainSegment2D, ABC):
         y_indices, x_indices = self._find_solid_material_indices(web_distance)
         x_grid, y_grid = self._indices_to_grid_coordinates(y_indices, x_indices)
 
-        # Get the center of gravity to use as reference point
-        center_of_gravity = self.get_center_of_gravity(web_distance)
         current_length = self.get_length(web_distance)
 
         # Convert to meters
-        x_denormalized = self.cells_to_meters(x_grid)
-        y_denormalized = self.cells_to_meters(y_grid)
+        x_denormalized = np.asarray(self.cells_to_meters(x_grid), dtype=np.float64)
+        y_denormalized = np.asarray(self.cells_to_meters(y_grid), dtype=np.float64)
+
+        # Radial CoG from the same coordinates, avoiding an index re-extraction.
+        # Axial CoG is unused here: 2D elements have no axial spread.
+        center_of_gravity = mechanics.get_center_of_gravity(
+            x_denormalized, y_denormalized, np.zeros_like(x_denormalized)
+        )
 
         # Coordinates relative to the center of gravity
         x_relative = x_denormalized - center_of_gravity[1]

--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -262,10 +262,8 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         return (float(self.denormalize(self.get_normalized_spacing())) * 2) ** 3
 
     def get_volume(self, web_distance: float) -> float:
-        face_map = self.get_face_map(web_distance=web_distance)
-        solid_voxel_count = np.count_nonzero(face_map == 1)
-        volume_per_element = self.get_voxel_volume()
-        return solid_voxel_count * volume_per_element
+        solid_voxel_count = int(np.count_nonzero(self._get_solid_mask(web_distance)))
+        return solid_voxel_count * self.get_voxel_volume()
 
     def _validate_web_distance(self, web_distance: float) -> None:
         """
@@ -295,9 +293,7 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         Raises:
             GrainGeometryError: If no active material is found.
         """
-        face_map = self.get_face_map(web_distance)
-        mask = face_map == 1  # active material only
-        z_indices, y_indices, x_indices = np.where(mask)
+        z_indices, y_indices, x_indices = self._get_solid_indices(web_distance)
 
         if len(x_indices) == 0:
             raise grain.GrainGeometryError(
@@ -385,13 +381,16 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
             z_indices, y_indices, x_indices
         )
 
-        # Get the center of gravity
-        center_of_gravity = self.get_center_of_gravity(web_distance)
-
         # Convert to meters
-        x_denormalized = self.cells_to_meters(x_grid)
-        y_denormalized = self.cells_to_meters(y_grid)
-        z_denormalized = self.cells_to_meters(z_grid)
+        x_denormalized = np.asarray(self.cells_to_meters(x_grid), dtype=np.float64)
+        y_denormalized = np.asarray(self.cells_to_meters(y_grid), dtype=np.float64)
+        z_denormalized = np.asarray(self.cells_to_meters(z_grid), dtype=np.float64)
+
+        # CoG from the same coordinates (matches get_center_of_gravity, avoids
+        # re-extracting indices for this web distance)
+        center_of_gravity = mechanics.get_center_of_gravity(
+            x_denormalized, y_denormalized, z_denormalized
+        )
 
         # Coordinates relative to the center of gravity
         x_relative = x_denormalized - center_of_gravity[1]

--- a/machwave/models/grain/fmm/base.py
+++ b/machwave/models/grain/fmm/base.py
@@ -43,7 +43,7 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
         self.regression_map = None
         self.web_thickness = None
 
-        # Cache variables dependent on web distance:
+        # Cache variables that only work for a specific web distance:
         self._solid_mask_web = None
         self._solid_mask = None
         self._solid_indices_web = None

--- a/machwave/models/grain/fmm/base.py
+++ b/machwave/models/grain/fmm/base.py
@@ -43,6 +43,13 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
         self.regression_map = None
         self.web_thickness = None
 
+        # Per-web-distance caches (maxsize-1; web is monotonic so each step
+        # evicts the previous entry, avoiding cross-scenario leaks).
+        self._solid_mask_web = None
+        self._solid_mask = None
+        self._solid_indices_web = None
+        self._solid_indices = None
+
         super().__init__(
             length=length,
             outer_diameter=outer_diameter,
@@ -258,6 +265,32 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
 
         # Fill masked entries with -1, valid/true entries remain 1 or 0
         return occupancy_state.filled(-1)
+
+    def _get_solid_mask(self, web_distance: float) -> NDArray[np.bool_]:
+        """
+        Boolean mask of solid (unburned, in-domain) cells at a web distance.
+
+        Equivalent to `get_face_map(web_distance) == 1` but built as a plain
+        boolean array, skipping the int64/MaskedArray/`filled(-1)` path. The
+        per-step consumers (volume, indices) route through this instead of
+        `get_face_map`, whose -1/0/1 encoding is kept for plot consumers.
+        """
+        if self._solid_mask is None or self._solid_mask_web != web_distance:
+            regression_map = self.get_regression_map()
+            web_distance_normalized = self.normalize(web_distance)
+            excluded_mask = np.ma.getmaskarray(regression_map)
+            self._solid_mask = (
+                np.ma.getdata(regression_map) > web_distance_normalized
+            ) & ~excluded_mask
+            self._solid_mask_web = web_distance
+        return self._solid_mask
+
+    def _get_solid_indices(self, web_distance: float) -> tuple[NDArray[np.int_], ...]:
+        """Indices of solid cells (`np.where` over the cached mask), memoized."""
+        if self._solid_indices is None or self._solid_indices_web != web_distance:
+            self._solid_indices = np.where(self._get_solid_mask(web_distance))
+            self._solid_indices_web = web_distance
+        return self._solid_indices
 
     @abstractmethod
     def get_contours(

--- a/machwave/models/grain/fmm/base.py
+++ b/machwave/models/grain/fmm/base.py
@@ -267,12 +267,10 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
 
     def _get_solid_mask(self, web_distance: float) -> NDArray[np.bool_]:
         """
-        Boolean mask of solid (unburned, in-domain) cells at a web distance.
+        Boolean mask of solid cells at a web distance.
 
-        Equivalent to `get_face_map(web_distance) == 1` but built as a plain
-        boolean array, skipping the int64/MaskedArray/`filled(-1)` path. The
-        per-step consumers (volume, indices) route through this instead of
-        `get_face_map`, whose -1/0/1 encoding is kept for plot consumers.
+        Memoized per web distance, since it is used for both volume, port area, center
+        of gravity and moment of inertia calculations.
         """
         if self._solid_mask is None or self._solid_mask_web != web_distance:
             regression_map = self.get_regression_map()
@@ -285,7 +283,7 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
         return self._solid_mask
 
     def _get_solid_indices(self, web_distance: float) -> tuple[NDArray[np.int_], ...]:
-        """Indices of solid cells (`np.where` over the cached mask), memoized."""
+        """Indices of solid cells, memoized."""
         if self._solid_indices is None or self._solid_indices_web != web_distance:
             self._solid_indices = np.where(self._get_solid_mask(web_distance))
             self._solid_indices_web = web_distance

--- a/machwave/models/grain/fmm/base.py
+++ b/machwave/models/grain/fmm/base.py
@@ -36,15 +36,14 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
         """
         self.grid_resolution = grid_resolution
 
-        # "Cache" variables:
+        # Cache variables:
         self.coordinate_grids = None
         self.outer_diameter_mask = None
         self.masked_face = None
         self.regression_map = None
         self.web_thickness = None
 
-        # Per-web-distance caches (maxsize-1; web is monotonic so each step
-        # evicts the previous entry, avoiding cross-scenario leaks).
+        # Cache variables dependent on web distance:
         self._solid_mask_web = None
         self._solid_mask = None
         self._solid_indices_web = None

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl.py
@@ -101,6 +101,26 @@ def test_finned_slice_has_less_solid_material_than_unfinned_slice(finocyl_segmen
     assert finned_solid < unfinned_solid
 
 
+def test_face_map_values_stay_in_minus_one_zero_one(finocyl_segment):
+    """get_face_map keeps its -1/0/1 encoding (plot consumers depend on it)."""
+    web_thickness = finocyl_segment.get_web_thickness()
+
+    for web_distance in np.linspace(0.0, web_thickness * 0.8, 4):
+        face_map = finocyl_segment.get_face_map(web_distance=web_distance)
+        assert set(np.unique(face_map)).issubset({-1, 0, 1})
+
+
+def test_solid_mask_matches_face_map_solid_cells(finocyl_segment):
+    """The boolean solid mask equals `get_face_map == 1` at every web distance."""
+    web_thickness = finocyl_segment.get_web_thickness()
+
+    for web_distance in np.linspace(0.0, web_thickness * 0.8, 4):
+        face_map = finocyl_segment.get_face_map(web_distance=web_distance)
+        solid_mask = finocyl_segment._get_solid_mask(web_distance)
+        assert solid_mask.dtype == bool
+        np.testing.assert_array_equal(solid_mask, face_map == 1)
+
+
 def test_unfinned_slice_matches_plain_core(finocyl_segment):
     """Outside the finned band the port is the plain circular bore."""
     # Compare against a conical segment with a constant (equal-diameter) core.


### PR DESCRIPTION
Closes #357.

Per timestep, 3D fast marching method grain segments rebuilt the full face map about eleven times and ran a whole-grid index search about five times for the same web distance, via `get_face_map` and the solid-index extraction.

This routes the per-step consumers (volume, center of gravity, moment of inertia, index extraction) through a maxsize-one boolean solid-mask cache and a memoized solid-index cache on `FMMGrainSegment`. The boolean mask skips the integer / masked-array / `filled(-1)` path; `get_face_map` keeps its -1/0/1 encoding for the plot consumers. The redundant center-of-gravity re-extraction inside the 2D and 3D moment-of-inertia methods is also dropped.

Results are bit-identical (volume, center of gravity, moment of inertia, face map; verified maximum absolute difference of 0 across web distances). The finocyl example simulation drops from about 257 s to about 61 s (4.2x). Two regression tests pin the face-map encoding and the boolean-mask equivalence.

Affects 2D and 3D fast marching method grains; BATES is unaffected. Companion to #356 (assembly-layer deduplication).