### PR TITLE
Stop biliquid flow once either propellant is exhausted

### DIFF
--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import math
 from typing import Callable
 
 import machwave.core.compressible_flow.isentropic as isentropic
@@ -67,7 +68,11 @@ def get_total_injector_mass_flow(
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class BiliquidTimestepConditions(simulation_states.TimestepConditions):
-    """Timestep conditions for a biliquid engine."""
+    """
+    Timestep conditions for a biliquid engine.
+
+    `oxidizer_to_fuel_ratio` is NaN whenever either propellant is not flowing.
+    """
 
     fuel_mass: float
     oxidizer_mass: float
@@ -162,7 +167,9 @@ class BiliquidEngineState(simulation_states.MotorState):
         self.oxidizer_tank_pressure.append(oxidizer_tank_pressure)
 
         is_feeding = (
-            propellant_mass > 0
+            not self.end_burn
+            and fuel_mass > 0
+            and oxidizer_mass > 0
             and fuel_tank_pressure > chamber_pressure
             and oxidizer_tank_pressure > chamber_pressure
         )
@@ -183,17 +190,17 @@ class BiliquidEngineState(simulation_states.MotorState):
         fuel_consumed = m_dot_fuel * d_t
         oxidizer_consumed = m_dot_ox * d_t
 
-        if m_dot_fuel > 0.0:
-            oxidizer_to_fuel_ratio = m_dot_ox / m_dot_fuel
-        else:
-            design_ratio = self.motor.propellant.oxidizer_to_fuel_ratio
-            assert design_ratio is not None
-            oxidizer_to_fuel_ratio = design_ratio
+        # Without both flows there is no live mixture ratio: record it as undefined and
+        # let the propellant card stand in for the residual combustion gas.
+        mixture_ratio = (
+            m_dot_ox / m_dot_fuel if m_dot_fuel > 0.0 and m_dot_ox > 0.0 else None
+        )
+        oxidizer_to_fuel_ratio = math.nan if mixture_ratio is None else mixture_ratio
         self.oxidizer_to_fuel_ratio.append(oxidizer_to_fuel_ratio)
 
         propellant_properties = self._evaluate_propellant_properties(
             chamber_pressure=chamber_pressure,
-            mixture_ratio=oxidizer_to_fuel_ratio,
+            mixture_ratio=mixture_ratio,
         )
 
         (

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -68,11 +68,7 @@ def get_total_injector_mass_flow(
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class BiliquidTimestepConditions(simulation_states.TimestepConditions):
-    """
-    Timestep conditions for a biliquid engine.
-
-    `oxidizer_to_fuel_ratio` is NaN whenever either propellant is not flowing.
-    """
+    """Timestep conditions for a biliquid engine."""
 
     fuel_mass: float
     oxidizer_mass: float
@@ -190,8 +186,7 @@ class BiliquidEngineState(simulation_states.MotorState):
         fuel_consumed = m_dot_fuel * d_t
         oxidizer_consumed = m_dot_ox * d_t
 
-        # Without both flows there is no live mixture ratio: record it as undefined and
-        # let the propellant card stand in for the residual combustion gas.
+        # Without both flows strictly positive, the OF ratio is NaN
         mixture_ratio = (
             m_dot_ox / m_dot_fuel if m_dot_fuel > 0.0 and m_dot_ox > 0.0 else None
         )

--- a/tests/test_simulations/test_biliquid_engine_simulation.py
+++ b/tests/test_simulations/test_biliquid_engine_simulation.py
@@ -207,6 +207,54 @@ def test_run_timestep_sets_end_burn_when_oxidizer_exhausts() -> None:
     assert state.burn_time == pytest.approx(state.time[-1])
 
 
+def test_flows_stop_after_fuel_exhausts() -> None:
+    """The oxidizer is not burned on its own once the fuel is gone."""
+    state = _build_state_for_burnout_test()
+    state.fuel_mass[-1] = 1e-9
+
+    state.run_timestep(d_t=1e-4, external_pressure=1e5)
+    assert state.end_burn is True
+    oxidizer_mass_at_burnout = state.oxidizer_mass[-1]
+    assert oxidizer_mass_at_burnout > 0.0
+
+    state.run_timestep(d_t=1e-4, external_pressure=1e5)
+
+    assert state.fuel_mass_flow_rate[-1] == 0.0
+    assert state.oxidizer_mass_flow_rate[-1] == 0.0
+    assert np.isnan(state.oxidizer_to_fuel_ratio[-1])
+    assert state.oxidizer_mass[-1] == oxidizer_mass_at_burnout
+
+
+def test_flows_stop_after_oxidizer_exhausts() -> None:
+    """The fuel is not burned on its own once the oxidizer is gone."""
+    state = _build_state_for_burnout_test()
+    state.oxidizer_mass[-1] = 1e-9
+
+    state.run_timestep(d_t=1e-4, external_pressure=1e5)
+    assert state.end_burn is True
+    fuel_mass_at_burnout = state.fuel_mass[-1]
+    assert fuel_mass_at_burnout > 0.0
+
+    state.run_timestep(d_t=1e-4, external_pressure=1e5)
+
+    assert state.fuel_mass_flow_rate[-1] == 0.0
+    assert state.oxidizer_mass_flow_rate[-1] == 0.0
+    assert np.isnan(state.oxidizer_to_fuel_ratio[-1])
+    assert state.fuel_mass[-1] == fuel_mass_at_burnout
+
+
+def test_surviving_propellant_stops_draining_after_burnout(
+    simulation_result: biliquid_simulation.BiliquidSimulationResult,
+) -> None:
+    """Tail-off is a blowdown: neither tank feeds the chamber past burnout."""
+    after_burnout = simulation_result.time >= simulation_result.burn_time
+    assert after_burnout.sum() > 1, "run ended at burnout, tail-off not exercised"
+
+    for series_name in ("fuel_mass", "oxidizer_mass"):
+        series = getattr(simulation_result, series_name)[after_burnout]
+        assert (series == series[0]).all(), f"{series_name} kept draining after burnout"
+
+
 def test_live_mixture_ratio_drives_cea() -> None:
     motor, params = motor_builders.build_1kn_biliquid_engine()
     state = biliquid_simulation.BiliquidEngineState(


### PR DESCRIPTION
Closes #423.

`BiliquidEngineState.run_timestep` gated feeding on the combined propellant mass, so an empty fuel tank still passed the check while oxidizer remained. The fuel flow clamped to zero, the oxidizer kept flowing, and the zero-fuel-flow branch fell back to the design oxidizer-to-fuel ratio (O/F), so the thermochemistry returned the full combustion temperature and thrust held on oxidizer alone.

On the 1 kN test engine the fuel empties at t = 3.056 s; the run then kept burning for another 1.95 s, consuming 0.40 kg of oxidizer with no fuel and adding 488 N-s of phantom thrust (7.6% of total impulse).

Feeding now requires both tanks to hold mass and the burn to still be running, so both flows stop at the first depletion and tail-off is a pure blowdown. The live O/F is recorded as NaN whenever either propellant is not flowing; the propellant card's design ratio still supplies the residual combustion gas properties during blowdown, which is where that fallback is valid.

Tests: three regression tests (both depletion orders at the state level, plus an end-to-end check that neither tank drains past burnout). All three fail on master and pass here; full suite green (945 passed).