### PR TITLE
Apply combustion efficiency on the chamber side of the biliquid engine path

### DIFF
--- a/machwave/simulation/biliquid/results.py
+++ b/machwave/simulation/biliquid/results.py
@@ -19,7 +19,9 @@ class BiliquidSimulationResult(
 
     oxidizer_mass: simulation_results.SimulationResultArray
     fuel_mass: simulation_results.SimulationResultArray
-    nozzle_correction_factor: simulation_results.SimulationResultArray
+    divergent_loss: simulation_results.SimulationResultArray
+    kinetics_loss: simulation_results.SimulationResultArray
+    nozzle_efficiency: simulation_results.SimulationResultArray
     fuel_tank_pressure: simulation_results.SimulationResultArray
     oxidizer_tank_pressure: simulation_results.SimulationResultArray
     final_oxidizer_mass: float
@@ -34,7 +36,9 @@ class BiliquidSimulationResult(
         return {
             "oxidizer_mass": oxidizer_mass,
             "fuel_mass": fuel_mass,
-            "nozzle_correction_factor": np.asarray(state.nozzle_correction_factor),
+            "divergent_loss": np.asarray(state.divergent_loss),
+            "kinetics_loss": np.asarray(state.kinetics_loss),
+            "nozzle_efficiency": np.asarray(state.nozzle_efficiency),
             "fuel_tank_pressure": np.asarray(state.fuel_tank_pressure),
             "oxidizer_tank_pressure": np.asarray(state.oxidizer_tank_pressure),
             "final_oxidizer_mass": float(oxidizer_mass[-1]),
@@ -65,6 +69,20 @@ class BiliquidSimulationResult(
         print("\nIMPULSE AND I_SP", file=file)
         print(f"  Total impulse: {self.total_impulse:.4f} N-s", file=file)
         print(f"  Specific impulse: {self.specific_impulse:.4f} s", file=file)
+
+        print("\nNOZZLE", file=file)
+        print(
+            f"  Average nozzle efficiency: {np.mean(self.nozzle_efficiency):.3%}",
+            file=file,
+        )
+        print(
+            f"  Divergent nozzle loss fraction: {np.mean(self.divergent_loss):.3%}",
+            file=file,
+        )
+        print(
+            f"  Average kinetics loss fraction: {np.mean(self.kinetics_loss):.3%}",
+            file=file,
+        )
 
         print("\nPROPELLANT REMAINING (kg)", file=file)
         print(f"  Oxidizer: {self.final_oxidizer_mass:.4f}", file=file)

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -8,6 +8,7 @@ import machwave.core.compressible_flow.losses as losses
 import machwave.core.compressible_flow.nozzle as nozzle_core
 import machwave.core.conversions as conversions
 import machwave.core.mass_balance as mass_balance
+import machwave.core.performance as performance
 import machwave.core.solvers.rk4 as rk4
 import machwave.models.feed_systems as feed_systems
 import machwave.models.motors as motors
@@ -108,7 +109,9 @@ class BiliquidEngineState(simulation_states.MotorState):
         self.oxidizer_to_fuel_ratio: simulation_states.SimulationStateArray = []
         self.fuel_tank_pressure: simulation_states.SimulationStateArray = []
         self.oxidizer_tank_pressure: simulation_states.SimulationStateArray = []
-        self.nozzle_correction_factor: simulation_states.SimulationStateArray = []
+        self.divergent_loss: simulation_states.SimulationStateArray = []
+        self.kinetics_loss: simulation_states.SimulationStateArray = []
+        self.nozzle_efficiency: simulation_states.SimulationStateArray = []
 
     def _evaluate_propellant_properties(
         self,
@@ -212,8 +215,9 @@ class BiliquidEngineState(simulation_states.MotorState):
         nozzle_efficiency = losses.get_overall_nozzle_efficiency(
             divergent_loss, kinetics_loss, 0.0, 0.0, other_losses=self.other_losses
         )
-        nozzle_correction_factor = nozzle_efficiency * self.motor.combustion_efficiency
-        self.nozzle_correction_factor.append(nozzle_correction_factor)
+        self.divergent_loss.append(divergent_loss)
+        self.kinetics_loss.append(kinetics_loss)
+        self.nozzle_efficiency.append(nozzle_efficiency)
 
         ideal_thrust_coefficient_components = (
             nozzle_core.get_ideal_thrust_coefficient_components(
@@ -227,7 +231,7 @@ class BiliquidEngineState(simulation_states.MotorState):
         ideal_thrust_coefficient = sum(ideal_thrust_coefficient_components)
         self.ideal_thrust_coefficient.append(ideal_thrust_coefficient)
         thrust_coefficient = nozzle_core.apply_thrust_coefficient_correction(
-            ideal_thrust_coefficient, nozzle_correction_factor
+            ideal_thrust_coefficient, nozzle_efficiency
         )
         self.thrust_coefficient.append(thrust_coefficient)
         thrust = nozzle_core.get_thrust_from_thrust_coefficient(
@@ -256,6 +260,10 @@ class BiliquidEngineState(simulation_states.MotorState):
 
         new_time = time + d_t
         self.time.append(new_time)
+        effective_flame_temperature = performance.get_effective_flame_temperature(
+            adiabatic_flame_temperature=propellant_properties.adiabatic_flame_temperature,
+            combustion_efficiency=self.motor.combustion_efficiency,
+        )
         new_chamber_pressure = rk4.rk4th_ode_solver(
             variables={"chamber_pressure": chamber_pressure},
             equation=mass_balance.compute_chamber_pressure_mass_balance,
@@ -268,7 +276,7 @@ class BiliquidEngineState(simulation_states.MotorState):
             throat_area=nozzle.get_throat_area(),
             k=propellant_properties.k_chamber,
             R=propellant_properties.R_chamber,
-            flame_temperature=propellant_properties.adiabatic_flame_temperature,
+            flame_temperature=effective_flame_temperature,
             nozzle_discharge_coefficient=nozzle.discharge_coefficient,
         )[0]
         self.chamber_pressure.append(new_chamber_pressure)

--- a/tests/test_simulations/test_biliquid_engine_simulation.py
+++ b/tests/test_simulations/test_biliquid_engine_simulation.py
@@ -193,16 +193,18 @@ def test_simulation_runs_through_burnout_without_crashing(
     assert simulation_result.propellant_mass[-1] <= simulation_result.propellant_mass[0]
 
 
-def test_nozzle_correction_factor_uses_motor_combustion_efficiency() -> None:
-    """The biliquid read site sources combustion efficiency from the motor.
+def test_combustion_efficiency_derates_chamber_not_thrust_coefficient() -> None:
+    """Combustion efficiency acts on the chamber side, not the thrust coefficient.
 
-    ``nozzle_correction_factor = nozzle_efficiency * motor.combustion_efficiency``.
-    The nozzle efficiency depends only on geometry and losses, which are identical
-    across the two runs' first step, so the recorded correction factor must scale
-    linearly with the motor's combustion efficiency.
+    The nozzle efficiency applied to the thrust coefficient depends only on
+    geometry and nozzle losses, so it is independent of the motor's combustion
+    efficiency. Combustion efficiency instead derates the flame temperature fed
+    to the chamber-pressure solver, so the chamber-pressure path responds to it.
     """
 
-    def first_nozzle_correction(combustion_efficiency: float) -> float:
+    def first_step(
+        combustion_efficiency: float,
+    ) -> biliquid_simulation.BiliquidEngineState:
         motor, params = motor_builders.build_1kn_biliquid_engine()
         motor.combustion_efficiency = combustion_efficiency
         state = biliquid_simulation.BiliquidEngineState(
@@ -212,8 +214,10 @@ def test_nozzle_correction_factor_uses_motor_combustion_efficiency() -> None:
             other_losses=params.other_losses,
         )
         state.run_timestep(d_t=params.d_t, external_pressure=params.external_pressure)
-        return state.nozzle_correction_factor[-1]
+        return state
 
-    assert first_nozzle_correction(1.0) == pytest.approx(
-        first_nozzle_correction(0.5) * 2.0
-    )
+    full = first_step(1.0)
+    derated = first_step(0.5)
+
+    assert derated.nozzle_efficiency[-1] == pytest.approx(full.nozzle_efficiency[-1])
+    assert derated.chamber_pressure[-1] != pytest.approx(full.chamber_pressure[-1])


### PR DESCRIPTION
## What

Move combustion efficiency off the biliquid thrust coefficient and onto the chamber side, so it derates chamber pressure rather than thrust — mirroring the solid path.

- Biliquid now derates the flame temperature fed to the chamber-pressure solver via `get_effective_flame_temperature` (it passed the raw adiabatic flame temperature before), using the linear, shared mapping the solid path already ships (`T = combustion_efficiency · T₀`). Combustion efficiency no longer multiplies the thrust coefficient.
- Solid is unchanged, so there is no regression re-baseline.

## Alignment

- The lumped `nozzle_correction_factor` becomes `nozzle_efficiency` (state and result), matching solid's name and meaning now that combustion efficiency is gone from it.
- Biliquid records `divergent_loss` and `kinetics_loss` (it already computed them) and reports them under a new `NOZZLE` section, mirroring solid. The only remaining field difference is `boundary_layer_loss` / `two_phase_loss`, which are solid-only physics.

## Tests

- Rewrote the old `nozzle_correction_factor_uses_motor_combustion_efficiency` (which asserted the now-removed C_F coupling) into `test_combustion_efficiency_derates_chamber_not_thrust_coefficient`: nozzle efficiency is independent of combustion efficiency, while the chamber-pressure path responds to it.
- Full suite green (804 passed); ruff check and format clean.

## Docs

No changes needed — mass_balance.md already applies combustion efficiency as a flame-temperature derate for all engines and documents the linear convention, and nozzle_losses.md already excludes it from the nozzle efficiency. Biliquid was the only code path not following the docs.

Prerequisite for the composable nozzle loss model (#181), so biliquid keeps its combustion-efficiency derate once combustion efficiency leaves the thrust-coefficient multiplier.

Closes #225.
