### PR TITLE
Validate physical preconditions on public-API inputs

### DIFF
--- a/machwave/models/thrust_chamber/base.py
+++ b/machwave/models/thrust_chamber/base.py
@@ -38,6 +38,25 @@ class ThrustChamber(abc.ABC):
             else None
         )
 
+        self._validate()
+
+    def _validate(self) -> None:
+        """
+        Validate the assembly inputs and that the components fit together.
+
+        Raises:
+            ValueError: If the dry mass is non-positive or the nozzle inlet does
+                not fit within the combustion chamber bore.
+        """
+        if self.dry_mass <= 0.0:
+            raise ValueError(f"dry_mass must be strictly positive, got {self.dry_mass}")
+        if self.nozzle.inlet_diameter > self.combustion_chamber.casing_inner_diameter:
+            raise ValueError(
+                f"nozzle inlet_diameter ({self.nozzle.inlet_diameter}) does not fit "
+                "within combustion chamber casing_inner_diameter "
+                f"({self.combustion_chamber.casing_inner_diameter})"
+            )
+
 
 class SolidMotorThrustChamber(ThrustChamber):
     """Thrust chamber assembly specialized for solid rocket motors."""
@@ -68,6 +87,12 @@ class SolidMotorThrustChamber(ThrustChamber):
             nozzle, combustion_chamber, dry_mass, center_of_gravity_coordinate
         )
         self.nozzle_exit_to_grain_port_distance = nozzle_exit_to_grain_port_distance
+
+        if nozzle_exit_to_grain_port_distance < 0.0:
+            raise ValueError(
+                "nozzle_exit_to_grain_port_distance must be non-negative, got "
+                f"{nozzle_exit_to_grain_port_distance}"
+            )
 
 
 class BiliquidEngineThrustChamber(ThrustChamber):

--- a/machwave/models/thrust_chamber/combustion_chamber.py
+++ b/machwave/models/thrust_chamber/combustion_chamber.py
@@ -27,6 +27,40 @@ class CombustionChamber:
         self.internal_length = internal_length
         self.thermal_liner_thickness = thermal_liner_thickness
 
+        self._validate()
+
+    def _validate(self) -> None:
+        """
+        Validate the combustion chamber geometry.
+
+        Raises:
+            ValueError: If any field is outside its valid physical range.
+        """
+        if self.casing_inner_diameter <= 0.0:
+            raise ValueError(
+                "casing_inner_diameter must be strictly positive, got "
+                f"{self.casing_inner_diameter}"
+            )
+        if self.casing_outer_diameter <= self.casing_inner_diameter:
+            raise ValueError(
+                f"casing_outer_diameter ({self.casing_outer_diameter}) must be larger "
+                f"than casing_inner_diameter ({self.casing_inner_diameter})"
+            )
+        if self.internal_length <= 0.0:
+            raise ValueError(
+                f"internal_length must be strictly positive, got {self.internal_length}"
+            )
+        if self.thermal_liner_thickness < 0.0:
+            raise ValueError(
+                "thermal_liner_thickness must be non-negative, got "
+                f"{self.thermal_liner_thickness}"
+            )
+        if self.thermal_liner_thickness >= 0.5 * self.casing_inner_diameter:
+            raise ValueError(
+                f"thermal_liner_thickness ({self.thermal_liner_thickness}) leaves no "
+                f"open bore for casing_inner_diameter ({self.casing_inner_diameter})"
+            )
+
     @property
     def inner_diameter(self) -> float:
         """Inner diameter of the combustion chamber [m]."""

--- a/machwave/models/thrust_chamber/injector.py
+++ b/machwave/models/thrust_chamber/injector.py
@@ -61,6 +61,32 @@ class BipropellantInjector:
         self.mass_flow_model_fuel = MassFlowModel(mass_flow_model_fuel)
         self.mass_flow_model_oxidizer = MassFlowModel(mass_flow_model_oxidizer)
 
