### PR TITLE
Compute 3D FMM center of gravity and moment of inertia from mask moments

### DIFF
--- a/docs/theory/grain_regression.md
+++ b/docs/theory/grain_regression.md
@@ -159,7 +159,7 @@ The face map at a web distance is obtained by thresholding the regression map at
 
 ![regressed face map](../assets/theory/grain_regression/face_map.svg)
 
-The mass-property reads, volume in 3D plus the center of gravity and moment of inertia in both 2D and 3D, need only the solid (`1`) cells of this map. They take those as a plain boolean mask from `_get_solid_mask`, cheaper to build and store than the masked integer map, which together with the solid-cell indices it feeds is cached per web distance. Several of these reads share one web distance on a single timestep, so the regression map is thresholded once and every consumer reuses the result. The web distance only grows over a burn, so a single-entry cache is enough.
+The mass-property reads, volume in 3D plus the center of gravity and moment of inertia in both 2D and 3D, need only the solid (`1`) cells of this map. They take those as a plain boolean mask from `_get_solid_mask`, cheaper to build and store than the masked integer map. The 2D reads pull the solid-cell indices from that mask, while the 3D reads reduce it straight to mass-property moments, and the mask, its indices, and its moments are each cached per web distance. Several of these reads share one web distance on a single timestep, so the regression map is thresholded once and every consumer reuses the result. The web distance only grows over a burn, so a single-entry cache is enough.
 
 **Contour the burn front: [`get_contours(w)`][machwave.models.grain.fmm._2d.FMMGrainSegment2D.get_contours].**
 A closed-loop curve is traced by `get_iso_contours` in `machwave.models.grain.fmm.contours`, for a given web distance.
@@ -194,7 +194,7 @@ Since the slice count is rounded to an integer, `_compute_regression_distance` p
 
 The regression map is generated differently for 2D and 3D. 2D traces a perimeter with marching squares ([`get_contours`][machwave.models.grain.fmm._2d.FMMGrainSegment2D.get_contours], using `skimage`'s `find_contours`). 3D meshes a surface with marching cubes ([`get_burn_area_interpolator`][machwave.models.grain.fmm._3d.FMMGrainSegment3D.get_burn_area_interpolator], `skimage`'s `marching_cubes`) and takes its area directly.
 
-For volume, 3D FMM counts the solid voxels in the cached solid mask and multiplies by the volume of one voxel. The center of gravity and moment of inertia read the same cached mask and its solid-cell indices, so the per-timestep mass properties all share a single threshold of the regression map instead of rebuilding it for each read.
+For volume, 3D FMM counts the solid voxels in the cached solid mask and multiplies by the volume of one voxel. The center of gravity and moment of inertia reduce that same cached mask to its voxel-index moments: the voxel count and first moments give the centroid, and the centroid-relative second moments give the inertia tensor. Those moments come from projecting the mask onto each coordinate plane and contracting with the per-axis coordinate vectors, so no per-voxel index or coordinate array is built. Both reads share one cached set of moments per web distance, so the per-timestep mass properties all reuse a single threshold of the regression map instead of rebuilding it for each read.
 
 Since the port area in 3D varies along the grain, [`get_port_area(w, z)`][machwave.models.grain.fmm._3d.FMMGrainSegment3D.get_port_area] slices the cross-section at axial height `z` and subtracts the solid area from the outer diameter exterior.
 
@@ -240,7 +240,7 @@ flowchart TB
     SG --> BR["get_burn_area(w)"]
     R --> SM["_get_solid_mask(w)<br/>boolean threshold, cached per web"]
     SM --> VO["get_volume(w) = solid voxels × cell volume"]
