### PR TITLE
Model nozzle flow separation to bound tail-off thrust

### DIFF
--- a/docs/api/core/compressible_flow.md
+++ b/docs/api/core/compressible_flow.md
@@ -3,7 +3,7 @@
 Compressible flow relations for convergent-divergent nozzle analysis.
 
 - **Isentropic flow** — Critical pressure ratio, exit Mach from expansion ratio, exit pressure, choked-flow detection.
-- **Nozzle performance** — Ideal and corrected thrust coefficient (Cf), optimal expansion ratio for a given altitude, thrust from Cf.
+- **Nozzle performance** — Ideal and corrected thrust coefficient (Cf), optimal expansion ratio for a given altitude, effective exit conditions under overexpanded flow separation, thrust from Cf.
 - **Loss models** — Fractional correction factors for divergent angle, finite-rate kinetics, boundary layer, and two-phase flow losses. These combine into an overall nozzle efficiency applied to the ideal Cf.
 
 All loss functions return a loss as a fraction in [0, 1] and follow the empirical correlations of Coats et al. (AFRPL-TR-75-36, 1975).

--- a/docs/theory/thrust.md
+++ b/docs/theory/thrust.md
@@ -40,7 +40,30 @@ where:
 
 Implemented in [`get_ideal_thrust_coefficient`][machwave.core.compressible_flow.nozzle.get_ideal_thrust_coefficient].
 
-## 1.3 Nozzle Efficiency
+## 1.3 Flow Separation
+
+The ideal thrust coefficient above assumes the nozzle flows full, with the exhaust attached to the wall all the way to the geometric exit.
+As the chamber pressure decays during tail-off the nozzle becomes increasingly overexpanded ($P_e \ll P_\text{ext}$), and below a threshold the boundary layer can no longer sustain the adverse pressure gradient.
+The flow then separates from the wall upstream of the geometric exit, shrinking the effective exit area and pinning the realized exit pressure near the separation pressure.
+
+Machwave applies a simple **Summerfield criterion**: separation occurs once the isentropic exit pressure drops below a fixed fraction of the ambient pressure,
+
+$$
+P_e < P_\text{sep} = f_\text{sep}\, P_\text{ext}, \qquad f_\text{sep} \approx 0.4
+$$
+
+Past that point the **effective expansion ratio** $\varepsilon_\text{eff}$ is the area ratio at which the isentropic wall pressure equals $P_\text{sep}$, and both $\varepsilon_\text{eff}$ and $P_\text{sep}$ feed the ideal thrust coefficient in place of the geometric values.
+This bounds the pressure-thrust term so tail-off thrust decays smoothly toward zero instead of diverging negative.
+
+where:
+
+- $P_\text{sep}$ is the separation pressure [Pa]
+- $f_\text{sep}$ is the separation-to-ambient pressure ratio (dimensionless)
+- $\varepsilon_\text{eff}$ is the effective expansion ratio at separation (dimensionless)
+
+Implemented in [`get_separated_exit_conditions`][machwave.core.compressible_flow.nozzle.get_separated_exit_conditions].
+
+## 1.4 Nozzle Efficiency
 
 Real nozzles deviate from the ideal assumptions baked into the ideal thrust coefficient.
 Machwave lumps these deviations into a single **nozzle efficiency** $\eta_\text{nozzle}$ applied multiplicatively to the ideal coefficient:
@@ -61,7 +84,7 @@ Implemented in
 with the efficiency from
 [`get_overall_nozzle_efficiency`][machwave.core.compressible_flow.losses.get_overall_nozzle_efficiency].
 
-## 1.4 Total Impulse and Specific Impulse
+## 1.5 Total Impulse and Specific Impulse
 
 After the thrust is calculated, the total impulse is obtained by integrating it over the thrust time:
 
@@ -97,3 +120,4 @@ Implemented in
 # References
 
 1. Sutton, G. P., & Biblarz, O. (2001). *Rocket Propulsion Elements* (7th ed.). Wiley. Ch. 2-3.
+2. Summerfield, M., Foster, C. R., & Swan, W. C. (1954). Flow separation in overexpanded supersonic exhaust nozzles. *Jet Propulsion*, 24(5), 319-321.

