### PR TITLE
Use the real saturated-vapour density for the tank phase threshold

### DIFF
--- a/docs/api/models/feed_systems/tank.md
+++ b/docs/api/models/feed_systems/tank.md
@@ -1,6 +1,6 @@
 # models.feed_systems.tank
 
-Stateless two-phase propellant tank model backed by CoolProp. The `Tank` carries no propellant-mass state: pressure and density are pure functions of a fluid mass supplied by the caller, so the integrator owns the mass and the model stays re-runnable. `get_pressure(fluid_mass)` returns the tank pressure from two-phase equilibrium (saturation pressure while liquid is present, ideal-gas vapour otherwise), and `get_density(fluid_mass)` the density at current conditions.
+Stateless two-phase propellant tank model backed by CoolProp. The `Tank` carries no propellant-mass state: pressure and density are pure functions of a fluid mass supplied by the caller, so the integrator owns the mass and the model stays re-runnable. `get_pressure(fluid_mass)` returns the tank pressure from two-phase equilibrium (saturation pressure while liquid is present, single-phase vapour from the real-gas equation of state otherwise), and `get_density(fluid_mass)` the density at current conditions.
 
 Tanks are identified by CoolProp fluid name (e.g., `"N2O"`, `"Oxygen"`, `"Hydrogen"`).
 

--- a/machwave/models/feed_systems/tank.py
+++ b/machwave/models/feed_systems/tank.py
@@ -1,4 +1,3 @@
-import machwave.core.ideal_gas as ideal_gas
 import machwave.services.coolprop as coolprop_service
 
 
@@ -54,9 +53,11 @@ class Tank:
 
         # The tank is isothermal with a fixed fluid, so these properties are constant
         # and cached
-        self.molar_mass = self._coolprop.get_molar_mass()  # kg/mol
         self.saturation_pressure = self._coolprop.get_saturation_pressure(temperature)
         self.saturated_liquid_density = self._coolprop.get_saturated_liquid_density(
+            temperature
+        )
+        self.saturated_vapor_density = self._coolprop.get_saturated_vapor_density(
             temperature
         )
         # Single phase density at the tank temperature, memoized per pressure.
@@ -108,11 +109,14 @@ class Tank:
         """
         Return the tank pressure [Pa] for a given fluid mass.
 
-        1) Compute the saturation pressure at the given temperature.
-        2) If the fluid mass is larger than the mass if all vapor at the saturation
-            pressure, the tank is partially liquid and the pressure is the saturation
+        1) An empty tank has zero pressure.
+        2) If the fluid mass exceeds the mass of saturated vapor that fills the
+            tank, the tank is partially liquid and the pressure is the saturation
             pressure.
-        3) Otherwise, the tank is all vapor and behaves like an ideal gas.
+        3) Otherwise, the tank is all sub-saturated vapor and the pressure
+            follows the real-gas equation of state at the bulk density. This
+            matches the saturation pressure at the phase boundary, so pressure
+            stays continuous as the tank crosses out of the two-phase regime.
 
         Args:
             fluid_mass: Current total mass of fluid in the tank [kg].
@@ -120,15 +124,16 @@ class Tank:
         Returns:
             Tank pressure [Pa].
         """
-        max_vapor_mass = ideal_gas.get_mass(
-            self.saturation_pressure, self.volume, self.temperature, self.molar_mass
-        )
+        if fluid_mass <= 0:
+            return 0.0
+
+        max_vapor_mass = self.saturated_vapor_density * self.volume
 
         if fluid_mass > max_vapor_mass:
             return self.saturation_pressure
         else:
-            return ideal_gas.get_pressure(
-                fluid_mass, self.volume, self.temperature, self.molar_mass
+            return self._coolprop.get_pressure_at_temperature_density(
+                self.temperature, fluid_mass / self.volume
             )
 
     def get_density(self, fluid_mass: float, pressure: float | None = None) -> float:
@@ -159,9 +164,7 @@ class Tank:
         if single_phase_density is not None:
             return single_phase_density
 
-        max_vapor_mass = ideal_gas.get_mass(
-            tank_pressure, self.volume, self.temperature, self.molar_mass
-        )
+        max_vapor_mass = self.saturated_vapor_density * self.volume
         if fluid_mass > max_vapor_mass:
             return self.saturated_liquid_density
         return fluid_mass / self.volume

--- a/machwave/models/feed_systems/tank.py
+++ b/machwave/models/feed_systems/tank.py
@@ -13,7 +13,8 @@ class Tank:
     Assumptions:
       - Constant temperature (isothermal).
       - Two-phase equilibrium if there's enough mass to form liquid + vapor.
-      - If insufficient mass for liquid, treat it as an ideal gas.
+      - If insufficient mass for liquid, treat it as single-phase vapor via
+        the real-gas equation of state.
       - Ignores temperature changes upon phase change (no thermal balance).
     """
 

--- a/machwave/models/feed_systems/tank.py
+++ b/machwave/models/feed_systems/tank.py
@@ -62,6 +62,9 @@ class Tank:
         )
         # Single phase density at the tank temperature, memoized per pressure.
         self._density_by_pressure: dict[float, float | None] = {}
+        # All-vapor pressure at the tank temperature, memoized per fluid mass:
+        # the feed system queries the same mass several times per timestep.
+        self._pressure_by_mass: dict[float, float] = {}
 
         self._check_not_overfilled()
 
@@ -127,25 +130,27 @@ class Tank:
         if fluid_mass <= 0:
             return 0.0
 
-        max_vapor_mass = self.saturated_vapor_density * self.volume
-
-        if fluid_mass > max_vapor_mass:
+        if fluid_mass > self.saturated_vapor_density * self.volume:
             return self.saturation_pressure
-        else:
-            return self._coolprop.get_pressure_at_temperature_density(
-                self.temperature, fluid_mass / self.volume
+
+        if fluid_mass not in self._pressure_by_mass:
+            self._pressure_by_mass[fluid_mass] = (
+                self._coolprop.get_pressure_at_temperature_density(
+                    self.temperature, fluid_mass / self.volume
+                )
             )
+        return self._pressure_by_mass[fluid_mass]
 
     def get_density(self, fluid_mass: float, pressure: float | None = None) -> float:
         """
         Return fluid density [kg/m^3] for a given fluid mass.
 
         1) An empty tank has zero density.
-        2) Away from saturation the single-phase density follows directly from
-            temperature and pressure.
-        3) At saturation that lookup is ambiguous: a partially liquid tank
+        2) With a pressure override the single-phase density follows directly
+            from temperature and pressure.
+        3) Otherwise the fill state fixes the density: a partially liquid tank
             returns the saturated liquid density (the feed system pulls liquid
-            from the bottom), otherwise it falls back to the bulk density.
+            from the bottom), and an all-vapor tank returns the bulk density.
 
         Args:
             fluid_mass: Current total mass of fluid in the tank [kg].
@@ -158,14 +163,12 @@ class Tank:
         if fluid_mass <= 0:
             return 0.0
 
-        tank_pressure = self.get_pressure(fluid_mass) if pressure is None else pressure
+        if pressure is not None:
+            single_phase_density = self._single_phase_density(pressure)
+            if single_phase_density is not None:
+                return single_phase_density
 
-        single_phase_density = self._single_phase_density(tank_pressure)
-        if single_phase_density is not None:
-            return single_phase_density
-
-        max_vapor_mass = self.saturated_vapor_density * self.volume
-        if fluid_mass > max_vapor_mass:
+        if fluid_mass > self.saturated_vapor_density * self.volume:
             return self.saturated_liquid_density
         return fluid_mass / self.volume
 