-    SM --> MP["center of gravity, moment of inertia<br/>via cached solid-cell indices"]
+    SM --> MP["center of gravity, moment of inertia<br/>via cached mask moments"]
     R --> PA["get_port_area(w, z)<br/>casing − slice solid area"]
 ```
 

--- a/machwave/core/mechanics.py
+++ b/machwave/core/mechanics.py
@@ -49,6 +49,45 @@ def get_center_of_gravity(
     return np.array([z_cog, x_cog, y_cog], dtype=np.float64)
 
 
+def get_moment_of_inertia_tensor_from_central_moments(
+    central_second_moments: npt.NDArray[np.float64],
+    element_mass: float,
+) -> npt.NDArray[np.float64]:
+    """
+    Build the inertia tensor from centroid-relative second moments.
+
+    Equivalent to get_moment_of_inertia_tensor but takes the already summed second
+    moments of the elements instead of per-element coordinates, so the caller can supply
+    them without materializing one coordinate per element.
+
+    Args:
+        central_second_moments: 3x3 symmetric matrix whose entry (i, j) is the sum over
+            elements of (r_i - cog_i)(r_j - cog_j), axes ordered [x, y, z] [m^2].
+        element_mass: Mass per element [kg].
+
+    Returns:
+        3x3 symmetric inertia tensor [kg-m^2] in coordinate system [z, x, y].
+    """
+    s_xx = central_second_moments[0, 0]
+    s_yy = central_second_moments[1, 1]
+    s_zz = central_second_moments[2, 2]
+    s_xy = central_second_moments[0, 1]
+    s_xz = central_second_moments[0, 2]
+    s_yz = central_second_moments[1, 2]
+
+    Ixx = element_mass * (s_yy + s_zz)
+    Iyy = element_mass * (s_xx + s_zz)
+    Izz = element_mass * (s_xx + s_yy)
+
+    Ixy = -element_mass * s_xy
+    Ixz = -element_mass * s_xz
+    Iyz = -element_mass * s_yz
+
+    return np.array(
+        [[Izz, Ixz, Iyz], [Ixz, Ixx, Ixy], [Iyz, Ixy, Iyy]], dtype=np.float64
+    )
+
+
 def get_moment_of_inertia_tensor(
     x_coords: npt.NDArray[np.float64],
     y_coords: npt.NDArray[np.float64],
@@ -78,18 +117,16 @@ def get_moment_of_inertia_tensor(
     if not (len(x_coords) == len(y_coords) == len(z_coords)):
         raise ValueError("All coordinate arrays must have the same length")
 
-    x_sq = x_coords**2
-    y_sq = y_coords**2
-    z_sq = z_coords**2
+    s_xx = np.sum(x_coords * x_coords)
+    s_yy = np.sum(y_coords * y_coords)
+    s_zz = np.sum(z_coords * z_coords)
+    s_xy = np.sum(x_coords * y_coords)
+    s_xz = np.sum(x_coords * z_coords)
+    s_yz = np.sum(y_coords * z_coords)
 
-    Ixx = element_mass * np.sum(y_sq + z_sq)
-    Iyy = element_mass * np.sum(x_sq + z_sq)
-    Izz = element_mass * np.sum(x_sq + y_sq)
-
-    Ixy = -element_mass * np.sum(x_coords * y_coords)
-    Ixz = -element_mass * np.sum(x_coords * z_coords)
-    Iyz = -element_mass * np.sum(y_coords * z_coords)
-
-    return np.array(
-        [[Izz, Ixz, Iyz], [Ixz, Ixx, Ixy], [Iyz, Ixy, Iyy]], dtype=np.float64
+    central_second_moments = np.array(
+        [[s_xx, s_xy, s_xz], [s_xy, s_yy, s_yz], [s_xz, s_yz, s_zz]], dtype=np.float64
+    )
+    return get_moment_of_inertia_tensor_from_central_moments(
+        central_second_moments, element_mass
     )

--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -29,6 +29,13 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         density_ratio: float = 1.0,
     ) -> None:
         self.burn_area_interpolator: Callable[[float], float] | None = None
+
+        # Cache center of gravity and moment of inertia shared moments per web distance
+        self._mask_moments_web: float | None = None
+        self._mask_moments: tuple[NDArray[np.float64], NDArray[np.float64]] | None = (
+            None
+        )
+
         super().__init__(
             length=length,
             outer_diameter=outer_diameter,
@@ -278,52 +285,83 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
                 "segment's web thickness."
             )
 
-    def _find_solid_material_indices(
+    def _solid_mask_moments(
         self, web_distance: float
-    ) -> tuple[NDArray[np.int_], NDArray[np.int_], NDArray[np.int_]]:
-        """
-        Get indices of active material at given web distance.
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]] | None:
+        """Centroid and second moments of the solid voxels, memoized per web."""
+        if self._mask_moments_web != web_distance:
+            self._mask_moments = self._compute_solid_mask_moments(web_distance)
+            self._mask_moments_web = web_distance
+        return self._mask_moments
 
-        Args:
-            web_distance: Web distance traveled [m].
+    def _compute_solid_mask_moments(
+        self, web_distance: float
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]] | None:
+        """
+        Centroid and centered second moments of the solid voxels.
+
+        Reduces the cached boolean solid mask onto each coordinate plane and
+        takes the moments as dot products with the per-axis coordinate vectors,
+        so the per-voxel index arrays and conversions are never built.
+        Coordinates match the index path: x and y are centered on the grid, z is
+        measured from the port end.
 
         Returns:
-            Tuple of (z_indices, y_indices, x_indices) for active material.
-
-        Raises:
-            GrainGeometryError: If no active material is found.
+            Tuple of the centroid [z, x, y] [m] and the 3x3 symmetric matrix of
+            summed (r_i - cog_i)(r_j - cog_j) over the voxels, axes ordered
+            [x, y, z] [m^2]. None when no solid voxels remain.
         """
-        z_indices, y_indices, x_indices = self._get_solid_indices(web_distance)
+        mask = self._get_solid_mask(web_distance)
+        count = int(np.count_nonzero(mask))
+        if count == 0:
+            return None
 
-        if len(x_indices) == 0:
-            raise grain.GrainGeometryError(
-                "No active material found at the given web distance."
-            )
+        axial_count, y_count, x_count = mask.shape
+        grid_center = self.grid_resolution / 2
+        x = np.asarray(
+            self.cells_to_meters(np.arange(x_count) - grid_center), dtype=np.float64
+        )
+        y = np.asarray(
+            self.cells_to_meters(np.arange(y_count) - grid_center), dtype=np.float64
+        )
+        z = np.asarray(self.cells_to_meters(np.arange(axial_count)), dtype=np.float64)
 
-        return z_indices, y_indices, x_indices
+        # Voxel counts projected onto each coordinate plane.
+        projection_yx = mask.sum(axis=0)  # over z -> (y, x)
+        projection_zx = mask.sum(axis=1)  # over y -> (z, x)
+        projection_zy = mask.sum(axis=2)  # over x -> (z, y)
 
-    def _indices_to_grid_coordinates(
-        self,
-        z_indices: NDArray[np.int_],
-        y_indices: NDArray[np.int_],
-        x_indices: NDArray[np.int_],
-    ) -> tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]:
-        """
-        Convert indices to normalized coordinates centered at origin.
+        count_x = projection_yx.sum(axis=0)
+        count_y = projection_yx.sum(axis=1)
+        count_z = projection_zx.sum(axis=1)
 
-        Args:
-            z_indices: Z-axis (axial) indices from face map.
-            y_indices: Y-axis indices from face map.
-            x_indices: X-axis indices from face map.
+        # First moments: sum of each physical coordinate over the voxels.
+        sum_x = count_x @ x
+        sum_y = count_y @ y
+        sum_z = count_z @ z
+        centroid = np.array([sum_z, sum_x, sum_y], dtype=np.float64) / count
 
-        Returns:
-            Tuple of (x_grid, y_grid, z_grid) in normalized units.
-        """
-        grid_center_index = self.grid_resolution / 2
-        x_grid = (x_indices - grid_center_index).astype(np.float64)
-        y_grid = (y_indices - grid_center_index).astype(np.float64)
-        z_grid = z_indices.astype(np.float64)
-        return x_grid, y_grid, z_grid
+        # Second moments about the origin; the cross terms need the planar
+        # projections because their two axes are coupled.
+        sum_xx = count_x @ (x * x)
+        sum_yy = count_y @ (y * y)
+        sum_zz = count_z @ (z * z)
+        sum_xy = y @ projection_yx @ x
+        sum_xz = z @ projection_zx @ x
+        sum_yz = z @ projection_zy @ y
+
+        # Shift to the centroid (parallel-axis theorem on the summed moments).
+        central = np.array(
+            [
+                [sum_xx, sum_xy, sum_xz],
+                [sum_xy, sum_yy, sum_yz],
+                [sum_xz, sum_yz, sum_zz],
+            ],
+            dtype=np.float64,
+        )
+        first = np.array([sum_x, sum_y, sum_z], dtype=np.float64)
+        central -= np.outer(first, first) / count
+        return centroid, central
 
     def get_center_of_gravity(self, web_distance: float) -> NDArray[np.float64]:
         """
@@ -340,21 +378,14 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
                 if no active material is found.
         """
         self._validate_web_distance(web_distance)
-        z_indices, y_indices, x_indices = self._find_solid_material_indices(
-            web_distance
-        )
-        x_grid, y_grid, z_grid = self._indices_to_grid_coordinates(
-            z_indices, y_indices, x_indices
-        )
-
-        # Convert normalized coordinates into physical meters
-        x_denormalized = np.asarray(self.cells_to_meters(x_grid), dtype=np.float64)
-        y_denormalized = np.asarray(self.cells_to_meters(y_grid), dtype=np.float64)
-        z_denormalized = np.asarray(self.cells_to_meters(z_grid), dtype=np.float64)
-
-        return mechanics.get_center_of_gravity(
-            x_denormalized, y_denormalized, z_denormalized
-        )
+        moments = self._solid_mask_moments(web_distance)
+        if moments is None:
+            raise grain.GrainGeometryError(
+                "No active material found at the given web distance."
+            )
+        centroid, _ = moments
+        # Copy so callers cannot mutate the per-web cached array.
+        return centroid.copy()
 
     def get_moment_of_inertia(
         self, ideal_density: float, web_distance: float = 0.0
@@ -374,34 +405,14 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
                 if no active material is found.
         """
         self._validate_web_distance(web_distance)
-        z_indices, y_indices, x_indices = self._find_solid_material_indices(
-            web_distance
-        )
-        x_grid, y_grid, z_grid = self._indices_to_grid_coordinates(
-            z_indices, y_indices, x_indices
-        )
+        moments = self._solid_mask_moments(web_distance)
+        if moments is None:
+            raise grain.GrainGeometryError(
+                "No active material found at the given web distance."
+            )
+        _, central_second_moments = moments
 
-        # Convert to meters
-        x_denormalized = np.asarray(self.cells_to_meters(x_grid), dtype=np.float64)
-        y_denormalized = np.asarray(self.cells_to_meters(y_grid), dtype=np.float64)
-        z_denormalized = np.asarray(self.cells_to_meters(z_grid), dtype=np.float64)
-
-        # CoG from the same coordinates (matches get_center_of_gravity, avoids
-        # re-extracting indices for this web distance)
-        center_of_gravity = mechanics.get_center_of_gravity(
-            x_denormalized, y_denormalized, z_denormalized
-        )
-
-        # Coordinates relative to the center of gravity
-        x_relative = x_denormalized - center_of_gravity[1]
-        y_relative = y_denormalized - center_of_gravity[2]
-        z_relative = z_denormalized - center_of_gravity[0]
-
-        # Calculate element mass
-        element_volume = self.get_voxel_volume()
-        element_mass = element_volume * ideal_density * self.density_ratio
-
-        # Use core function to compute inertia tensor
-        return mechanics.get_moment_of_inertia_tensor(
-            x_relative, y_relative, z_relative, element_mass
+        element_mass = self.get_voxel_volume() * ideal_density * self.density_ratio
+        return mechanics.get_moment_of_inertia_tensor_from_central_moments(
+            central_second_moments, element_mass
         )

--- a/tests/test_core/test_mechanics.py
+++ b/tests/test_core/test_mechanics.py
@@ -164,3 +164,46 @@ class TestGetMomentOfInertiaTensor:
         assert result[1, 1] == pytest.approx(2.0)  # Ixx_physical in [z,x,y] tensor
         assert result[2, 2] == pytest.approx(2.0)  # Iyy_physical
         assert result[0, 0] == pytest.approx(4.0)  # Izz_physical
+
+
+class TestGetMomentOfInertiaTensorFromCentralMoments:
+    def test_matches_per_element_path(self):
+        """The moment form reproduces the per-element tensor for any cloud."""
+        rng = np.random.default_rng(0)
+        x, y, z = rng.normal(size=(3, 50))
+        # Center on the cloud so the per-element path takes relative coordinates.
+        x, y, z = x - x.mean(), y - y.mean(), z - z.mean()
+        mass = 0.3
+
+        per_element = core_mechanics.get_moment_of_inertia_tensor(x, y, z, mass)
+
+        central = np.array(
+            [
+                [np.sum(x * x), np.sum(x * y), np.sum(x * z)],
+                [np.sum(x * y), np.sum(y * y), np.sum(y * z)],
+                [np.sum(x * z), np.sum(y * z), np.sum(z * z)],
+            ]
+        )
+        from_moments = core_mechanics.get_moment_of_inertia_tensor_from_central_moments(
+            central, mass
+        )
+        np.testing.assert_allclose(from_moments, per_element)
+
+    def test_returns_symmetric_3x3(self):
+        central = np.array([[2.0, 0.5, -0.3], [0.5, 1.0, 0.2], [-0.3, 0.2, 3.0]])
+        result = core_mechanics.get_moment_of_inertia_tensor_from_central_moments(
+            central, element_mass=1.0
+        )
+        assert result.shape == (3, 3)
+        assert result.dtype == np.float64
+        np.testing.assert_allclose(result, result.T)
+
+    def test_products_of_inertia_are_negated_cross_moments(self):
+        """Off-diagonals equal -mass * cross moment, axes [z, x, y]."""
+        central = np.zeros((3, 3))
+        central[0, 1] = central[1, 0] = 4.0  # x-y cross moment
+        result = core_mechanics.get_moment_of_inertia_tensor_from_central_moments(
+            central, element_mass=0.5
+        )
+        assert result[1, 2] == pytest.approx(-2.0)  # Ixy slot in [z, x, y]
+        assert result[2, 1] == pytest.approx(-2.0)


### PR DESCRIPTION
Closes #414.

## What

The dominant per-timestep cost in the 3D fast marching method path was the `np.where` materialization of solid-cell indices in `_get_solid_indices`, consumed by `get_center_of_gravity` and `get_moment_of_inertia`, plus the per-cell `cells_to_meters` conversions each then ran over those index arrays.

This computes the centroid and inertia tensor directly as moments over the cached boolean solid mask. The mask is reduced onto each coordinate plane once (`mask.sum(axis=...)`), and the first and second moments follow as dot products with the per-axis coordinate vectors, so no per-voxel index or coordinate array is ever built. The cross terms use the planar projections because their two axes are coupled; the diagonals come from the marginals; the moments are shifted to the centroid with the parallel-axis identity.

The shared moments are memoized per web distance, since the center of gravity and moment of inertia are read at the same web distance each timestep.

`get_moment_of_inertia_tensor_from_central_moments` is added to `core.mechanics`, and the per-element `get_moment_of_inertia_tensor` now delegates to it, keeping the inertia tensor layout in one place.

The 2D path is unchanged and still uses the solid-cell indices (`base._get_solid_indices` is kept for it).

## Correctness

Outputs match the index-based path on master to machine precision, measured across a CAD-validated finocyl, an axially offset finocyl, and a conical segment at six web fractions each:

| Quantity | max abs delta | max rel delta |
|---|---|---|
| Center of gravity | 5.6e-17 m | 3.6e-16 |
| Moment of inertia | 2.4e-17 kg·m² | 6.1e-15 |
| Volume | 0 | identical |

Gated on the existing `test_fmm3d_cog`, `test_fmm3d_moi`, and `test_finocyl_solidworks` suites staying within tolerance. All grain/core/motor tests pass; three tests are added for the new mechanics function (including equivalence with the per-element path on an asymmetric point cloud).

## Performance

Combined center-of-gravity + moment-of-inertia per timestep (best of 3, sweeping web distances like a real burn):

| Geometry | master | this branch | speedup |
|---|---|---|---|
| finocyl (300×100×100) | 13.9 ms/step | 3.5 ms/step | 3.9× |
| conical (250×100×100) | 11.0 ms/step | 2.9 ms/step | 3.8× |

End-to-end finocyl example simulation (3517 timesteps, identical trajectory): **66.1 s → 23.9 s (2.76×)**.

Builds on #412.