### PR TITLE
Quantize biliquid mixture ratio in the thermochemistry cache key

### DIFF
--- a/machwave/models/propellants/categories/base.py
+++ b/machwave/models/propellants/categories/base.py
@@ -42,6 +42,9 @@ class Propellant(abc.ABC):
     # Chamber pressure is quantized to this width [Pa] before evaluation.
     CHAMBER_PRESSURE_QUANTIZATION_PA: float = 200.0
 
+    # Mixture ratio (O/F) is quantized to this width before evaluation.
+    MIXTURE_RATIO_QUANTIZATION: float = 1e-3
+
     def __init__(
         self,
         name: str,
@@ -160,8 +163,9 @@ class Propellant(abc.ABC):
         """
         Evaluate thermochemical properties at given conditions.
 
-        Chamber pressure is quantized to `CHAMBER_PRESSURE_QUANTIZATION_PA` and the
-        result is cached per `(chamber_pressure, expansion_ratio, mixture_ratio)`.
+        Chamber pressure is quantized to `CHAMBER_PRESSURE_QUANTIZATION_PA` and
+        mixture ratio to `MIXTURE_RATIO_QUANTIZATION`; the result is cached per
+        `(chamber_pressure, expansion_ratio, mixture_ratio)`.
 
         Args:
             chamber_pressure: Chamber pressure [Pa].
@@ -178,7 +182,17 @@ class Propellant(abc.ABC):
             round(chamber_pressure / self.CHAMBER_PRESSURE_QUANTIZATION_PA)
             * self.CHAMBER_PRESSURE_QUANTIZATION_PA
         )
-        cache_key = (quantized_chamber_pressure, expansion_ratio, mixture_ratio)
+        quantized_mixture_ratio = (
+            round(mixture_ratio / self.MIXTURE_RATIO_QUANTIZATION)
+            * self.MIXTURE_RATIO_QUANTIZATION
+            if mixture_ratio is not None
+            else None
+        )
+        cache_key = (
+            quantized_chamber_pressure,
+            expansion_ratio,
+            quantized_mixture_ratio,
+        )
         cached_properties = self._evaluation_cache.get(cache_key)
         if cached_properties is not None:
             return cached_properties
@@ -186,7 +200,7 @@ class Propellant(abc.ABC):
         properties = self._compute_thermochemical_properties(
             chamber_pressure=quantized_chamber_pressure,
             expansion_ratio=expansion_ratio,
-            mixture_ratio=mixture_ratio,
+            mixture_ratio=quantized_mixture_ratio,
         )
         self._evaluation_cache[cache_key] = properties
         return properties

--- a/tests/test_models/test_propulsion/test_propellants/test_formulations/test_biliquid.py
+++ b/tests/test_models/test_propulsion/test_propellants/test_formulations/test_biliquid.py
@@ -61,6 +61,26 @@ class TestBiliquidEvaluateMixtureRatio:
         lox_rp1_propellant.evaluate(chamber_pressure=3e6, mixture_ratio=1.5)
         assert lox_rp1_propellant.oxidizer_to_fuel_ratio == 2.5
 
+    def test_nearby_mixture_ratios_share_cache_entry(self, lox_rp1_propellant):
+        quantization = lox_rp1_propellant.MIXTURE_RATIO_QUANTIZATION
+        first = lox_rp1_propellant.evaluate(chamber_pressure=3e6, mixture_ratio=2.5)
+        second = lox_rp1_propellant.evaluate(
+            chamber_pressure=3e6, mixture_ratio=2.5 + quantization / 4
+        )
+        assert second is first
+        assert len(lox_rp1_propellant._evaluation_cache) == 1
+
+    def test_distinct_mixture_ratios_use_separate_cache_entries(
+        self, lox_rp1_propellant
+    ):
+        quantization = lox_rp1_propellant.MIXTURE_RATIO_QUANTIZATION
+        first = lox_rp1_propellant.evaluate(chamber_pressure=3e6, mixture_ratio=2.5)
+        second = lox_rp1_propellant.evaluate(
+            chamber_pressure=3e6, mixture_ratio=2.5 + 2 * quantization
+        )
+        assert second is not first
+        assert len(lox_rp1_propellant._evaluation_cache) == 2
+
 
 def _biliquid_with_fuel_formula(
     fuel_formula: dict[str, int],


### PR DESCRIPTION
Closes #424.

`Propellant.evaluate` quantized chamber pressure to 200 Pa but put `mixture_ratio` (oxidizer-to-fuel ratio) into the cache key at full float precision. A biliquid engine's mixture ratio drifts every timestep, so the key never repeated and the thermochemistry queries re-ran on every step.

Quantize `mixture_ratio` to a fixed width (`MIXTURE_RATIO_QUANTIZATION = 1e-3`) before building the cache key, mirroring how chamber pressure is handled. The quantized value is also passed into the computation so the cached entry matches its key. `None` (solid propellants) passes through unchanged.

Tests: nearby mixture ratios now share one cache entry; ratios separated by more than one quantum get separate entries. Existing biliquid and solid suites pass.