--- a/machwave/models/feed_systems/tank.py
+++ b/machwave/models/feed_systems/tank.py
@@ -63,8 +63,7 @@ class Tank:
         )
         # Single phase density at the tank temperature, memoized per pressure.
         self._density_by_pressure: dict[float, float | None] = {}
-        # All-vapor pressure at the tank temperature, memoized per fluid mass:
-        # the feed system queries the same mass several times per timestep.
+        # Vapor pressure at the tank temperature, memoized per fluid mass.
         self._pressure_by_mass: dict[float, float] = {}
 
         self._check_not_overfilled()

--- a/machwave/services/coolprop.py
+++ b/machwave/services/coolprop.py
@@ -48,6 +48,18 @@ class CoolPropService:
         """
         return CP.PropsSI("D", "T", temperature, "Q", 0, self.fluid_name)
 
+    def get_saturated_vapor_density(self, temperature: float) -> float:
+        """
+        Get the saturated-vapor density at a given temperature.
+
+        Args:
+            temperature: Temperature [K].
+
+        Returns:
+            Saturated-vapor density [kg/m^3].
+        """
+        return CP.PropsSI("D", "T", temperature, "Q", 1, self.fluid_name)
+
     def get_saturated_liquid_enthalpy(self, temperature: float) -> float:
         """
         Get the saturated-liquid specific enthalpy at a given temperature.
@@ -86,6 +98,21 @@ class CoolPropService:
             Density [kg/m^3].
         """
         return CP.PropsSI("D", "T", temperature, "P", pressure, self.fluid_name)
+
+    def get_pressure_at_temperature_density(
+        self, temperature: float, density: float
+    ) -> float:
+        """
+        Get the single-phase pressure at a given temperature and density.
+
+        Args:
+            temperature: Temperature [K].
+            density: Density [kg/m^3].
+
+        Returns:
+            Pressure [Pa].
+        """
+        return CP.PropsSI("P", "T", temperature, "D", density, self.fluid_name)
 
     def get_enthalpy_at_temperature_pressure(
         self, temperature: float, pressure: float

--- a/tests/test_models/test_propulsion/test_feed_systems/test_tank.py
+++ b/tests/test_models/test_propulsion/test_feed_systems/test_tank.py
@@ -30,10 +30,8 @@ def test_saturated_condition(fluid_name, temperature):
     #    This might fail if T is out of range for the fluid.
     p_sat = CP.PropsSI("P", "T", temperature, "Q", 0, fluid_name)
 
-    # 2) Calculate how much mass is vapor only at p_sat.
-    molar_mass = CP.PropsSI("M", fluid_name)  # kg/mol
-    R_universal = scipy.constants.R
-    m_vap = (p_sat * volume * molar_mass) / (R_universal * temperature)
+    # 2) Mass of saturated vapor that just fills the tank.
+    m_vap = CP.PropsSI("D", "T", temperature, "Q", 1, fluid_name) * volume
 
     # 3) Put more mass than m_vap => ensures there's liquid
     fluid_mass = 2.0 * m_vap  # definitely more than needed for vapor only
@@ -53,16 +51,13 @@ def test_saturated_condition(fluid_name, temperature):
 @pytest.mark.parametrize("fluid_name, temperature", TEST_FLUIDS)
 def test_all_vapor_condition(fluid_name, temperature):
     """
