### PR TITLE
Move boundary-layer loss coefficients onto BoundaryLayerLoss

### DIFF
--- a/docs/api/models/thrust_chamber.md
+++ b/docs/api/models/thrust_chamber.md
@@ -2,7 +2,7 @@
 
 Thrust chamber assembly and sub-components.
 
-- `Nozzle` — Conical nozzle defined by throat diameter, expansion ratio, convergent/divergent half-angles, and boundary-layer loss coefficients (`c_1`, `c_2`). Computes throat area and outlet diameter.
+- `Nozzle` — Conical nozzle defined by throat diameter, expansion ratio, and convergent/divergent half-angles. Computes throat area and outlet diameter.
 - `CombustionChamber` — Cylindrical casing with thermal liner. Provides internal volume from casing dimensions and liner thickness.
 - `BipropellantInjector` — Injector for biliquid engines, characterized by discharge coefficients, orifice areas, and a per-side `MassFlowModel` for the oxidizer and fuel sides. Owns the orifice mass-flow dispatch: `get_mass_flow_ox(*, tank, pressure_upstream, chamber_pressure, fluid_mass)` and `get_mass_flow_fuel(*, tank, pressure_upstream, chamber_pressure, fluid_mass)`. Feed systems delegate to these methods.
 - `MassFlowModel` — Enum selecting the orifice flow model. `SPI` (single-phase incompressible) for subcooled liquid propellants; `HEM` (homogeneous-equilibrium two-phase) for self-pressurized propellants such as nitrous oxide, where flow can choke on the two-phase sound speed.

--- a/machwave/models/nozzle_losses/components/spp1975.py
+++ b/machwave/models/nozzle_losses/components/spp1975.py
@@ -11,6 +11,8 @@ References:
 
 from __future__ import annotations
 
+import typing
+
 import numpy as np
 
 import machwave.core.conversions as conversions
@@ -18,6 +20,9 @@ import machwave.core.geometric as geometric
 import machwave.models.nozzle_losses.base as losses_base
 import machwave.models.nozzle_losses.components.base as components_base
 import machwave.models.propellants as propellants
+
+if typing.TYPE_CHECKING:
+    import machwave.simulation.states as simulation_states
 
 KINETICS_LOSS_PRESSURE_THRESHOLD_PSI = 200
 
@@ -97,10 +102,30 @@ class BoundaryLayerLoss(components_base.LossComponent):
         "throat_diameter": "nozzle.throat_diameter",
         "expansion_ratio": "nozzle.expansion_ratio",
         "time": "time",
-        "c_1": "nozzle.c_1",
-        "c_2": "nozzle.c_2",
     }
     typical_range = (0.001, 0.03)
