### PR TITLE
Terminate the run on tail-off as well as loss of choking

### DIFF
--- a/docs/api/simulation.md
+++ b/docs/api/simulation.md
@@ -2,7 +2,18 @@
 
 Main entry point for running internal ballistics simulations. `InternalBallisticsSimulation` takes a motor model and simulation parameters (time step, igniter pressure, external pressure), then marches through time using an RK4 solver.
 
-The run marches until thrust terminates, on whichever comes first: the nozzle un-chokes (chamber pressure falls to the critical ratio of the ambient pressure), or a burnt out motor tails off (thrust falls to `TAIL_OFF_THRUST_FRACTION` of its peak). Tail-off is what ends a vacuum or upper stage run, where the nozzle stays choked as the chamber pressure decays toward zero. It sits well below the un-choking pressure at any realistic ambient, so it does not affect runs against an atmosphere.
+The run ends on whichever of these two conditions fires first:
+
+| Condition | Fires when | Ends |
+| --- | --- | --- |
+| Loss of choking | Chamber pressure falls to the critical ratio of the ambient pressure, roughly 1.7 to 1.8 times `external_pressure` | Runs against an atmosphere |
+| Tail-off | The motor has burnt out **and** thrust has decayed to `TAIL_OFF_THRUST_FRACTION` (0.1%) of its peak | Vacuum and upper stage runs, where the nozzle stays choked all the way down |
+
+- With `external_pressure=0.0` the nozzle stays choked at any chamber pressure, so loss of choking never fires and tail-off is what ends the run.
+- Tail-off only fires first for a motor peaking around 175 MPa or more, so it leaves runs against an atmosphere untouched.
+- Stopping at tail-off costs almost no impulse: under 0.002% of the total for the motors under test. The 0.1% threshold matches [openMotor](https://github.com/reilleya/openMotor)'s default, alongside the NFPA 1125 (5%) and JANNAF (10%) conventions for burn and action time.
+
+Which condition fired, and when, is on the result: `end_thrust` and `end_burn` flag whether thrust terminated and whether the motor burnt out, while `thrust_time` and `burn_time` date each event [s].
 
 `run()` returns a frozen `SimulationResult` (subclassed per motor type — `SolidSimulationResult`, `BiliquidSimulationResult`) carrying the full time-series data (thrust, chamber pressure, propellant mass, efficiency losses, …) along with derived scalars (total impulse, specific impulse, burn time). Each result class provides a `report()` method to print a human-readable summary and a `summary()` method that returns the scalar metrics as a dict.
 

--- a/docs/api/simulation.md
+++ b/docs/api/simulation.md
@@ -2,6 +2,8 @@
 
 Main entry point for running internal ballistics simulations. `InternalBallisticsSimulation` takes a motor model and simulation parameters (time step, igniter pressure, external pressure), then marches through time using an RK4 solver.
 
+The run marches until thrust terminates, on whichever comes first: the nozzle un-chokes (chamber pressure falls to the critical ratio of the ambient pressure), or a burnt out motor tails off (thrust falls to `TAIL_OFF_THRUST_FRACTION` of its peak). Tail-off is what ends a vacuum or upper stage run, where the nozzle stays choked as the chamber pressure decays toward zero. It sits well below the un-choking pressure at any realistic ambient, so it does not affect runs against an atmosphere.
+
 `run()` returns a frozen `SimulationResult` (subclassed per motor type — `SolidSimulationResult`, `BiliquidSimulationResult`) carrying the full time-series data (thrust, chamber pressure, propellant mass, efficiency losses, …) along with derived scalars (total impulse, specific impulse, burn time). Each result class provides a `report()` method to print a human-readable summary and a `summary()` method that returns the scalar metrics as a dict.
 
 The per-step accumulator state used by the integrator (`MotorState` and its subclasses `SolidMotorState`, `BiliquidEngineState`) lives in this same package — it is rarely consumed directly outside the simulation loop. Alongside it, the abstract `TimestepConditions` and its per-engine subclasses `SolidTimestepConditions`, `BiliquidTimestepConditions` snapshot the operating quantities of one timestep and are handed to the nozzle loss model.

--- a/docs/api/simulation.md
+++ b/docs/api/simulation.md
@@ -13,8 +13,6 @@ The run ends on whichever of these two conditions fires first:
 - Tail-off only fires first for a motor peaking around 175 MPa or more, so it leaves runs against an atmosphere untouched.
 - Stopping at tail-off costs almost no impulse: under 0.002% of the total for the motors under test. The 0.1% threshold matches [openMotor](https://github.com/reilleya/openMotor)'s default, alongside the NFPA 1125 (5%) and JANNAF (10%) conventions for burn and action time.
 
-Which condition fired, and when, is on the result: `end_thrust` and `end_burn` flag whether thrust terminated and whether the motor burnt out, while `thrust_time` and `burn_time` date each event [s].
-
 `run()` returns a frozen `SimulationResult` (subclassed per motor type — `SolidSimulationResult`, `BiliquidSimulationResult`) carrying the full time-series data (thrust, chamber pressure, propellant mass, efficiency losses, …) along with derived scalars (total impulse, specific impulse, burn time). Each result class provides a `report()` method to print a human-readable summary and a `summary()` method that returns the scalar metrics as a dict.
 
 The per-step accumulator state used by the integrator (`MotorState` and its subclasses `SolidMotorState`, `BiliquidEngineState`) lives in this same package — it is rarely consumed directly outside the simulation loop. Alongside it, the abstract `TimestepConditions` and its per-engine subclasses `SolidTimestepConditions`, `BiliquidTimestepConditions` snapshot the operating quantities of one timestep and are handed to the nozzle loss model.

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -5,7 +5,6 @@ import functools
 import math
 from typing import Callable
 
-import machwave.core.compressible_flow.isentropic as isentropic
 import machwave.core.mass_balance as mass_balance
 import machwave.core.performance as performance
 import machwave.core.solvers.rk4 as rk4
@@ -243,15 +242,12 @@ class BiliquidEngineState(simulation_states.MotorState):
             self.end_burn = True
             self._burn_time = time + d_t
 
-        if not isentropic.is_flow_choked(
+        if self._update_thrust_termination(
+            time,
             chamber_pressure,
             external_pressure,
-            isentropic.get_critical_pressure_ratio(propellant_properties.k_chamber),
+            propellant_properties.k_chamber,
         ):
-            if self._burn_time is None:
-                self._burn_time = time
-            self._thrust_time = time
-            self.end_thrust = True
             return
 
         new_time = time + d_t

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -7,7 +7,6 @@ from typing import Callable
 import numpy as np
 import numpy.typing as npt
 
-import machwave.core.compressible_flow.isentropic as isentropic
 import machwave.core.mass_balance as mass_balance
 import machwave.core.performance as performance
 import machwave.core.solvers.rk4 as rk4
@@ -232,15 +231,12 @@ class SolidMotorState(simulation_states.MotorState):
             self._burn_time = time
             self.end_burn = True
 
-        if not isentropic.is_flow_choked(
+        if self._update_thrust_termination(
+            time,
             chamber_pressure,
             external_pressure,
-            isentropic.get_critical_pressure_ratio(propellant_properties.k_chamber),
+            propellant_properties.k_chamber,
         ):
-            if self._burn_time is None:
-                self._burn_time = time
-            self._thrust_time = time
-            self.end_thrust = True
             return
 
         new_time = time + d_t

--- a/machwave/simulation/states.py
+++ b/machwave/simulation/states.py
@@ -4,6 +4,7 @@ import dataclasses
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar, TypeAlias
 
+import machwave.core.compressible_flow.isentropic as isentropic
 import machwave.core.compressible_flow.nozzle as nozzle_core
 import machwave.models.motors as motors
 
@@ -13,6 +14,8 @@ if TYPE_CHECKING:
     import machwave.simulation.results as simulation_results
 
 SimulationStateArray: TypeAlias = list[float]
+
+TAIL_OFF_THRUST_FRACTION = 0.001
 
 
 class MotorState(ABC):
@@ -45,6 +48,7 @@ class MotorState(ABC):
         self.ideal_thrust_coefficient: SimulationStateArray = []
         self.thrust_coefficient: SimulationStateArray = []
         self.thrust: SimulationStateArray = []
+        self.peak_thrust: float = 0.0
         self.nozzle_efficiency: SimulationStateArray = []
         self.loss_fractions: dict[str, SimulationStateArray] = {
             name: [] for name in motor.nozzle_loss_model.component_names
@@ -143,6 +147,48 @@ class MotorState(ABC):
             thrust_coefficient, chamber_pressure, nozzle.get_throat_area()
         )
         self.thrust.append(thrust)
+        self.peak_thrust = max(self.peak_thrust, thrust)
+
+    def _update_thrust_termination(
+        self,
+        time: float,
+        chamber_pressure: float,
+        external_pressure: float,
+        k_chamber: float,
+    ) -> bool:
+        """
+        Flag thrust termination once the nozzle un-chokes or the tail-off ends.
+
+        Loss of choking never fires against a vacuum, where the nozzle stays choked
+        for any chamber pressure, so a burnt out motor also terminates once its
+        thrust decays to ``TAIL_OFF_THRUST_FRACTION`` of the peak.
+
+        Args:
+            time: Time at the start of the timestep [s].
+            chamber_pressure: Chamber pressure [Pa].
+            external_pressure: Ambient pressure [Pa].
+            k_chamber: Isentropic exponent in the chamber.
+
+        Returns:
+            True if thrust has terminated on this timestep.
+        """
+        is_choked = isentropic.is_flow_choked(
+            chamber_pressure,
+            external_pressure,
+            isentropic.get_critical_pressure_ratio(k_chamber),
+        )
+        has_tailed_off = (
+            self.end_burn
+            and self.thrust[-1] < TAIL_OFF_THRUST_FRACTION * self.peak_thrust
+        )
+        if is_choked and not has_tailed_off:
+            return False
+
+        if self._burn_time is None:
+            self._burn_time = time
+        self._thrust_time = time
+        self.end_thrust = True
+        return True
 
     def build_result(self) -> "simulation_results.SimulationResult":
         """Return a frozen ``SimulationResult`` snapshot of this state."""

--- a/tests/test_simulations/test_biliquid_engine_simulation.py
+++ b/tests/test_simulations/test_biliquid_engine_simulation.py
@@ -16,6 +16,7 @@ import pytest
 
 import machwave.models.motors as motors_models
 import machwave.simulation.biliquid as biliquid_simulation
+import machwave.simulation.states as simulation_states
 from tests.test_simulations import motor_builders
 from tests.test_simulations.conftest import (
     assert_recorded_arrays_aligned,
@@ -253,6 +254,22 @@ def test_surviving_propellant_stops_draining_after_burnout(
     for series_name in ("fuel_mass", "oxidizer_mass"):
         series = getattr(simulation_result, series_name)[after_burnout]
         assert (series == series[0]).all(), f"{series_name} kept draining after burnout"
+
+
+def test_tail_off_terminates_thrust_against_zero_ambient_pressure() -> None:
+    """Against zero ambient pressure the nozzle stays choked, so tail-off ends it."""
+    state = _build_state_for_burnout_test()
+    state.fuel_mass[-1] = 1e-9
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        while not state.end_thrust:
+            state.run_timestep(d_t=1e-4, external_pressure=0.0)
+
+    assert state.end_burn is True
+    assert state.thrust[-1] < (
+        simulation_states.TAIL_OFF_THRUST_FRACTION * state.peak_thrust
+    )
 
 
 def test_live_mixture_ratio_drives_cea() -> None:

--- a/tests/test_simulations/test_solid_motor_simulation.py
+++ b/tests/test_simulations/test_solid_motor_simulation.py
@@ -7,12 +7,14 @@ they can be reused by benchmarks under tests/benchmarks/.
 
 from __future__ import annotations
 
+import dataclasses
 import io
 from typing import Callable
 
 import numpy as np
 import pytest
 
+import machwave.core.compressible_flow.isentropic as isentropic
 import machwave.models.motors as motors_models
 import machwave.models.nozzle_losses as nozzle_losses
 import machwave.models.nozzle_losses.components.constant as constant
@@ -20,6 +22,7 @@ import machwave.models.nozzle_losses.components.spp1975 as spp1975
 import machwave.models.propellants as propellants
 import machwave.simulation as machwave_simulation
 import machwave.simulation.solid as solid_simulation
+import machwave.simulation.states as simulation_states
 from tests.test_simulations import motor_builders
 from tests.test_simulations.conftest import (
     assert_recorded_arrays_aligned,
@@ -205,6 +208,34 @@ def test_all_both_targets_match_legacy_scalar_correction() -> None:
         result.ideal_thrust_coefficient * result.nozzle_efficiency,
         rtol=1e-12,
     )
+
+
+def test_vacuum_run_terminates_on_tail_off() -> None:
+    """Against zero ambient pressure the nozzle stays choked, so tail-off ends it."""
+    motor, params = motor_builders.build_nero_motor()
+    result = run_simulation(motor, dataclasses.replace(params, external_pressure=0.0))
+
+    assert result.end_thrust is True
+    assert result.end_burn is True
+    assert result.thrust_time > result.burn_time
+    peak_thrust = float(np.max(result.thrust))
+    assert result.thrust[-1] < simulation_states.TAIL_OFF_THRUST_FRACTION * peak_thrust
+
+
+def test_sea_level_run_still_ends_on_loss_of_choking() -> None:
+    """Tail-off sits far below the un-choking pressure, so it never preempts it."""
+    motor, params = motor_builders.build_nero_motor()
+    result = run_simulation(motor, params)
+
+    propellant_properties = motor.propellant.properties
+    assert propellant_properties is not None
+    assert not isentropic.is_flow_choked(
+        float(result.chamber_pressure[-1]),
+        params.external_pressure,
+        isentropic.get_critical_pressure_ratio(propellant_properties.k_chamber),
+    )
+    peak_thrust = float(np.max(result.thrust))
+    assert result.thrust[-1] > simulation_states.TAIL_OFF_THRUST_FRACTION * peak_thrust
 
 
 def test_moment_of_inertia_is_guarded_past_burnout() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -823,7 +823,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coolprop", specifier = ">=6.7.0,<8.0.0" },
+    { name = "coolprop", specifier = ">=6.7.0,<9.0.0" },
     { name = "fluids", specifier = ">=1.1.0,<2.0.0" },
     { name = "matplotlib", specifier = ">=3.10.0,<4.0.0" },
     { name = "numpy", specifier = ">=2.0.0,<3.0.0" },


### PR DESCRIPTION
Closes #339.

Loss of choking was the only exit from the run loop, and against zero external pressure it never fires: `is_flow_choked` is true for any chamber pressure, so a vacuum or upper stage run looped forever while the chamber pressure decayed to a denormal.

A burnt out motor now also terminates once its thrust decays to `TAIL_OFF_THRUST_FRACTION` (0.1%) of the peak. Both checks live in a shared `MotorState._update_thrust_termination`, replacing the block that was duplicated across the solid and biliquid states.

### Why 0.1% of peak thrust

It matches openMotor's shipping default, and sits in the same family as the NFPA 1125 5% and JANNAF 10% conventions for burn and action time.

Tail-off only binds before un-choking when `fraction × peak > Pe / P*`, i.e. for a motor peaking above roughly 180 MPa. Every motor under test peaks at 3.3 to 8.0 MPa, so runs against an atmosphere are structurally unable to reach the tail-off cutoff and terminate exactly where they did before. Verified: sea level thrust times and total impulses are identical to master for all three solid motors and the biliquid engine.

Measured against runs marched to exhaustion, the impulse left behind in vacuum is 0.0017% (Nero) and 0.0004% (APCP), for four to five extra timesteps.

The 0.1% threshold was also checked against thermochemistry validity: a vacuum biliquid run reaches 2.3 kPa chamber pressure with CEA intact, well clear of where it degrades.