-    If the tank doesn't have enough mass to sustain liquid, it should be all vapor
-    and the pressure should follow the ideal gas law.
+    If the tank doesn't have enough mass to sustain liquid, it should be all
+    vapor and the pressure should follow the real-gas equation of state.
     """
     volume = 0.01  # m^3
-    p_sat = CP.PropsSI("P", "T", temperature, "Q", 0, fluid_name)
-    molar_mass = CP.PropsSI("M", fluid_name)
-    R_universal = scipy.constants.R
 
-    # m_vap_sat = mass of vapor at p_sat (all vapor)
-    m_vap_sat = (p_sat * volume * molar_mass) / (R_universal * temperature)
+    # m_vap_sat = mass of saturated vapor that just fills the tank
+    m_vap_sat = CP.PropsSI("D", "T", temperature, "Q", 1, fluid_name) * volume
 
     # Put slightly less than that => ensures no liquid
     mass = 0.5 * m_vap_sat
@@ -73,13 +68,45 @@ def test_all_vapor_condition(fluid_name, temperature):
         initial_fluid_mass=mass,
     )
 
-    # Ideal gas law pressure => P_ideal = (n * R * T)/V
-    n_moles = mass / molar_mass
-    p_ideal = (n_moles * R_universal * temperature) / volume
-
-    assert tank.get_pressure(mass) == pytest.approx(p_ideal, rel=1e-3), (
-        f"Expected ideal-gas pressure for {fluid_name} at T={temperature} K with insufficient mass."
+    p_real = CP.PropsSI("P", "T", temperature, "D", mass / volume, fluid_name)
+    assert tank.get_pressure(mass) == pytest.approx(p_real, rel=1e-3), (
+        f"Expected real-gas pressure for {fluid_name} at T={temperature} K with insufficient mass."
     )
+
+
+def test_near_critical_vapor_not_misclassified_as_two_phase():
+    """
+    Near the critical point the saturated-vapor density far exceeds the
+    ideal-gas value, so a fill between the two is still single-phase vapor.
+    The phase split must use the real saturated-vapor density; the ideal-gas
+    threshold would wrongly report the saturation pressure here.
+    """
+    fluid_name, temperature, volume = "N2O", 298.0, 0.01  # T_c = 309.5 K
+
+    p_sat = CP.PropsSI("P", "T", temperature, "Q", 0, fluid_name)
+    molar_mass = CP.PropsSI("M", fluid_name)
+    rho_vapor = CP.PropsSI("D", "T", temperature, "Q", 1, fluid_name)
+    rho_vapor_ideal = p_sat * molar_mass / (scipy.constants.R * temperature)
+    assert rho_vapor > 1.5 * rho_vapor_ideal  # genuinely near-critical
+
+    # Fill between the ideal-gas and real saturated-vapor masses: above the old
+    # (ideal-gas) threshold, below the real one.
+    mass = 0.5 * (rho_vapor_ideal + rho_vapor) * volume
+    assert rho_vapor_ideal * volume < mass < rho_vapor * volume
+
+    tank = tank_models.Tank(
+        fluid_name=fluid_name,
+        volume=volume,
+        temperature=temperature,
+        initial_fluid_mass=mass,
+    )
+
+    # Single-phase vapor: the pressure is the real-gas value and stays strictly
+    # below saturation. The old ideal-gas threshold would have reported p_sat.
+    p_real = CP.PropsSI("P", "T", temperature, "D", mass / volume, fluid_name)
+    pressure = tank.get_pressure(mass)
+    assert pressure == pytest.approx(p_real, rel=1e-3)
+    assert pressure < p_sat
 
 
 @pytest.mark.parametrize("fluid_name, temperature", TEST_FLUIDS)
@@ -109,10 +136,7 @@ def test_two_phase_density_returns_saturated_liquid(fluid_name, temperature):
     density under-predicts ṁ as the tank empties.
     """
     volume = 0.01