--- a/machwave/core/compressible_flow/__init__.py
+++ b/machwave/core/compressible_flow/__init__.py
@@ -4,6 +4,7 @@ from .nozzle import (
     apply_thrust_coefficient_correction,
     get_ideal_thrust_coefficient,
     get_optimal_expansion_ratio,
+    get_separated_exit_conditions,
     get_thrust_from_thrust_coefficient,
 )
 from .isentropic import (
@@ -24,6 +25,7 @@ from .losses import (
 __all__ = [
     # nozzle
     "get_optimal_expansion_ratio",
+    "get_separated_exit_conditions",
     "get_ideal_thrust_coefficient",
     "apply_thrust_coefficient_correction",
     "get_thrust_from_thrust_coefficient",

--- a/machwave/core/compressible_flow/nozzle.py
+++ b/machwave/core/compressible_flow/nozzle.py
@@ -1,4 +1,9 @@
+from typing import cast
+
 import numpy as np
+import scipy.optimize
+
+import machwave.core.compressible_flow.isentropic as isentropic
 
 
 def get_optimal_expansion_ratio(
@@ -23,6 +28,61 @@ def get_optimal_expansion_ratio(
             * (1 - (atmospheric_pressure / chamber_pressure) ** ((k - 1) / k))
         )
     ) ** -1
+
+
+def get_separated_exit_conditions(
+    k_exhaust: float,
+    expansion_ratio: float,
+    chamber_pressure: float,
+    external_pressure: float,
+    separation_pressure_ratio: float,
+) -> tuple[float, float]:
+    """
+    Get the effective exit conditions accounting for flow separation.
+
+    The model implemented is based on the work of Summerfield et al. (1954) and assumes
+    that flow separation occurs when the exit pressure is below a certain fraction of
+    the ambient pressure.
+
+    Args:
+        k_exhaust: Isentropic exponent at exit.
+        expansion_ratio: Geometric expansion ratio.
+        chamber_pressure: Chamber pressure [Pa].
+        external_pressure: Ambient pressure [Pa].
+        separation_pressure_ratio: Separation-to-ambient pressure ratio.
+
+    Returns:
+        Effective expansion ratio and effective exit pressure [Pa].
+
+    References:
+        Summerfield, M., Foster, C. R., & Swan, W. C. (1954). Flow separation in
+        overexpanded supersonic exhaust nozzles.
+    """
+    exit_pressure = isentropic.get_exit_pressure(
+        k_exhaust, expansion_ratio, chamber_pressure
+    )
+    separation_pressure = separation_pressure_ratio * external_pressure
+    if exit_pressure >= separation_pressure:
+        return expansion_ratio, exit_pressure
+
+    sonic_pressure = chamber_pressure * isentropic.get_critical_pressure_ratio(
+        k_exhaust
+    )
+    if separation_pressure >= sonic_pressure:
+        return 1.0, sonic_pressure
+
+    effective_expansion_ratio = cast(
+        float,
+        scipy.optimize.brentq(
+            lambda ratio: (
+                isentropic.get_exit_pressure(k_exhaust, ratio, chamber_pressure)
+                - separation_pressure
+            ),
+            a=1.001,
+            b=expansion_ratio,
+        ),
+    )
+    return effective_expansion_ratio, separation_pressure
 
 
 def get_ideal_thrust_coefficient(

--- a/machwave/models/thrust_chamber/nozzle.py
+++ b/machwave/models/thrust_chamber/nozzle.py
@@ -2,6 +2,8 @@ import numpy as np
 
 import machwave.core.geometric as geometric
 
+DEFAULT_SEPARATION_PRESSURE_RATIO = 0.4  # typically between 0.3 and 0.4
+
 
 class Nozzle:
     """Converging-diverging nozzle geometry and loss coefficients."""
@@ -16,6 +18,7 @@ class Nozzle:
         c_1: float = 0.00506,
         c_2: float = 0.0,
         discharge_coefficient: float = 1.0,
+        separation_pressure_ratio: float = DEFAULT_SEPARATION_PRESSURE_RATIO,
     ) -> None:
         """
         Initialize a nozzle.
@@ -29,6 +32,8 @@ class Nozzle:
             c_1: Boundary-layer loss coefficient (see notes below).
             c_2: Boundary-layer loss coefficient (see notes below).
             discharge_coefficient: Throat discharge coefficient.
+            separation_pressure_ratio: Pressure ratio at which the overexpanded flow
+                separates from the nozzle wall (Summerfield criterion).
 
         Notes:
             Boundary-layer loss correction coefficients (ref. a015140) are used
@@ -47,6 +52,7 @@ class Nozzle:
         self.c_1 = c_1
         self.c_2 = c_2
         self.discharge_coefficient = discharge_coefficient
+        self.separation_pressure_ratio = separation_pressure_ratio
 
     @property
     def outlet_diameter(self) -> float:

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -145,10 +145,14 @@ class BiliquidEngineState(simulation_states.MotorState):
             mixture_ratio=oxidizer_to_fuel_ratio,
         )
 
-        exit_pressure = isentropic.get_exit_pressure(
-            propellant_properties.k_exhaust,
-            nozzle.expansion_ratio,
-            chamber_pressure,
+        effective_expansion_ratio, exit_pressure = (
+            nozzle_core.get_separated_exit_conditions(
+                propellant_properties.k_exhaust,
+                nozzle.expansion_ratio,
+                chamber_pressure,
+                external_pressure,
+                nozzle.separation_pressure_ratio,
+            )
         )
         self.exit_pressure.append(exit_pressure)
 
@@ -171,7 +175,7 @@ class BiliquidEngineState(simulation_states.MotorState):
             chamber_pressure,
             exit_pressure,
             external_pressure,
-            nozzle.expansion_ratio,
+            effective_expansion_ratio,
             propellant_properties.k_exhaust,
         )
         self.ideal_thrust_coefficient.append(ideal_thrust_coefficient)

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -155,10 +155,14 @@ class SolidMotorState(simulation_states.MotorState):
         )
         self.grain_segment_mass_flow.append(grain_segment_mass_flow)
 
-        exit_pressure = isentropic.get_exit_pressure(
-            propellant_properties.k_exhaust,
-            nozzle.expansion_ratio,
-            chamber_pressure,
+        effective_expansion_ratio, exit_pressure = (
+            nozzle_core.get_separated_exit_conditions(
+                propellant_properties.k_exhaust,
+                nozzle.expansion_ratio,
+                chamber_pressure,
+                external_pressure,
+                nozzle.separation_pressure_ratio,
+            )
         )
         self.exit_pressure.append(exit_pressure)
 
@@ -207,7 +211,7 @@ class SolidMotorState(simulation_states.MotorState):
             chamber_pressure,
             exit_pressure,
             external_pressure,
-            nozzle.expansion_ratio,
+            effective_expansion_ratio,
             propellant_properties.k_exhaust,
         )
         self.ideal_thrust_coefficient.append(ideal_thrust_coefficient)

--- a/tests/test_core/test_compressible_flow/test_nozzle.py
+++ b/tests/test_core/test_compressible_flow/test_nozzle.py
@@ -1,5 +1,6 @@
 import pytest
 
+import machwave.core.compressible_flow.isentropic as isentropic
 import machwave.core.compressible_flow.nozzle as core_nozzle
 
 
@@ -12,6 +13,64 @@ def test_get_optimal_expansion_ratio():
     )
 
     assert optimal_expansion_ratio == pytest.approx(9.37, rel=1e-2)
+
+
+def test_get_separated_exit_conditions_attached():
+    # High chamber pressure: the nozzle flows full and conditions are unchanged.
+    k_exhaust = 1.2
+    expansion_ratio = 8.0
+    chamber_pressure = 7e6
+    external_pressure = 1e5
+    effective_expansion_ratio, exit_pressure = (
+        core_nozzle.get_separated_exit_conditions(
+            k_exhaust, expansion_ratio, chamber_pressure, external_pressure, 0.4
+        )
+    )
+
+    assert effective_expansion_ratio == expansion_ratio
+    assert exit_pressure == pytest.approx(
+        isentropic.get_exit_pressure(k_exhaust, expansion_ratio, chamber_pressure)
+    )
+
+
+def test_get_separated_exit_conditions_separated():
+    # Low chamber pressure: the flow separates upstream of the geometric exit.
+    k_exhaust = 1.2
+    expansion_ratio = 8.0
+    chamber_pressure = 3e5
+    external_pressure = 1e5
+    separation_pressure_ratio = 0.4
+    effective_expansion_ratio, exit_pressure = (
+        core_nozzle.get_separated_exit_conditions(
+            k_exhaust,
+            expansion_ratio,
+            chamber_pressure,
+            external_pressure,
+            separation_pressure_ratio,
+        )
+    )
+
+    assert 1.0 < effective_expansion_ratio < expansion_ratio
+    assert exit_pressure == pytest.approx(separation_pressure_ratio * external_pressure)
+
+
+def test_get_separated_exit_conditions_unchoked_limit():
+    # Near-ambient chamber pressure: separation reaches the throat, so the
+    # effective exit collapses to sonic conditions.
+    k_exhaust = 1.2
+    expansion_ratio = 8.0
+    chamber_pressure = 6e4
+    external_pressure = 1e5
+    effective_expansion_ratio, exit_pressure = (
+        core_nozzle.get_separated_exit_conditions(
+            k_exhaust, expansion_ratio, chamber_pressure, external_pressure, 0.4
+        )
+    )
+
+    assert effective_expansion_ratio == 1.0
+    assert exit_pressure == pytest.approx(
+        chamber_pressure * isentropic.get_critical_pressure_ratio(k_exhaust)
+    )
 
 
 def test_get_ideal_thrust_coefficient():

--- a/tests/test_models/test_propulsion/test_nozzle.py
+++ b/tests/test_models/test_propulsion/test_nozzle.py
@@ -1,6 +1,7 @@
 import pytest
 
 import machwave.core.geometric as geometric
+import machwave.models.thrust_chamber.nozzle as nozzle_model
 
 from tests.factories import NozzleFactory
 
@@ -77,3 +78,15 @@ class TestNozzleGeometry:
         """Throat discharge coefficient can be overridden."""
         n = NozzleFactory.build(discharge_coefficient=0.95)
         assert n.discharge_coefficient == pytest.approx(0.95, rel=1e-9)
+
+    def test_default_separation_pressure_ratio(self, nozzle):
+        """Separation pressure ratio defaults to the Summerfield value."""
+        assert (
+            nozzle.separation_pressure_ratio
+            == nozzle_model.DEFAULT_SEPARATION_PRESSURE_RATIO
+        )
+
+    def test_custom_separation_pressure_ratio(self):
+        """Separation pressure ratio can be overridden."""
+        n = NozzleFactory.build(separation_pressure_ratio=0.35)
+        assert n.separation_pressure_ratio == pytest.approx(0.35, rel=1e-9)

--- a/tests/test_simulations/test_biliquid_engine_simulation.py
+++ b/tests/test_simulations/test_biliquid_engine_simulation.py
@@ -100,6 +100,10 @@ def test_chamber_pressure_and_thrust_are_physically_plausible(
     assert 100.0 < peak_thrust < 1.0e4, (
         f"peak thrust {peak_thrust:.2e} N outside [100, 1e4]"
     )
+    # Flow separation bounds the overexpanded pressure-thrust term, so thrust
+    # stays non-negative through tail-off.
+    min_thrust = float(np.min(simulation_result.thrust))
+    assert min_thrust >= 0.0, f"thrust dips negative: {min_thrust:.2e} N"
 
 
 def test_recorded_per_timestep_arrays_are_aligned(

--- a/tests/test_simulations/test_solid_motor_simulation.py
+++ b/tests/test_simulations/test_solid_motor_simulation.py
@@ -94,6 +94,10 @@ def test_chamber_pressure_and_thrust_are_physically_plausible(
     assert 100.0 < peak_thrust < 1.0e5, (
         f"peak thrust {peak_thrust:.2e} N outside [100, 1e5]"
     )
+    # Flow separation bounds the overexpanded pressure-thrust term, so thrust
+    # stays non-negative through tail-off.
+    min_thrust = float(np.min(simulation_result.thrust))
+    assert min_thrust >= 0.0, f"thrust dips negative: {min_thrust:.2e} N"
     assert simulation_result.total_impulse > 0
     assert simulation_result.specific_impulse > 0
 


### PR DESCRIPTION
Thrust dipped below zero during tail-off. As the chamber pressure decays the nozzle becomes increasingly overexpanded, and the ideal thrust coefficient's pressure-thrust term `ε·(Pe − Pa)/Pc` diverges negative because the exit pressure is taken at the fixed geometric expansion ratio. A real nozzle separates well before that point, which bounds the term.

## Approach

A simple Summerfield flow-separation model, in the shared core so both motor types benefit:

- `get_separated_exit_conditions` returns the effective expansion ratio and exit pressure. Once the isentropic exit pressure drops below `separation_pressure_ratio · external_pressure`, it solves for the area ratio where the wall pressure equals the separation pressure; otherwise the nozzle flows full and conditions are unchanged.
- `separation_pressure_ratio` is a tunable nozzle property (default 0.4).
- The solid and biliquid timesteps feed the effective expansion ratio and exit pressure into the thrust coefficient. The loss terms keep using the geometric expansion ratio, and the existing unchoke termination is unchanged.

On the Olympus configuration the thrust coefficient now decays smoothly from about 1.6 to about 0.5 at the unchoke point instead of crossing zero near 5 bar.

## Docs

`docs/theory/thrust.md` gains a "Flow Separation" section; the compressible-flow API overview mentions the new step.

## Tests

Unit tests for the helper (attached, separated, unchoked-limit), a nozzle default/override pair, and a non-negative-thrust regression check in both simulation suites.

Closes #139.