### PR TITLE
Decouple the momentum and pressure terms of the ideal thrust coefficient

### DIFF
--- a/docs/theory/thrust.md
+++ b/docs/theory/thrust.md
@@ -38,7 +38,8 @@ where:
 - $P_\text{ext}$ is the external (ambient) pressure [Pa]
 - $\varepsilon$ is the expansion ratio (dimensionless)
 
-Implemented in [`get_ideal_thrust_coefficient`][machwave.core.compressible_flow.nozzle.get_ideal_thrust_coefficient].
+The momentum term and the pressure term are returned separately by [`get_ideal_thrust_coefficient_components`][machwave.core.compressible_flow.nozzle.get_ideal_thrust_coefficient_components].
+This way, nozzle losses can act on either term separately.
 
 ## 1.3 Flow Separation
 

--- a/machwave/core/compressible_flow/__init__.py
+++ b/machwave/core/compressible_flow/__init__.py
@@ -2,7 +2,7 @@
 
 from .nozzle import (
     apply_thrust_coefficient_correction,
-    get_ideal_thrust_coefficient,
+    get_ideal_thrust_coefficient_components,
     get_optimal_expansion_ratio,
     get_separated_exit_conditions,
     get_thrust_from_thrust_coefficient,
@@ -26,7 +26,7 @@ __all__ = [
     # nozzle
     "get_optimal_expansion_ratio",
     "get_separated_exit_conditions",
-    "get_ideal_thrust_coefficient",
+    "get_ideal_thrust_coefficient_components",
     "apply_thrust_coefficient_correction",
     "get_thrust_from_thrust_coefficient",
     # isentropic

--- a/machwave/core/compressible_flow/nozzle.py
+++ b/machwave/core/compressible_flow/nozzle.py
@@ -85,15 +85,15 @@ def get_separated_exit_conditions(
     return effective_expansion_ratio, separation_pressure
 
 
-def get_ideal_thrust_coefficient(
+def get_ideal_thrust_coefficient_components(
     chamber_pressure: float,
     exit_pressure: float,
     external_pressure: float,
     expansion_ratio: float,
     k_exhaust: float,
-) -> float:
+) -> tuple[float, float]:
     """
-    Get ideal thrust coefficient for DeLaval nozzle.
+    Get the momentum and pressure terms of the ideal thrust coefficient.
 
     Args:
         chamber_pressure: Chamber pressure [Pa].
@@ -103,20 +103,22 @@ def get_ideal_thrust_coefficient(
         k_exhaust: Isentropic exponent at exit.
 
     Returns:
-        Ideal thrust coefficient.
+        Momentum term then pressure term. The pressure term is positive when under
+        expanded and negative when over expanded.
 
     References:
         https://www.nakka-rocketry.net/th_thrst.html
     """
     pressure_ratio = exit_pressure / chamber_pressure
-    return (
-        np.sqrt(
-            (2 * (k_exhaust**2) / (k_exhaust - 1))
-            * ((2 / (k_exhaust + 1)) ** ((k_exhaust + 1) / (k_exhaust - 1)))
-            * (1 - (pressure_ratio ** ((k_exhaust - 1) / k_exhaust)))
-        )
-        + expansion_ratio * (exit_pressure - external_pressure) / chamber_pressure
+    momentum_term = np.sqrt(
+        (2 * (k_exhaust**2) / (k_exhaust - 1))
+        * ((2 / (k_exhaust + 1)) ** ((k_exhaust + 1) / (k_exhaust - 1)))
+        * (1 - (pressure_ratio ** ((k_exhaust - 1) / k_exhaust)))
     )
+    pressure_term = (
+        expansion_ratio * (exit_pressure - external_pressure) / chamber_pressure
+    )
+    return momentum_term, pressure_term
 
 
 def apply_thrust_coefficient_correction(

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -215,13 +215,16 @@ class BiliquidEngineState(simulation_states.MotorState):
         nozzle_correction_factor = nozzle_efficiency * self.motor.combustion_efficiency
         self.nozzle_correction_factor.append(nozzle_correction_factor)
 
-        ideal_thrust_coefficient = nozzle_core.get_ideal_thrust_coefficient(
-            chamber_pressure,
-            exit_pressure,
-            external_pressure,
-            effective_expansion_ratio,
-            propellant_properties.k_exhaust,
+        ideal_thrust_coefficient_components = (
+            nozzle_core.get_ideal_thrust_coefficient_components(
+                chamber_pressure,
+                exit_pressure,
+                external_pressure,
+                effective_expansion_ratio,
+                propellant_properties.k_exhaust,
+            )
         )
+        ideal_thrust_coefficient = sum(ideal_thrust_coefficient_components)
         self.ideal_thrust_coefficient.append(ideal_thrust_coefficient)
         thrust_coefficient = nozzle_core.apply_thrust_coefficient_correction(
             ideal_thrust_coefficient, nozzle_correction_factor

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -248,13 +248,16 @@ class SolidMotorState(simulation_states.MotorState):
         self.two_phase_loss.append(two_phase_loss)
         self.nozzle_efficiency.append(nozzle_efficiency)
 
-        ideal_thrust_coefficient = nozzle_core.get_ideal_thrust_coefficient(
-            chamber_pressure,
-            exit_pressure,
-            external_pressure,
-            effective_expansion_ratio,
-            propellant_properties.k_exhaust,
+        ideal_thrust_coefficient_components = (
+            nozzle_core.get_ideal_thrust_coefficient_components(
+                chamber_pressure,
+                exit_pressure,
+                external_pressure,
+                effective_expansion_ratio,
+                propellant_properties.k_exhaust,
+            )
         )
+        ideal_thrust_coefficient = sum(ideal_thrust_coefficient_components)
         self.ideal_thrust_coefficient.append(ideal_thrust_coefficient)
         thrust_coefficient = nozzle_core.apply_thrust_coefficient_correction(
             ideal_thrust_coefficient, nozzle_efficiency

--- a/tests/test_core/test_compressible_flow/test_nozzle.py
+++ b/tests/test_core/test_compressible_flow/test_nozzle.py
@@ -73,13 +73,22 @@ def test_get_separated_exit_conditions_unchoked_limit():
     )
 
 
-def test_get_ideal_thrust_coefficient():
+@pytest.mark.parametrize(
+    "external_pressure, expected_pressure_term",
+    [
+        pytest.param(1e5, 0.022857142857142857, id="under_expanded"),
+        pytest.param(1.2e5, 0.0, id="perfectly_expanded"),
+        pytest.param(2e5, -0.09142857142857143, id="over_expanded"),
+    ],
+)
+def test_get_ideal_thrust_coefficient_components(
+    external_pressure, expected_pressure_term
+):
     chamber_pressure = 7e6
     exit_pressure = 1.2e5
-    external_pressure = 1e5
     expansion_ratio = 8.0
     k_exhaust = 1.4
-    ideal_thrust_coefficient = core_nozzle.get_ideal_thrust_coefficient(
+    momentum_term, pressure_term = core_nozzle.get_ideal_thrust_coefficient_components(
         chamber_pressure,
         exit_pressure,
         external_pressure,
@@ -87,7 +96,13 @@ def test_get_ideal_thrust_coefficient():
         k_exhaust,
     )
 
-    assert ideal_thrust_coefficient == pytest.approx(1.524507)
+    # The momentum term depends only on the pressure ratio, so it is the same
+    # across expansion conditions; only the pressure term changes sign.
+    assert momentum_term == pytest.approx(1.5016496568524347)
+    assert pressure_term == pytest.approx(expected_pressure_term)
+    assert pressure_term == pytest.approx(
+        expansion_ratio * (exit_pressure - external_pressure) / chamber_pressure
+    )
 
 
 def test_apply_thrust_coefficient_correction():


### PR DESCRIPTION
## What

Split the ideal thrust coefficient into its momentum and pressure terms so a nozzle loss can act on either term independently.

- `get_ideal_thrust_coefficient_components` returns `(momentum_term, pressure_term)`; the pressure term is positive when under-expanded and negative when over-expanded.
- Removed the scalar `get_ideal_thrust_coefficient`; the solid and biliquid states sum the two terms for the recorded `ideal_thrust_coefficient` total, so behavior is unchanged.
- Updated the thrust theory doc cross-reference.

No per-component loss is applied yet — that lands with the composable nozzle loss model (#181) and the divergence-on-momentum-only change (#421), both of which this unblocks.

## Tests

- `get_ideal_thrust_coefficient_components` covered for each term across under-, perfectly-, and over-expanded conditions.
- Full suite green (804 passed); ruff check and format clean.

Closes #429.
