### PR TITLE
Evaluate the chamber pressure inflow at each Runge-Kutta stage

### DIFF
--- a/docs/api/core/mass_balance.md
+++ b/docs/api/core/mass_balance.md
@@ -5,6 +5,7 @@ simulation. A single control-volume mass balance covers both choked and
 sub-critical nozzle flow (Seidel 1965, Eq. 35), and is shared by the solid-motor
 and biliquid-engine state integrations — the caller supplies the appropriate
 \(\dot{m}_{in}\) (propellant regression for a solid motor, summed injector flows
-for a biliquid engine).
+for a biliquid engine) as a callable evaluated at each Runge-Kutta stage
+pressure, so the inflow stays consistent with the outflow.
 
 ::: machwave.core.mass_balance

--- a/docs/api/core/solvers.md
+++ b/docs/api/core/solvers.md
@@ -4,4 +4,6 @@ Numerical ODE solvers used by the simulation engine.
 
 Provides a classical 4th-order Runge-Kutta integrator (`rk4th_ode_solver`) that advances the internal ballistics state at each time step. Accepts a generic equation callable and a dictionary of state variables, returning updated values after one step of size `d_t`.
 
+Only the entries in the state-variable dictionary are advanced through the four stages; any other keyword arguments are held constant for the whole step. A source term that depends on an integrated variable (such as the pressure-dependent chamber inflow) must therefore be supplied through the equation callable — for example, as a callable evaluated at each stage pressure — rather than as a precomputed constant.
+
 ::: machwave.core.solvers

--- a/docs/theory/mass_balance.md
+++ b/docs/theory/mass_balance.md
@@ -65,7 +65,7 @@ $$
 
 where:
 
-- $C_d$ is the throat discharge coefficient (dimensionless; set to 1 for the biliquid engine)
+- $C_d$ is the throat discharge coefficient (dimensionless)
 - $A_t$ is the nozzle throat area [m$^2$]
 - $H$ is the dimensionless flow function, set by the throat regime
 
@@ -102,6 +102,7 @@ $$
 
 This single differential equation is the foundation of all internal ballistics simulations in Machwave.
 It is evaluated by [`compute_chamber_pressure_mass_balance`][machwave.core.mass_balance.compute_chamber_pressure_mass_balance] and integrated numerically with the fourth-order Runge–Kutta solver in [`machwave.core.solvers`][machwave.core.solvers].
+Both source terms are evaluated at the chamber pressure of each Runge–Kutta stage: $\dot{m}_{out}$ is linear in $P_0$, and $\dot{m}_{in}$ carries the pressure dependence of the burn rate (solid motor) or of the injector pressure drop (biliquid engine), so the integrator advances the true coupled $(\dot{m}_{in} - \dot{m}_{out})$ slope instead of freezing the inflow at the start of the step.
 The next sections derive the specific forms of $\dot{m}_{in}$ for different categories of motors/engines.
 
 ## 2.1 Solid Rocket Motor

--- a/machwave/core/mass_balance.py
+++ b/machwave/core/mass_balance.py
@@ -1,17 +1,24 @@
+from typing import Callable
+
 from .compressible_flow.isentropic import get_critical_pressure_ratio
+
+
+def _zero_volume_rate(chamber_pressure: float) -> float:
+    """Free chamber volume rate for a rigid chamber: zero at any pressure."""
+    return 0.0
 
 
 def compute_chamber_pressure_mass_balance(
     chamber_pressure: float,
     external_pressure: float,
-    mass_flow_in: float,
+    mass_flow_in: Callable[[float], float],
     free_chamber_volume: float,
     throat_area: float,
     k: float,
     R: float,
     flame_temperature: float,
     nozzle_discharge_coefficient: float = 1.0,
-    free_chamber_volume_rate: float = 0.0,
+    free_chamber_volume_rate: Callable[[float], float] = _zero_volume_rate,
 ) -> tuple[float]:
     """
     Right-hand side of the chamber pressure ODE from a control-volume mass balance.
@@ -21,19 +28,26 @@ def compute_chamber_pressure_mass_balance(
     Args:
         chamber_pressure: Chamber pressure [Pa].
         external_pressure: External pressure [Pa].
-        mass_flow_in: Mass flow rate into the chamber [kg/s].
+        mass_flow_in: Callable mapping chamber pressure to the mass flow rate
+            into the chamber [kg/s]. It is evaluated at each Runge-Kutta stage
+            pressure, keeping the pressure-dependent inflow consistent with
+            the outflow term.
         free_chamber_volume: Chamber free volume [m^3].
         throat_area: Nozzle throat area [m^2].
         k: Isentropic exponent of the mix.
         R: Gas constant per molecular weight [J/(kg-K)].
         flame_temperature: Effective flame temperature [K].
         nozzle_discharge_coefficient: Nozzle discharge coefficient.
-        free_chamber_volume_rate: Rate of change of chamber free volume [m^3/s].
-            Defaults to 0, i.e. constant free volume.
+        free_chamber_volume_rate: Callable mapping chamber pressure to the rate
+            of change of chamber free volume [m^3/s]. Defaults to a callable
+            returning 0, i.e. constant free volume.
 
     Returns:
         Derivative of chamber pressure with respect to time, as a one-tuple.
     """
