### PR TITLE
Guard the moment of inertia query past burnout in the solid motor timestep

### DIFF
--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -138,12 +138,13 @@ class SolidMotorState(simulation_states.MotorState):
             propellant_cog = self.motor.grain.get_center_of_gravity(
                 web_distance=web_distance
             )
-        else:  # no propellant left, CoG is undefined
+            propellant_moi = self.motor.grain.get_moment_of_inertia(
+                ideal_density=ideal_propellant_density, web_distance=web_distance
+            )
+        else:  # no propellant left: CoG is undefined and inertia is zero
             propellant_cog = np.full(3, np.nan)
+            propellant_moi = np.zeros((3, 3))
         self.propellant_cog.append(propellant_cog)
-        propellant_moi = self.motor.grain.get_moment_of_inertia(
-            ideal_density=ideal_propellant_density, web_distance=web_distance
-        )
         self.propellant_moi.append(propellant_moi)
 
         grain_segment_mass_flow = (

--- a/tests/test_simulations/motor_builders.py
+++ b/tests/test_simulations/motor_builders.py
@@ -20,6 +20,7 @@ from tests.factories import (
     BiliquidPropellantFactory,
     BipropellantInjectorFactory,
     CombustionChamberFactory,
+    FinocylGrainSegmentFactory,
     FuelComponentFactory,
     NozzleFactory,
     OxidizerComponentFactory,
@@ -147,6 +148,55 @@ def build_nero_motor() -> tuple[
     )
     params = machwave_simulation.InternalBallisticsSimulationParams(
         d_t=0.01,
+        igniter_pressure=1e6,
+        external_pressure=1e5,
+        other_losses=0.12,
+    )
+    return motor, params
+
+
+def build_finocyl_motor() -> tuple[
+    motors_models.SolidMotor, machwave_simulation.InternalBallisticsSimulationParams
+]:
+    """Small single-segment finocyl (3D fast marching method) motor.
+
+    Short grain so the fast marching method grid and per-step cost stay small,
+    for exercising the 3D solid path (including tail-off past burnout).
+    """
+    grain = grain_models.Grain()
+    grain.add_segment(
+        FinocylGrainSegmentFactory.build(
+            length=0.05,
+            outer_diameter=0.05,
+            core_diameter=0.02,
+            number_of_fins=4,
+            fin_length=0.008,
+            fin_width=0.003,
+        )
+    )
+
+    thrust_chamber = SolidMotorThrustChamberFactory.build(
+        nozzle=NozzleFactory.build(
+            inlet_diameter=0.045,
+            throat_diameter=0.012,
+            divergent_angle=12,
+            convergent_angle=45,
+            expansion_ratio=8,
+        ),
+        combustion_chamber=CombustionChamberFactory.build(
+            casing_inner_diameter=0.052,
+            casing_outer_diameter=0.06,
+            thermal_liner_thickness=0.002,
+            internal_length=grain.total_length + 0.01,
+        ),
+    )
+    motor = SolidMotorFactory.build(
+        grain=grain,
+        propellant=solid_propellants.KNDX,
+        thrust_chamber=thrust_chamber,
+    )
+    params = machwave_simulation.InternalBallisticsSimulationParams(
+        d_t=0.005,
         igniter_pressure=1e6,
         external_pressure=1e5,
         other_losses=0.12,

--- a/tests/test_simulations/test_solid_motor_simulation.py
+++ b/tests/test_simulations/test_solid_motor_simulation.py
@@ -125,3 +125,30 @@ def test_effective_flame_temperature_uses_motor_combustion_efficiency() -> None:
         return state.chamber_pressure[-1]
 
     assert first_step_chamber_pressure(1.0) > first_step_chamber_pressure(0.5)
+
+
+def test_moment_of_inertia_is_guarded_past_burnout() -> None:
+    """Past burnout the loop records a zero inertia tensor instead of crashing.
+
+    A 3D grain raises past its web thickness, and the simulation keeps advancing
+    the web after burnout until the flow un-chokes. The loop must skip the mass
+    property queries once the propellant is gone, mirroring the center-of-gravity
+    guard, rather than querying the grain out of range.
+    """
+    motor, params = motor_builders.build_finocyl_motor()
+    state = solid_simulation.SolidMotorState(
+        motor=motor,
+        igniter_pressure=params.igniter_pressure,
+        external_pressure=params.external_pressure,
+        other_losses=params.other_losses,
+    )
+    # Fully consumed: volume and mass are zero, and a direct moment-of-inertia
+    # query at this web would raise GrainGeometryError.
+    state.web = [motor.grain.segments[0].get_web_thickness() * 1.5]
+
+    # Small step so the one-shot chamber-pressure update stays well-behaved; the
+    # mass-property guard runs regardless of the step size.
+    state.run_timestep(d_t=1e-5, external_pressure=params.external_pressure)
+
+    np.testing.assert_array_equal(state.propellant_moi[-1], np.zeros((3, 3)))
+    assert np.all(np.isnan(state.propellant_cog[-1]))


### PR DESCRIPTION
Closes #337.

`get_center_of_gravity` and `get_moment_of_inertia` on a 3D fast marching method grain raise past the web thickness, and the simulation keeps advancing the web after burnout until the flow un-chokes, so the run aborted near burnout. The center-of-gravity query in `run_timestep` was already guarded by `propellant_mass > 0`, but the moment-of-inertia query right below it was not.

This moves the moment-of-inertia query inside the same guard and records a zero tensor once the propellant is gone. The web is intentionally left to grow past the web thickness so `get_burn_area` returns zero and the burn terminates: at exactly the web thickness the burn area is still the full value while the volume is already zero, so freezing the stored web there would hold a non-zero burn area and the burn would never terminate.

Adds a small finocyl motor builder and a regression test that drives the state past burnout. The finocyl example simulation now runs to completion.