### PR TITLE
Remove the unused pressure override from Tank.get_density

### DIFF
--- a/machwave/models/feed_systems/tank.py
+++ b/machwave/models/feed_systems/tank.py
@@ -111,13 +111,12 @@ class Tank:
         Return the tank pressure [Pa] for a given fluid mass.
 
         1) An empty tank has zero pressure.
-        2) If the fluid mass exceeds the mass of saturated vapor that fills the
-            tank, the tank is partially liquid and the pressure is the saturation
-            pressure.
-        3) Otherwise, the tank is all sub-saturated vapor and the pressure
-            follows the real-gas equation of state at the bulk density. This
-            matches the saturation pressure at the phase boundary, so pressure
-            stays continuous as the tank crosses out of the two-phase regime.
+        2) If the fluid mass exceeds the mass of saturated vapor that fills the tank,
+            the tank is partially liquid and the pressure is the saturation pressure.
+        3) Otherwise, the tank is all sub-saturated vapor and the pressure follows the
+            real-gas equation of state at the bulk density. This matches the saturation
+            pressure at the phase boundary, so pressure stays continuous as the tank
+            crosses out of the two-phase regime.
 
         Args:
             fluid_mass: Current total mass of fluid in the tank [kg].
@@ -144,9 +143,9 @@ class Tank:
         Return fluid density [kg/m^3] for a given fluid mass.
 
         1) An empty tank has zero density.
-        2) Otherwise the fill state fixes the density: a partially liquid tank
-            returns the saturated liquid density (the feed system pulls liquid
-            from the bottom), and an all-vapor tank returns the bulk density.
+        2) Otherwise the fill state fixes the density: a partially liquid tank returns
+            the saturated liquid density (the feed system pulls liquid from the bottom),
+            and an all-vapor tank returns the bulk density.
 
         Args:
             fluid_mass: Current total mass of fluid in the tank [kg].

--- a/machwave/models/feed_systems/tank.py
+++ b/machwave/models/feed_systems/tank.py
@@ -61,8 +61,6 @@ class Tank:
         self.saturated_vapor_density = self._coolprop.get_saturated_vapor_density(
             temperature
         )
-        # Single phase density at the tank temperature, memoized per pressure.
-        self._density_by_pressure: dict[float, float | None] = {}
         # Vapor pressure at the tank temperature, memoized per fluid mass.
         self._pressure_by_mass: dict[float, float] = {}
 
@@ -141,21 +139,17 @@ class Tank:
             )
         return self._pressure_by_mass[fluid_mass]
 
-    def get_density(self, fluid_mass: float, pressure: float | None = None) -> float:
+    def get_density(self, fluid_mass: float) -> float:
         """
         Return fluid density [kg/m^3] for a given fluid mass.
 
         1) An empty tank has zero density.
-        2) With a pressure override the single-phase density follows directly
-            from temperature and pressure.
-        3) Otherwise the fill state fixes the density: a partially liquid tank
+        2) Otherwise the fill state fixes the density: a partially liquid tank
             returns the saturated liquid density (the feed system pulls liquid
             from the bottom), and an all-vapor tank returns the bulk density.
 
         Args:
             fluid_mass: Current total mass of fluid in the tank [kg].
-            pressure: Tank pressure override [Pa], e.g. for a piston-pressurized
-                stacked-tank system. Defaults to the tank's own pressure.
 
         Returns:
             Fluid density [kg/m^3].
@@ -163,29 +157,6 @@ class Tank:
         if fluid_mass <= 0:
             return 0.0
 
-        if pressure is not None:
-            single_phase_density = self._single_phase_density(pressure)
-            if single_phase_density is not None:
-                return single_phase_density
-
         if fluid_mass > self.saturated_vapor_density * self.volume:
             return self.saturated_liquid_density
         return fluid_mass / self.volume
-
-    def _single_phase_density(self, pressure: float) -> float | None:
-        """
-        Return the memoized single-phase density [kg/m^3] at the tank temperature.
-
-        Returns None when the (temperature, pressure) lookup is undefined at the
-        saturation boundary, which the caller resolves from the fill state.
-        """
-        if pressure not in self._density_by_pressure:
-            try:
-                self._density_by_pressure[pressure] = (
-                    self._coolprop.get_density_at_temperature_pressure(
-                        self.temperature, pressure
-                    )
-                )
-            except ValueError:
-                self._density_by_pressure[pressure] = None
-        return self._density_by_pressure[pressure]


### PR DESCRIPTION
Closes #324. Also closes #323.

The `pressure` parameter of `Tank.get_density` was never supplied by any caller. The only consumer, `BipropellantInjector._get_mass_flow`, calls `get_density(fluid_mass)`, and the `StackedTankPressureFedFeedSystem` never threads a piston pressure through to it, so the advertised piston-pressurized stacked-tank use was never wired.

I removed the parameter rather than wiring it up: the override only yields a compressed-liquid density correction of well under a percent for a near-incompressible liquid, and its single-phase density lookup was memoized in a dictionary keyed on a continuously-varying pressure float (effectively no cache hits, unbounded growth). Dropping it removes the `_single_phase_density` helper and that cache.

Removing `_single_phase_density` also resolves #323: the broad `except ValueError` that silently routed out-of-range pressure/temperature lookups into the two-phase fallback lived entirely in that helper, so it is gone. No `try`/`except` remains in `tank.py`.

Existing feed-system and injector tests pass unchanged; no test exercised the override.