+
+    def __init__(self, c_1: float = 0.00506, c_2: float = 0.0) -> None:
+        """
+        Initialize the boundary layer loss.
+
+        Args:
+            c_1: First boundary layer loss coefficient. Defaults to the
+                thick-walled steel-nozzle value.
+            c_2: Second boundary layer loss coefficient. Defaults to the
+                thick-walled steel-nozzle value.
+        """
+        self.c_1 = c_1
+        self.c_2 = c_2
+
+    def _parse_compute_loss_fraction_arguments(
+        self, timestep_conditions: simulation_states.TimestepConditions
+    ) -> dict[str, typing.Any]:
+        """Add the coefficients to the arguments."""
+        arguments = super()._parse_compute_loss_fraction_arguments(timestep_conditions)
+        arguments["c_1"] = self.c_1
+        arguments["c_2"] = self.c_2
+        return arguments
 
     @staticmethod
     def compute_loss_fraction(

--- a/machwave/models/thrust_chamber/nozzle.py
+++ b/machwave/models/thrust_chamber/nozzle.py
@@ -6,7 +6,7 @@ DEFAULT_SEPARATION_PRESSURE_RATIO = 0.4  # typically between 0.3 and 0.4
 
 
 class Nozzle:
-    """Converging-diverging nozzle geometry and loss coefficients."""
+    """Converging-diverging nozzle geometry."""
 
     def __init__(
         self,
@@ -15,8 +15,6 @@ class Nozzle:
         divergent_angle: float,
         convergent_angle: float,
         expansion_ratio: float,
-        c_1: float = 0.00506,
-        c_2: float = 0.0,
         discharge_coefficient: float = 1.0,
         separation_pressure_ratio: float = DEFAULT_SEPARATION_PRESSURE_RATIO,
     ) -> None:
@@ -29,28 +27,15 @@ class Nozzle:
             divergent_angle: Divergent half-angle [deg].
             convergent_angle: Convergent half-angle [deg].
             expansion_ratio: Area ratio of exit to throat.
-            c_1: Boundary-layer loss coefficient (see notes below).
-            c_2: Boundary-layer loss coefficient (see notes below).
             discharge_coefficient: Throat discharge coefficient.
             separation_pressure_ratio: Pressure ratio at which the overexpanded flow
                 separates from the nozzle wall (Summerfield criterion).
-
-        Notes:
-            Boundary-layer loss correction coefficients (ref. a015140) are used
-            in the boundary-layer percentage loss calculation to account for
-            viscous and heat-transfer effects on the nozzle walls. Typical
-            values:
-
-            - Ordinary nozzle: `c_1 = 0.003650`, `c_2 = 0.000937`.
-            - Thick-walled solid steel nozzle: `c_1 = 0.005060`, `c_2 = 0.0`.
         """
         self.inlet_diameter = inlet_diameter
         self.throat_diameter = throat_diameter
         self.divergent_angle = divergent_angle
         self.convergent_angle = convergent_angle
         self.expansion_ratio = expansion_ratio
-        self.c_1 = c_1
-        self.c_2 = c_2
         self.discharge_coefficient = discharge_coefficient
         self.separation_pressure_ratio = separation_pressure_ratio
 

--- a/tests/test_models/test_nozzle_losses/conftest.py
+++ b/tests/test_models/test_nozzle_losses/conftest.py
@@ -13,8 +13,6 @@ def nozzle() -> thrust_chamber.Nozzle:
         divergent_angle=15.0,
         convergent_angle=30.0,
         expansion_ratio=8.0,
-        c_1=0.00365,
-        c_2=0.000937,
     )
 
 

--- a/tests/test_models/test_nozzle_losses/test_components.py
+++ b/tests/test_models/test_nozzle_losses/test_components.py
@@ -39,7 +39,7 @@ def test_kinetics_loss_resolves_timestep_conditions(timestep_conditions):
 
 
 def test_boundary_layer_loss_resolves_timestep_conditions(timestep_conditions):
-    component = spp1975.BoundaryLayerLoss()
+    component = spp1975.BoundaryLayerLoss(c_1=0.00365, c_2=0.000937)
     assert component.get_loss_fraction(
         timestep_conditions
     ) == spp1975.BoundaryLayerLoss.compute_loss_fraction(
@@ -47,9 +47,15 @@ def test_boundary_layer_loss_resolves_timestep_conditions(timestep_conditions):
         throat_diameter=timestep_conditions.nozzle.throat_diameter,
         expansion_ratio=timestep_conditions.nozzle.expansion_ratio,
         time=timestep_conditions.time,
-        c_1=timestep_conditions.nozzle.c_1,
-        c_2=timestep_conditions.nozzle.c_2,
+        c_1=0.00365,
+        c_2=0.000937,
     )
+
+
+def test_boundary_layer_loss_defaults_to_thick_walled_steel_coefficients():
+    component = spp1975.BoundaryLayerLoss()
+    assert component.c_1 == pytest.approx(0.00506, rel=1e-3)
+    assert component.c_2 == pytest.approx(0.0, abs=1e-9)
 
 
 def test_two_phase_flow_loss_resolves_timestep_conditions(timestep_conditions):
@@ -262,8 +268,6 @@ def test_divergent_loss_warns_outside_typical_range(timestep_conditions):
         divergent_angle=30.0,  # ~0.067 fraction, above the 0.05 upper bound
         convergent_angle=base.convergent_angle,
         expansion_ratio=base.expansion_ratio,
-        c_1=base.c_1,
-        c_2=base.c_2,
         discharge_coefficient=base.discharge_coefficient,
         separation_pressure_ratio=base.separation_pressure_ratio,
     )
@@ -280,8 +284,6 @@ def test_divergent_loss_warns_below_typical_range(timestep_conditions):
         divergent_angle=5.0,  # ~0.0019 fraction, below the 0.0075 lower bound
         convergent_angle=base.convergent_angle,
         expansion_ratio=base.expansion_ratio,
-        c_1=base.c_1,
-        c_2=base.c_2,
         discharge_coefficient=base.discharge_coefficient,
         separation_pressure_ratio=base.separation_pressure_ratio,
     )

--- a/tests/test_models/test_nozzle_losses/test_nozzle_loss_model.py
+++ b/tests/test_models/test_nozzle_losses/test_nozzle_loss_model.py
@@ -59,7 +59,7 @@ def test_all_both_targets_reduce_to_scalar_correction(timestep_conditions):
     model = nozzle_losses.NozzleLossModel(
         [
             spp1975.KineticsLoss(),
-            spp1975.BoundaryLayerLoss(),
+            spp1975.BoundaryLayerLoss(c_1=0.00365, c_2=0.000937),
             spp1975.TwoPhaseFlowLoss(),
         ],
         mixture_type=SOLID,

--- a/tests/test_models/test_propulsion/test_nozzle.py
+++ b/tests/test_models/test_propulsion/test_nozzle.py
@@ -59,17 +59,6 @@ class TestNozzleGeometry:
     def test_stores_expansion_ratio(self, nozzle):
         assert nozzle.expansion_ratio == 4
 
-    def test_default_boundary_layer_coefficients(self, nozzle):
-        """Default c_1/c_2 are for a thick-walled steel nozzle."""
-        assert nozzle.c_1 == pytest.approx(0.00506, rel=1e-3)
-        assert nozzle.c_2 == pytest.approx(0.0, abs=1e-9)
-
-    def test_custom_boundary_layer_coefficients(self):
-        """Ordinary nozzle coefficients can be overridden."""
-        n = NozzleFactory.build(c_1=0.003650, c_2=0.000937)
-        assert n.c_1 == pytest.approx(0.003650, rel=1e-3)
-        assert n.c_2 == pytest.approx(0.000937, rel=1e-3)
-
     def test_default_discharge_coefficient(self, nozzle):
         """Throat discharge coefficient defaults to 1.0 (ideal nozzle)."""
         assert nozzle.discharge_coefficient == pytest.approx(1.0, rel=1e-9)


### PR DESCRIPTION
Closes #434.

`Nozzle` carried the boundary-layer loss coefficients `c_1` and `c_2`, which only `BoundaryLayerLoss` read (through `context.nozzle.c_1`/`c_2`). They are now constructor arguments on the component, with defaults `c_1 = 0.00506`, `c_2 = 0.0` — the thick-walled steel-nozzle values the simulations rely on today — so a correlation's empirical coefficients live with the correlation rather than on the generic nozzle geometry.

- `BoundaryLayerLoss.__init__` takes `c_1`/`c_2` and injects them into the loss computation via `_parse_compute_loss_fraction_arguments`; the coefficients are dropped from `timestep_parameter_map`.
- `Nozzle` no longer accepts or stores `c_1`/`c_2`; its docstring and the thrust-chamber API doc are updated to match.
- Behavior is unchanged: every simulation and example used the default coefficient, which the component now reproduces.

Tests updated to construct the coefficients on the component; full suite green.