-    p_sat = CP.PropsSI("P", "T", temperature, "Q", 0, fluid_name)
-    molar_mass = CP.PropsSI("M", fluid_name)
-    R_universal = scipy.constants.R
-    m_vap_sat = (p_sat * volume * molar_mass) / (R_universal * temperature)
+    m_vap_sat = CP.PropsSI("D", "T", temperature, "Q", 1, fluid_name) * volume
 
     fluid_mass = 2.0 * m_vap_sat
     tank = tank_models.Tank(
@@ -134,21 +158,20 @@ def test_two_phase_density_constant_while_two_phase(fluid_name, temperature):
     bulk mixture.
     """
     volume = 0.01
-    p_sat = CP.PropsSI("P", "T", temperature, "Q", 0, fluid_name)
-    molar_mass = CP.PropsSI("M", fluid_name)
-    R_universal = scipy.constants.R
-    m_vap_sat = (p_sat * volume * molar_mass) / (R_universal * temperature)
+    m_vap_sat = CP.PropsSI("D", "T", temperature, "Q", 1, fluid_name) * volume
 
     tank = tank_models.Tank(
         fluid_name=fluid_name,
         volume=volume,
         temperature=temperature,
-        initial_fluid_mass=5.0 * m_vap_sat,
+        initial_fluid_mass=2.5 * m_vap_sat,
     )
 
     # Both masses leave the tank two-phase (> m_vap_sat), so density is invariant.
-    higher_mass = 5.0 * m_vap_sat
-    lower_mass = 4.0 * m_vap_sat
+    # Multipliers stay below the liquid/vapor density ratio to avoid overfill for
+    # near-critical fluids like N2O.
+    higher_mass = 2.5 * m_vap_sat
+    lower_mass = 1.5 * m_vap_sat
     assert lower_mass > m_vap_sat
     assert tank.get_density(lower_mass) == pytest.approx(
         tank.get_density(higher_mass), rel=1e-6


### PR DESCRIPTION
Closes #134.

The tank chose between single-phase and two-phase with `max_vapor_mass = ideal_gas.get_mass(p_sat, ...)`, the ideal-gas mass at the saturation pressure. Near the critical point the real saturated-vapour density far exceeds the ideal-gas value (about 2x for nitrous oxide at 300 K, critical temperature 309.5 K), so the threshold misclassified dense sub-saturated vapour as two-phase. The threshold now uses the real saturated-vapour density from CoolProp.

Fixing the threshold on its own introduces a pressure discontinuity. The old threshold was the ideal-gas mass at the saturation pressure, so the all-vapour ideal-gas pressure equalled the saturation pressure exactly at the boundary. With the real threshold the ideal-gas law overshoots to roughly twice the saturation pressure at the transition, producing a nonphysical chamber-pressure spike late in a nitrous oxide burn (the 1 kN biliquid case peaked at 5.5 MPa at the transition instead of 3.4 MPa at ignition). The all-vapour pressure now comes from the real-gas equation of state at the bulk density; it returns the saturation pressure at the saturated-vapour density, so the pressure stays continuous across the phase boundary.

`Tank.molar_mass` and the `ideal_gas` import are dropped, since the real-gas lookup replaces the only ideal-gas use.

### Performance

The real-gas pressure lookup runs per timestep, and the feed system queries the same tank mass several times per step, so the all-vapour pressure is memoised per fluid mass; `get_density` also returns the bulk density directly in the single-phase regime instead of round-tripping through CoolProp. This cuts the tank's CoolProp calls about sixfold (CoolProp is then ~0.1 s of the loop).

The biliquid benchmark still shows a regression because the corrected (lower, continuous) all-vapour pressure makes the engine drain slower and burn longer, traversing more distinct quantized thermochemistry states (about 5,700 vs 3,400 CEA evaluations). That cost is thermochemistry, not fluid properties, and it is a one-time baseline step-up: the benchmark compares each pull request against its base commit, so once this lands the slower burn becomes the baseline and future pull requests no longer see it. The `master` branch has no required checks and the benchmark job only runs on pull requests, so this does not block merge and `master` CI stays green; the 25% threshold is left intact.

Tests: existing two-phase fills were resized off the real saturated-vapour density (the old 4-5x multipliers overfilled nitrous oxide once the threshold rose), the all-vapour test now expects the real-gas pressure, and a regression test fills nitrous oxide between the ideal-gas and real thresholds and asserts a single-phase pressure below saturation. Full suite passes (795 tests).