+    inflow = mass_flow_in(chamber_pressure)
+    volume_rate = free_chamber_volume_rate(chamber_pressure)
+
     critical_pressure_ratio = get_critical_pressure_ratio(k=k)
     pressure_ratio = external_pressure / chamber_pressure
 
@@ -57,6 +71,6 @@ def compute_chamber_pressure_mass_balance(
     )
 
     chamber_pressure_derivative = (R * flame_temperature / free_chamber_volume) * (
-        mass_flow_in - mass_flow_out
-    ) - chamber_pressure * free_chamber_volume_rate / free_chamber_volume
+        inflow - mass_flow_out
+    ) - chamber_pressure * volume_rate / free_chamber_volume
     return (chamber_pressure_derivative,)

--- a/machwave/core/solvers/rk4.py
+++ b/machwave/core/solvers/rk4.py
@@ -14,7 +14,11 @@ def rk4th_ode_solver(
         variables: Mapping of variable name to current value.
         equation: Callable returning the derivatives of the variables.
         d_t: Time step [s].
-        **kwargs: Additional keyword arguments forwarded to `equation`.
+        **kwargs: Additional keyword arguments forwarded to `equation`. These
+            are held constant across all four stages, while `variables` are
+            advanced; a term that depends on a `variables` entry must be
+            computed inside `equation` (or passed as a callable it resolves)
+            so it stays consistent across the stages.
 
     Returns:
         Tuple containing the new values of the variables followed by the

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -1,15 +1,69 @@
 from __future__ import annotations
 
+import functools
+from typing import Callable
+
 import machwave.core.compressible_flow.isentropic as isentropic
 import machwave.core.compressible_flow.losses as losses
 import machwave.core.compressible_flow.nozzle as nozzle_core
 import machwave.core.conversions as conversions
 import machwave.core.mass_balance as mass_balance
 import machwave.core.solvers.rk4 as rk4
+import machwave.models.feed_systems as feed_systems
 import machwave.models.motors as motors
 import machwave.models.propellants.properties as propellant_properties_models
+import machwave.models.thrust_chamber.injector as injector_models
 import machwave.simulation.biliquid.results as biliquid_results
 import machwave.simulation.states as simulation_states
+
+
+def get_injector_mass_flows(
+    chamber_pressure: float,
+    *,
+    feed_system: feed_systems.FeedSystem,
+    injector: injector_models.BipropellantInjector,
+    fuel_mass: float,
+    oxidizer_mass: float,
+    fuel_tank_pressure: float,
+    oxidizer_tank_pressure: float,
+    is_feeding: bool,
+    d_t: float,
+) -> tuple[float, float]:
+    """Fuel and oxidizer injector flows at the given chamber pressure [kg/s]."""
+    if not is_feeding:
+        return 0.0, 0.0
+    fuel_flow = (
+        feed_system.get_mass_flow_fuel(
+            chamber_pressure=chamber_pressure,
+            injector=injector,
+            fuel_mass=fuel_mass,
+            oxidizer_mass=oxidizer_mass,
+        )
+        if fuel_tank_pressure > chamber_pressure
+        else 0.0
+    )
+    oxidizer_flow = (
+        feed_system.get_mass_flow_ox(
+            chamber_pressure=chamber_pressure,
+            injector=injector,
+            oxidizer_mass=oxidizer_mass,
+        )
+        if oxidizer_tank_pressure > chamber_pressure
+        else 0.0
+    )
+    return (
+        min(fuel_flow, fuel_mass / d_t),
+        min(oxidizer_flow, oxidizer_mass / d_t),
+    )
+
+
+def get_total_injector_mass_flow(
+    chamber_pressure: float,
+    *,
+    injector_flows: Callable[[float], tuple[float, float]],
+) -> float:
+    """Total injector mass flow (fuel + oxidizer) at the given pressure [kg/s]."""
+    return sum(injector_flows(chamber_pressure))
 
 
 class BiliquidEngineState(simulation_states.MotorState):
@@ -56,10 +110,6 @@ class BiliquidEngineState(simulation_states.MotorState):
         self.oxidizer_tank_pressure: simulation_states.SimulationStateArray = []
         self.nozzle_correction_factor: simulation_states.SimulationStateArray = []
 
-    def get_m_dot_in(self) -> float:
-        """Return the total inlet mass flow (fuel + oxidizer) [kg/s]."""
-        return self.fuel_mass_flow_rate[-1] + self.oxidizer_mass_flow_rate[-1]
-
     def _evaluate_propellant_properties(
         self,
         chamber_pressure: float,
@@ -85,7 +135,6 @@ class BiliquidEngineState(simulation_states.MotorState):
             external_pressure: External pressure.
         """
         nozzle = self.motor.thrust_chamber.nozzle
-        injector = self.motor.thrust_chamber.injector
         feed_system = self.motor.feed_system
 
         time = self.time[-1]
@@ -105,28 +154,23 @@ class BiliquidEngineState(simulation_states.MotorState):
         )
         self.oxidizer_tank_pressure.append(oxidizer_tank_pressure)
 
-        can_feed = (
+        is_feeding = (
             propellant_mass > 0
             and fuel_tank_pressure > chamber_pressure
             and oxidizer_tank_pressure > chamber_pressure
         )
-        if can_feed:
-            m_dot_fuel = feed_system.get_mass_flow_fuel(
-                chamber_pressure=chamber_pressure,
-                injector=injector,
-                fuel_mass=fuel_mass,
-                oxidizer_mass=oxidizer_mass,
-            )
-            m_dot_ox = feed_system.get_mass_flow_ox(
-                chamber_pressure=chamber_pressure,
-                injector=injector,
-                oxidizer_mass=oxidizer_mass,
-            )
-        else:
-            m_dot_fuel = m_dot_ox = 0.0
-
-        m_dot_fuel = min(m_dot_fuel, fuel_mass / d_t)
-        m_dot_ox = min(m_dot_ox, oxidizer_mass / d_t)
+        injector_flows = functools.partial(
+            get_injector_mass_flows,
+            feed_system=feed_system,
+            injector=self.motor.thrust_chamber.injector,
+            fuel_mass=fuel_mass,
+            oxidizer_mass=oxidizer_mass,
+            fuel_tank_pressure=fuel_tank_pressure,
+            oxidizer_tank_pressure=oxidizer_tank_pressure,
+            is_feeding=is_feeding,
+            d_t=d_t,
+        )
+        m_dot_fuel, m_dot_ox = injector_flows(chamber_pressure)
         self.fuel_mass_flow_rate.append(m_dot_fuel)
         self.oxidizer_mass_flow_rate.append(m_dot_ox)
         fuel_consumed = m_dot_fuel * d_t
@@ -189,7 +233,7 @@ class BiliquidEngineState(simulation_states.MotorState):
         self.thrust.append(thrust)
 
         if (
-            not can_feed
+            not is_feeding
             or fuel_consumed >= fuel_mass
             or oxidizer_consumed >= oxidizer_mass
         ) and not self.end_burn:
@@ -209,20 +253,21 @@ class BiliquidEngineState(simulation_states.MotorState):
 
         new_time = time + d_t
         self.time.append(new_time)
-        self.fuel_mass.append(fuel_mass - fuel_consumed)
-        self.oxidizer_mass.append(oxidizer_mass - oxidizer_consumed)
         new_chamber_pressure = rk4.rk4th_ode_solver(
             variables={"chamber_pressure": chamber_pressure},
             equation=mass_balance.compute_chamber_pressure_mass_balance,
             d_t=d_t,
             external_pressure=external_pressure,
-            mass_flow_in=self.get_m_dot_in(),
+            mass_flow_in=functools.partial(
+                get_total_injector_mass_flow, injector_flows=injector_flows
+            ),
             free_chamber_volume=self.motor.thrust_chamber.combustion_chamber.internal_volume,
             throat_area=nozzle.get_throat_area(),
             k=propellant_properties.k_chamber,
             R=propellant_properties.R_chamber,
             flame_temperature=propellant_properties.adiabatic_flame_temperature,
             nozzle_discharge_coefficient=nozzle.discharge_coefficient,
-            free_chamber_volume_rate=0.0,
         )[0]
         self.chamber_pressure.append(new_chamber_pressure)
+        self.fuel_mass.append(fuel_mass - fuel_consumed)
+        self.oxidizer_mass.append(oxidizer_mass - oxidizer_consumed)

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import functools
+from typing import Callable
+
 import numpy as np
 import numpy.typing as npt
 
@@ -11,8 +14,44 @@ import machwave.core.mass_balance as mass_balance
 import machwave.core.performance as performance
 import machwave.core.solvers.rk4 as rk4
 import machwave.models.motors as motors
+import machwave.models.propellants as propellants
 import machwave.simulation.solid.results as solid_results
 import machwave.simulation.states as simulation_states
+
+
+def get_grain_mass_flow_per_segment(
+    chamber_pressure: float,
+    *,
+    propellant: propellants.SolidPropellant,
+    burn_area_per_segment: npt.NDArray[np.float64],
+    segment_density_ratios: npt.NDArray[np.float64],
+) -> npt.NDArray[np.float64]:
+    """Per-segment grain mass generation rate at the given chamber pressure [kg/s]."""
+    return (
+        propellant.ideal_density
+        * propellant.get_burn_rate(chamber_pressure)
+        * burn_area_per_segment
+        * segment_density_ratios
+    )
+
+
+def get_grain_mass_flow(
+    chamber_pressure: float,
+    *,
+    mass_flow_per_segment: Callable[[float], npt.NDArray[np.float64]],
+) -> float:
+    """Total grain mass generation rate at the given chamber pressure [kg/s]."""
+    return float(np.sum(mass_flow_per_segment(chamber_pressure)))
+
+
+def get_free_chamber_volume_rate(
+    chamber_pressure: float,
+    *,
+    propellant: propellants.SolidPropellant,
+    burn_area: float,
+) -> float:
+    """Free chamber volume growth rate at the given chamber pressure [m^3/s]."""
+    return propellant.get_burn_rate(chamber_pressure) * burn_area
 
 
 class SolidMotorState(simulation_states.MotorState):
@@ -81,10 +120,6 @@ class SolidMotorState(simulation_states.MotorState):
         self.two_phase_loss: simulation_states.SimulationStateArray = []
         self.nozzle_efficiency: simulation_states.SimulationStateArray = []
 
-    def get_m_dot_in(self) -> float:
-        """Return the propellant mass generation rate from the grain [kg/s]."""
-        return float(np.sum(self.grain_segment_mass_flow[-1]))
-
     def run_timestep(
         self,
         d_t: float,
@@ -110,6 +145,19 @@ class SolidMotorState(simulation_states.MotorState):
         burn_area = float(np.sum(burn_area_per_segment))
         self.burn_area.append(burn_area)
 
+        # Pressure-dependent inflow: recorded at start-of-step, re-evaluated per stage.
+        mass_flow_per_segment = functools.partial(
+            get_grain_mass_flow_per_segment,
+            propellant=self.motor.propellant,
+            burn_area_per_segment=burn_area_per_segment,
+            segment_density_ratios=self.segment_density_ratios,
+        )
+        free_chamber_volume_rate = functools.partial(
+            get_free_chamber_volume_rate,
+            propellant=self.motor.propellant,
+            burn_area=burn_area,
+        )
+
         propellant_volume_per_segment = (
             self.motor.grain.get_propellant_volume_per_segment(web_distance)
         )
@@ -123,8 +171,7 @@ class SolidMotorState(simulation_states.MotorState):
 
         free_chamber_volume = self.motor.get_free_chamber_volume(propellant_volume)
         self.free_chamber_volume.append(free_chamber_volume)
-        free_chamber_volume_rate = burn_rate * burn_area
-        self.free_chamber_volume_rate.append(free_chamber_volume_rate)
+        self.free_chamber_volume_rate.append(free_chamber_volume_rate(chamber_pressure))
         propellant_mass_per_segment = (
             propellant_volume_per_segment
             * self.segment_density_ratios
@@ -147,13 +194,7 @@ class SolidMotorState(simulation_states.MotorState):
         self.propellant_cog.append(propellant_cog)
         self.propellant_moi.append(propellant_moi)
 
-        grain_segment_mass_flow = (
-            ideal_propellant_density
-            * burn_rate
-            * burn_area_per_segment
-            * self.segment_density_ratios
-        )
-        self.grain_segment_mass_flow.append(grain_segment_mass_flow)
+        self.grain_segment_mass_flow.append(mass_flow_per_segment(chamber_pressure))
 
         effective_expansion_ratio, exit_pressure = (
             nozzle_core.get_separated_exit_conditions(
@@ -247,12 +288,15 @@ class SolidMotorState(simulation_states.MotorState):
             adiabatic_flame_temperature=propellant_properties.adiabatic_flame_temperature,
             combustion_efficiency=self.motor.combustion_efficiency,
         )
+
         new_chamber_pressure = rk4.rk4th_ode_solver(
             variables={"chamber_pressure": self.chamber_pressure[-1]},
             equation=mass_balance.compute_chamber_pressure_mass_balance,
             d_t=d_t,
             external_pressure=external_pressure,
-            mass_flow_in=self.get_m_dot_in(),
+            mass_flow_in=functools.partial(
+                get_grain_mass_flow, mass_flow_per_segment=mass_flow_per_segment
+            ),
             free_chamber_volume=free_chamber_volume,
             throat_area=nozzle.get_throat_area(),
             k=propellant_properties.k_chamber,

--- a/machwave/simulation/states.py
+++ b/machwave/simulation/states.py
@@ -53,10 +53,6 @@ class MotorState(ABC):
         self.end_burn: bool = False
 
     @abstractmethod
-    def get_m_dot_in(self) -> float:
-        """Mass flow rate into the combustion chamber [kg/s]."""
-
-    @abstractmethod
     def run_timestep(self, *args, **kwargs) -> None:
         """Advance the per-step accumulators by one time increment."""
 

--- a/tests/test_core/test_mass_balance.py
+++ b/tests/test_core/test_mass_balance.py
@@ -1,6 +1,8 @@
+import numpy as np
 import pytest
 
 import machwave.core.mass_balance as mass_balance
+import machwave.core.solvers.rk4 as rk4
 
 
 BASE_KWARGS = {
@@ -12,6 +14,11 @@ BASE_KWARGS = {
     "flame_temperature": 2_800.0,
     "nozzle_discharge_coefficient": 0.95,
 }
+
+
+def constant(value):
+    """Wrap a scalar as a chamber-pressure-independent callable."""
+    return lambda _chamber_pressure: value
 
 
 @pytest.mark.parametrize(
@@ -28,13 +35,13 @@ def test_zero_volume_rate_matches_rigid_form(chamber_pressure, mass_flow_in):
     """With V_dot = 0 (default), output must equal the rigid-volume form."""
     explicit = mass_balance.compute_chamber_pressure_mass_balance(
         chamber_pressure=chamber_pressure,
-        mass_flow_in=mass_flow_in,
-        free_chamber_volume_rate=0.0,
+        mass_flow_in=constant(mass_flow_in),
+        free_chamber_volume_rate=constant(0.0),
         **BASE_KWARGS,
     )
     default = mass_balance.compute_chamber_pressure_mass_balance(
         chamber_pressure=chamber_pressure,
-        mass_flow_in=mass_flow_in,
+        mass_flow_in=constant(mass_flow_in),
         **BASE_KWARGS,
     )
     assert explicit == default
@@ -45,7 +52,7 @@ def test_balanced_mass_flow_isolates_volume_term():
     chamber_pressure = 4.0e6
     (baseline,) = mass_balance.compute_chamber_pressure_mass_balance(
         chamber_pressure=chamber_pressure,
-        mass_flow_in=0.0,
+        mass_flow_in=constant(0.0),
         **BASE_KWARGS,
     )
     mass_flow_out = (
@@ -57,8 +64,8 @@ def test_balanced_mass_flow_isolates_volume_term():
     free_chamber_volume_rate = 2.5e-5
     (derivative,) = mass_balance.compute_chamber_pressure_mass_balance(
         chamber_pressure=chamber_pressure,
-        mass_flow_in=mass_flow_out,
-        free_chamber_volume_rate=free_chamber_volume_rate,
+        mass_flow_in=constant(mass_flow_out),
+        free_chamber_volume_rate=constant(free_chamber_volume_rate),
         **BASE_KWARGS,
     )
 
@@ -84,14 +91,13 @@ def test_volume_term_is_linear_addition(
     """dP/dt(V_dot) = dP/dt(0) + (-P V_dot / V) to machine precision."""
     (baseline,) = mass_balance.compute_chamber_pressure_mass_balance(
         chamber_pressure=chamber_pressure,
-        mass_flow_in=mass_flow_in,
-        free_chamber_volume_rate=0.0,
+        mass_flow_in=constant(mass_flow_in),
         **BASE_KWARGS,
     )
     (with_rate,) = mass_balance.compute_chamber_pressure_mass_balance(
         chamber_pressure=chamber_pressure,
-        mass_flow_in=mass_flow_in,
-        free_chamber_volume_rate=free_chamber_volume_rate,
+        mass_flow_in=constant(mass_flow_in),
+        free_chamber_volume_rate=constant(free_chamber_volume_rate),
         **BASE_KWARGS,
     )
     expected = (
@@ -101,3 +107,101 @@ def test_volume_term_is_linear_addition(
         / BASE_KWARGS["free_chamber_volume"]
     )
     assert with_rate == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_inflow_callable_is_evaluated_at_each_rk4_stage_pressure():
+    """RK4 evaluates the inflow at the staged pressure, not a frozen value."""
+    seen_pressures = []
+
+    def mass_flow_in(chamber_pressure):
+        seen_pressures.append(chamber_pressure)
+        return 0.5
+
+    rk4.rk4th_ode_solver(
+        variables={"chamber_pressure": 5.0e6},
+        equation=mass_balance.compute_chamber_pressure_mass_balance,
+        d_t=0.05,
+        mass_flow_in=mass_flow_in,
+        **BASE_KWARGS,
+    )
+
+    assert len(seen_pressures) == 4
+    assert len(set(seen_pressures)) > 1
+
+
+# Lumped solid chamber for the staged-inflow convergence test: choked outflow
+# plus a Saint Robert inflow r = a * Pc^n, so the inflow depends on pressure.
+STAGED_CHAMBER_KWARGS = {
+    "external_pressure": 101_325.0,
+    "free_chamber_volume": 9.0e-4,
+    "throat_area": 7.7e-5,
+    "k": 1.2,
+    "R": 320.0,
+    "flame_temperature": 2_800.0,
+    "nozzle_discharge_coefficient": 0.95,
+}
+BURN_RATE_COEFFICIENT = 1.2e-4
+BURN_RATE_EXPONENT = 0.5
+
+
+def saint_robert_inflow(chamber_pressure):
+    return BURN_RATE_COEFFICIENT * chamber_pressure**BURN_RATE_EXPONENT
+
+
+def integrate_chamber_pressure(*, staged, d_t, step_count, initial_pressure):
+    """Integrate the lumped chamber ODE; freeze or stage the inflow per step."""
+    pressures = [initial_pressure]
+    for _ in range(step_count):
+        chamber_pressure = pressures[-1]
+        if staged:
+            mass_flow_in = saint_robert_inflow
+        else:
+            mass_flow_in = constant(saint_robert_inflow(chamber_pressure))
+        result = rk4.rk4th_ode_solver(
+            variables={"chamber_pressure": chamber_pressure},
+            equation=mass_balance.compute_chamber_pressure_mass_balance,
+            d_t=d_t,
+            mass_flow_in=mass_flow_in,
+            **STAGED_CHAMBER_KWARGS,
+        )
+        pressures.append(result[0])
+    return np.array(pressures)
+
+
+def test_staged_inflow_tracks_refined_reference_better_than_freezing():
+    """Staging the pressure-dependent inflow restores high-order accuracy.
+
+    Freezing the inflow across the four RK4 stages drops the integrator to
+    first order, so a coarse step lags a refined reference. Evaluating the
+    inflow at each stage pressure keeps the same coarse step close to it.
+    """
+    initial_pressure = 2.0e6
+    end_time = 0.15
+    fine_d_t = 1.0e-4
+    coarse_d_t = 1.0e-2
+    stride = round(coarse_d_t / fine_d_t)
+
+    reference = integrate_chamber_pressure(
+        staged=True,
+        d_t=fine_d_t,
+        step_count=round(end_time / fine_d_t),
+        initial_pressure=initial_pressure,
+    )[::stride]
+    staged = integrate_chamber_pressure(
+        staged=True,
+        d_t=coarse_d_t,
+        step_count=round(end_time / coarse_d_t),
+        initial_pressure=initial_pressure,
+    )
+    frozen = integrate_chamber_pressure(
+        staged=False,
+        d_t=coarse_d_t,
+        step_count=round(end_time / coarse_d_t),
+        initial_pressure=initial_pressure,
+    )
+
+    staged_error = np.max(np.abs(staged - reference))
+    frozen_error = np.max(np.abs(frozen - reference))
+
+    assert np.all(staged > 0.0)
+    assert staged_error < 0.2 * frozen_error


### PR DESCRIPTION
Closes #319.

## Problem
The chamber-pressure mass balance integrated inflow and outflow at inconsistent pressures: the inflow was held at the start-of-step chamber pressure across all four Runge-Kutta stages, while the outflow tracked the stage pressure. Because the burn rate (solid motor) and injector flow (biliquid engine) depend on chamber pressure, the integrator saw the outflow eigenvalue alone instead of the coupled inflow-plus-outflow slope. This roughly halved the stable time step and left a startup transient error that is first order in the step, growing into an overshoot — and eventually a divergence to negative pressure — at coarse time steps.

## Fix
`compute_chamber_pressure_mass_balance` now takes the inflow and the free chamber volume rate as callables of chamber pressure, evaluated at each stage. The solid motor recomputes the burn-rate-driven inflow per stage; the biliquid engine recomputes the injector flow per stage and clamps each side to zero when the tank pressure falls to or below the stage pressure (a rising stage pressure can now reach it). Chamber thermochemistry stays fixed at the start-of-step value, since re-evaluating it per stage would multiply the cost of the thermochemistry-bound biliquid loop for negligible accuracy gain.

## Implementation
Each category supplies its pressure-dependent source terms as small pure functions bound to the start-of-step state and resolved by the solver at each stage: the grain mass flow and the free chamber volume rate for the solid motor, the summed injector flow for the biliquid engine. The unused `get_m_dot_in` state accessor, which only re-derived the inflow at the start-of-step pressure, was removed.

## Most affected regions
At the production time step the integrated results are essentially unchanged (peak chamber pressure, total impulse, and specific impulse within ~0.15%). The deviation is concentrated in the ignition transient, where this branch is the accurate one — for the Nero motor at its 10 ms step the startup error against a refined reference drops from ~34% (master) to ~6% (this branch):

![Ignition transient at the production time step](https://raw.githubusercontent.com/felipebogaertsm/machwave/6eae3bbb074d69a984d3a8073e974748c45619ae/pr-assets/ignition_transient.png)

At coarser time steps the deviation becomes a hard stability limit. At an 18 ms step the frozen inflow overshoots and collapses to negative pressure on the first step (raising BurnRateOutOfBoundsError), while the staged inflow climbs to steady operation and completes the full burn:

![Coarse time step startup divergence](https://raw.githubusercontent.com/felipebogaertsm/machwave/6eae3bbb074d69a984d3a8073e974748c45619ae/pr-assets/coarse_step_divergence.png)

The usable time step grows by roughly 1.5-2x for solid motors, matching the 1/(1-n) theory, where n is the burn-rate pressure exponent. The largest step that still completes a real burn rises from 10 to 20 ms for the Kappa motor, 11 to 16 ms for Nero, and 15 to 18 ms for the APCP motor. The biliquid engine is essentially unchanged: its coarse-step limit is a thermochemistry degeneracy, not the integrator, so this change is orthogonal to it.

## Tests
- A convergence test showing the staged inflow tracks a refined reference far closer than the frozen inflow at a coarse step (about 7500x smaller error in the lumped model).
- A test that the inflow callable is evaluated at the staged pressure.
- Existing mass-balance and end-to-end solid and biliquid simulation tests pass.