+        self._validate()
+
+    def _validate(self) -> None:
+        """
+        Validate the injector inputs.
+
+        Raises:
+            ValueError: If any field is outside its valid physical range.
+        """
+        if self.area_fuel <= 0.0:
+            raise ValueError(
+                f"area_fuel must be strictly positive, got {self.area_fuel}"
+            )
+        if self.area_ox <= 0.0:
+            raise ValueError(f"area_ox must be strictly positive, got {self.area_ox}")
+        if not 0.0 < self.discharge_coefficient_fuel <= 1.0:
+            raise ValueError(
+                "discharge_coefficient_fuel must be in (0, 1], got "
+                f"{self.discharge_coefficient_fuel}"
+            )
+        if not 0.0 < self.discharge_coefficient_oxidizer <= 1.0:
+            raise ValueError(
+                "discharge_coefficient_oxidizer must be in (0, 1], got "
+                f"{self.discharge_coefficient_oxidizer}"
+            )
+
     def get_mass_flow_fuel(
         self,
         *,

--- a/machwave/models/thrust_chamber/nozzle.py
+++ b/machwave/models/thrust_chamber/nozzle.py
@@ -39,6 +39,51 @@ class Nozzle:
         self.discharge_coefficient = discharge_coefficient
         self.separation_pressure_ratio = separation_pressure_ratio
 
+        self._validate()
+
+    def _validate(self) -> None:
+        """
+        Validate the nozzle geometry.
+
+        Raises:
+            ValueError: If any field is outside its valid physical range.
+        """
+        if self.inlet_diameter <= 0.0:
+            raise ValueError(
+                f"inlet_diameter must be strictly positive, got {self.inlet_diameter}"
+            )
+        if self.throat_diameter <= 0.0:
+            raise ValueError(
+                f"throat_diameter must be strictly positive, got {self.throat_diameter}"
+            )
+        if self.throat_diameter >= self.inlet_diameter:
+            raise ValueError(
+                f"throat_diameter ({self.throat_diameter}) must be smaller than "
+                f"inlet_diameter ({self.inlet_diameter})"
+            )
+        if self.expansion_ratio <= 1.0:
+            raise ValueError(
+                f"expansion_ratio must be greater than 1, got {self.expansion_ratio}"
+            )
+        if not 0.0 < self.discharge_coefficient <= 1.0:
+            raise ValueError(
+                "discharge_coefficient must be in (0, 1], got "
+                f"{self.discharge_coefficient}"
+            )
+        if not 0.0 < self.separation_pressure_ratio < 1.0:
+            raise ValueError(
+                "separation_pressure_ratio must be in (0, 1), got "
+                f"{self.separation_pressure_ratio}"
+            )
+        if not 0.0 < self.divergent_angle < 90.0:
+            raise ValueError(
+                f"divergent_angle must be in (0, 90) deg, got {self.divergent_angle}"
+            )
+        if not 0.0 < self.convergent_angle < 90.0:
+            raise ValueError(
+                f"convergent_angle must be in (0, 90) deg, got {self.convergent_angle}"
+            )
+
     @property
     def outlet_diameter(self) -> float:
         """Return the nozzle exit diameter [m]."""

--- a/machwave/simulation/base.py
+++ b/machwave/simulation/base.py
@@ -6,6 +6,9 @@ import machwave.simulation.results as simulation_results
 import machwave.simulation.solid.states as solid_states
 import machwave.simulation.states as simulation_states
 
+MAX_TIME_STEP = 0.01  # s
+SEA_LEVEL_PRESSURE = 101_325.0  # Pa
+
 
 @dataclass
 class InternalBallisticsSimulationParams:
@@ -13,14 +16,35 @@ class InternalBallisticsSimulationParams:
     Parameters for an internal ballistics simulation.
 
     Attributes:
-        d_t: Time step.
-        igniter_pressure: Igniter pressure.
-        external_pressure: External pressure.
+        d_t: Time step [s].
+        igniter_pressure: Igniter pressure [Pa].
+        external_pressure: External pressure [Pa].
     """
 
     d_t: float
     igniter_pressure: float
     external_pressure: float
+
+    def __post_init__(self) -> None:
+        """
+        Validate the simulation parameters.
+
+        Raises:
+            ValueError: If any field is outside its valid physical range.
+        """
+        if not 0.0 < self.d_t <= MAX_TIME_STEP:
+            raise ValueError(f"d_t must be in (0, {MAX_TIME_STEP}] s, got {self.d_t}")
+
+        if self.igniter_pressure < SEA_LEVEL_PRESSURE:
+            raise ValueError(
+                f"igniter_pressure must be at least {SEA_LEVEL_PRESSURE} Pa, got "
+                f"{self.igniter_pressure}"
+            )
+
+        if self.external_pressure < 0.0:
+            raise ValueError(
+                f"external_pressure must be non-negative, got {self.external_pressure}"
+            )
 
 
 class InternalBallisticsSimulation:

--- a/tests/test_models/test_propulsion/test_combustion_chamber.py
+++ b/tests/test_models/test_propulsion/test_combustion_chamber.py
@@ -1,0 +1,35 @@
+import pytest
+
+from tests.factories import CombustionChamberFactory
+
+
+class TestCombustionChamberValidation:
+    @pytest.mark.parametrize("casing_inner_diameter", [0.0, -1e-3])
+    def test_non_positive_casing_inner_diameter(self, casing_inner_diameter):
+        with pytest.raises(ValueError, match="casing_inner_diameter"):
+            CombustionChamberFactory.build(casing_inner_diameter=casing_inner_diameter)
+
+    @pytest.mark.parametrize("casing_outer_diameter", [70e-3, 60e-3])
+    def test_outer_not_larger_than_inner(self, casing_outer_diameter):
+        with pytest.raises(ValueError, match="casing_outer_diameter"):
+            CombustionChamberFactory.build(
+                casing_inner_diameter=70e-3,
+                casing_outer_diameter=casing_outer_diameter,
+            )
+
+    @pytest.mark.parametrize("internal_length", [0.0, -0.1])
+    def test_non_positive_internal_length(self, internal_length):
+        with pytest.raises(ValueError, match="internal_length"):
+            CombustionChamberFactory.build(internal_length=internal_length)
+
+    def test_negative_liner_thickness(self):
+        with pytest.raises(ValueError, match="thermal_liner_thickness"):
+            CombustionChamberFactory.build(thermal_liner_thickness=-1e-3)
+
+    @pytest.mark.parametrize("thermal_liner_thickness", [35e-3, 40e-3])
+    def test_liner_leaves_no_open_bore(self, thermal_liner_thickness):
+        with pytest.raises(ValueError, match="open bore"):
+            CombustionChamberFactory.build(
+                casing_inner_diameter=70e-3,
+                thermal_liner_thickness=thermal_liner_thickness,
+            )

--- a/tests/test_models/test_propulsion/test_injector.py
+++ b/tests/test_models/test_propulsion/test_injector.py
@@ -56,6 +56,34 @@ class TestBipropellantInjectorInstantiation:
             BipropellantInjectorFactory.build(mass_flow_model_fuel="foo")
 
 
+class TestBipropellantInjectorValidation:
+    @pytest.mark.parametrize("area_fuel", [0.0, -1e-6])
+    def test_non_positive_fuel_area(self, area_fuel):
+        with pytest.raises(ValueError, match="area_fuel"):
+            BipropellantInjectorFactory.build(area_fuel=area_fuel)
+
+    @pytest.mark.parametrize("area_ox", [0.0, -1e-6])
+    def test_non_positive_oxidizer_area(self, area_ox):
+        with pytest.raises(ValueError, match="area_ox"):
+            BipropellantInjectorFactory.build(area_ox=area_ox)
+
+    @pytest.mark.parametrize("discharge_coefficient_fuel", [0.0, -0.1, 1.2])
+    def test_fuel_discharge_coefficient_out_of_range(self, discharge_coefficient_fuel):
+        with pytest.raises(ValueError, match="discharge_coefficient_fuel"):
+            BipropellantInjectorFactory.build(
+                discharge_coefficient_fuel=discharge_coefficient_fuel
+            )
+
+    @pytest.mark.parametrize("discharge_coefficient_oxidizer", [0.0, -0.1, 1.2])
+    def test_oxidizer_discharge_coefficient_out_of_range(
+        self, discharge_coefficient_oxidizer
+    ):
+        with pytest.raises(ValueError, match="discharge_coefficient_oxidizer"):
+            BipropellantInjectorFactory.build(
+                discharge_coefficient_oxidizer=discharge_coefficient_oxidizer
+            )
+
+
 class TestBipropellantInjectorMassFlow:
     def test_hem_predicts_lower_oxidizer_flow_than_spi_for_saturated_n2o(self):
         """For saturated N2O, HEM under-predicts SPI."""

--- a/tests/test_models/test_propulsion/test_nozzle.py
+++ b/tests/test_models/test_propulsion/test_nozzle.py
@@ -79,3 +79,45 @@ class TestNozzleGeometry:
         """Separation pressure ratio can be overridden."""
         n = NozzleFactory.build(separation_pressure_ratio=0.35)
         assert n.separation_pressure_ratio == pytest.approx(0.35, rel=1e-9)
+
+
+class TestNozzleValidation:
+    @pytest.mark.parametrize("inlet_diameter", [0.0, -1e-3])
+    def test_non_positive_inlet_diameter(self, inlet_diameter):
+        with pytest.raises(ValueError, match="inlet_diameter"):
+            NozzleFactory.build(inlet_diameter=inlet_diameter)
+
+    @pytest.mark.parametrize("throat_diameter", [0.0, -1e-3])
+    def test_non_positive_throat_diameter(self, throat_diameter):
+        with pytest.raises(ValueError, match="throat_diameter"):
+            NozzleFactory.build(throat_diameter=throat_diameter)
+
+    @pytest.mark.parametrize("throat_diameter", [25e-3, 30e-3])
+    def test_throat_not_smaller_than_inlet(self, throat_diameter):
+        with pytest.raises(ValueError, match="smaller than"):
+            NozzleFactory.build(inlet_diameter=25e-3, throat_diameter=throat_diameter)
+
+    @pytest.mark.parametrize("expansion_ratio", [1.0, 0.5, -1.0])
+    def test_expansion_ratio_not_above_one(self, expansion_ratio):
+        with pytest.raises(ValueError, match="expansion_ratio"):
+            NozzleFactory.build(expansion_ratio=expansion_ratio)
+
+    @pytest.mark.parametrize("discharge_coefficient", [0.0, -0.1, 1.5])
+    def test_discharge_coefficient_out_of_range(self, discharge_coefficient):
+        with pytest.raises(ValueError, match="discharge_coefficient"):
+            NozzleFactory.build(discharge_coefficient=discharge_coefficient)
+
+    @pytest.mark.parametrize("separation_pressure_ratio", [0.0, -0.1, 1.0, 1.5])
+    def test_separation_pressure_ratio_out_of_range(self, separation_pressure_ratio):
+        with pytest.raises(ValueError, match="separation_pressure_ratio"):
+            NozzleFactory.build(separation_pressure_ratio=separation_pressure_ratio)
+
+    @pytest.mark.parametrize("divergent_angle", [0, -5, 90, 120])
+    def test_divergent_angle_out_of_range(self, divergent_angle):
+        with pytest.raises(ValueError, match="divergent_angle"):
+            NozzleFactory.build(divergent_angle=divergent_angle)
+
+    @pytest.mark.parametrize("convergent_angle", [0, -5, 90, 120])
+    def test_convergent_angle_out_of_range(self, convergent_angle):
+        with pytest.raises(ValueError, match="convergent_angle"):
+            NozzleFactory.build(convergent_angle=convergent_angle)

--- a/tests/test_models/test_propulsion/test_thrust_chamber.py
+++ b/tests/test_models/test_propulsion/test_thrust_chamber.py
@@ -1,3 +1,42 @@
+import pytest
+
+from tests.factories import (
+    CombustionChamberFactory,
+    NozzleFactory,
+    SolidMotorThrustChamberFactory,
+)
+
+
+class TestThrustChamberValidation:
+    @pytest.mark.parametrize("dry_mass", [0.0, -1.0])
+    def test_non_positive_dry_mass(self, dry_mass):
+        with pytest.raises(ValueError, match="dry_mass"):
+            SolidMotorThrustChamberFactory.build(dry_mass=dry_mass)
+
+    @pytest.mark.parametrize("inlet_diameter", [72e-3, 90e-3])
+    def test_nozzle_inlet_larger_than_casing_bore(self, inlet_diameter):
+        # Default chamber casing_inner_diameter is 70 mm.
+        oversized_nozzle = NozzleFactory.build(inlet_diameter=inlet_diameter)
+        with pytest.raises(ValueError, match="does not fit"):
+            SolidMotorThrustChamberFactory.build(nozzle=oversized_nozzle)
+
+    def test_nozzle_inlet_flush_with_casing_bore_is_allowed(self):
+        """A nozzle inlet equal to the casing bore fits (flush mounting)."""
+        nozzle = NozzleFactory.build(inlet_diameter=70e-3)
+        chamber = CombustionChamberFactory.build(casing_inner_diameter=70e-3)
+        thrust_chamber = SolidMotorThrustChamberFactory.build(
+            nozzle=nozzle, combustion_chamber=chamber
+        )
+        assert thrust_chamber.nozzle.inlet_diameter == pytest.approx(70e-3)
+
+    @pytest.mark.parametrize("distance", [-0.01, -1.0])
+    def test_negative_grain_port_distance(self, distance):
+        with pytest.raises(ValueError, match="nozzle_exit_to_grain_port_distance"):
+            SolidMotorThrustChamberFactory.build(
+                nozzle_exit_to_grain_port_distance=distance
+            )
+
+
 def _test_combustion_chamber_properties(combustion_chamber_olympus):
     """
     Generic test function for CombustionChamber and its descendents.

--- a/tests/test_simulations/test_simulation_params.py
+++ b/tests/test_simulations/test_simulation_params.py
@@ -1,0 +1,38 @@
+import pytest
+
+import machwave.simulation as machwave_simulation
+from machwave.simulation.base import MAX_TIME_STEP, SEA_LEVEL_PRESSURE
+
+
+def _build(**overrides):
+    kwargs = dict(d_t=0.001, igniter_pressure=1e6, external_pressure=1e5)
+    kwargs.update(overrides)
+    return machwave_simulation.InternalBallisticsSimulationParams(**kwargs)
+
+
+class TestSimulationParamsValidation:
+    def test_accepts_max_time_step(self):
+        assert _build(d_t=MAX_TIME_STEP).d_t == MAX_TIME_STEP
+
+    @pytest.mark.parametrize("d_t", [0.0, -0.001, MAX_TIME_STEP * 2])
+    def test_time_step_out_of_range(self, d_t):
+        with pytest.raises(ValueError, match="d_t"):
+            _build(d_t=d_t)
+
+    def test_accepts_sea_level_igniter_pressure(self):
+        assert _build(igniter_pressure=SEA_LEVEL_PRESSURE).igniter_pressure == (
+            SEA_LEVEL_PRESSURE
+        )
+
+    @pytest.mark.parametrize("igniter_pressure", [SEA_LEVEL_PRESSURE - 1.0, 0.0, -1.0])
+    def test_igniter_pressure_below_sea_level(self, igniter_pressure):
+        with pytest.raises(ValueError, match="igniter_pressure"):
+            _build(igniter_pressure=igniter_pressure)
+
+    @pytest.mark.parametrize("external_pressure", [-1.0, -1e5])
+    def test_negative_external_pressure(self, external_pressure):
+        with pytest.raises(ValueError, match="external_pressure"):
+            _build(external_pressure=external_pressure)
+
+    def test_accepts_vacuum_external_pressure(self):
+        assert _build(external_pressure=0.0).external_pressure == 0.0


### PR DESCRIPTION
Closes #165.

Fail fast at public entry points with a `ValueError` that names the offending parameter and its value, instead of letting bad inputs propagate into NaN/Inf or silent garbage.

## Validation added

- **`InternalBallisticsSimulationParams`**: time step in `(0, 0.01]`, igniter pressure at least sea-level pressure (101325 Pa), non-negative external pressure.
- **`Nozzle`**: positive diameters with throat smaller than inlet, expansion ratio above 1, discharge coefficient in `(0, 1]`, separation pressure ratio in `(0, 1)`, convergent and divergent angles in `(0, 90)` degrees (a zero angle is rejected).
- **`CombustionChamber`**: positive inner diameter and length, outer diameter larger than inner, liner thinner than the casing radius.
- **`BipropellantInjector`**: positive orifice areas, discharge coefficients in `(0, 1]`.
- **`ThrustChamber`**: positive dry mass and a nozzle inlet that fits within the casing inner diameter; non-negative grain-port distance.

## Notes

- The "everything fits" check compares the nozzle inlet against the **casing inner diameter** (allowing a flush, equal fit), not the post-liner bore — the nozzle bolts to the casing while the liner runs along the cylindrical wall.
- The core functions in `machwave.core.compressible_flow` are internal numerics called only by model methods whose inputs are already validated at the boundary, so no checks were added there.
- Isentropic exponent and mass-fraction-sum checks from the issue were skipped because neither is a user-supplied constructor argument (the exponent comes from the thermochemistry service at run time; mass fractions come from propellant JSON, which has its own validation path).

## Tests

Every rejection branch has a parametrized unit test (covering both ends of each range plus extra invalid values), alongside accept-boundary cases such as the maximum time step, a sea-level igniter pressure, a vacuum external pressure, and a flush nozzle inlet. Full local suite: 749 passed, ruff clean.