### PR TITLE
Drop port area from the solid-mask docstring

### DIFF
--- a/machwave/models/grain/fmm/base.py
+++ b/machwave/models/grain/fmm/base.py
@@ -269,8 +269,8 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
         """
         Boolean mask of solid cells at a web distance.
 
-        Memoized per web distance, since it is used for both volume, port area, center
-        of gravity and moment of inertia calculations.
+        Memoized per web distance, since it is used for volume, center of gravity
+        and moment of inertia calculations.
         """
         if self._solid_mask is None or self._solid_mask_web != web_distance:
             regression_map = self.get_regression_map()


### PR DESCRIPTION
Follow-up to #357 (merged in #412).

The `_get_solid_mask` docstring listed port area among its consumers, but `get_port_area` computes its own threshold and does not route through `_get_solid_mask`. It also could not do so trivially: `get_port_area` masks with the outer-diameter mask only, while `_get_solid_mask` uses the regression map's full excluded mask (outer diameter plus inhibited surfaces), so they would diverge for a grain with an inhibited inner surface.

Drop port area so the docstring lists only the actual consumers: volume, center of gravity, and moment of inertia.