### PR TITLE
Bound BATES burnout by the radial and axial limits

### DIFF
--- a/machwave/models/grain/base.py
+++ b/machwave/models/grain/base.py
@@ -67,6 +67,23 @@ class GrainSegment(ABC):
 
         self.validate()
 
+    @property
+    def exposed_end_count(self) -> int:
+        """Return the number of uninhibited end faces."""
+        return (not self.inhibited_surfaces.upper_end) + (
+            not self.inhibited_surfaces.lower_end
+        )
+
+    def get_axial_web_thickness(self) -> float:
+        """
+        Return the web distance at which the end faces consume the segment [m].
+
+        Infinite when both ends are inhibited, since no end face regresses.
+        """
+        if self.exposed_end_count == 0:
+            return math.inf
+        return self.length / self.exposed_end_count
+
     @abstractmethod
     def get_web_thickness(self) -> float:
         """Return the total web thickness of the segment [m]."""
@@ -242,10 +259,7 @@ class GrainSegment2D(GrainSegment, ABC):
 
     def get_length(self, web_distance: float) -> float:
         """Return the segment length at a given web distance [m]."""
-        exposed_ends = (not self.inhibited_surfaces.upper_end) + (
-            not self.inhibited_surfaces.lower_end
-        )
-        return self.length - web_distance * exposed_ends
+        return max(0.0, self.length - web_distance * self.exposed_end_count)
 
     def get_burn_area(self, web_distance: float) -> float:
         """Return the segment burn area at a given web distance [m^2]."""
@@ -258,10 +272,7 @@ class GrainSegment2D(GrainSegment, ABC):
             else self.get_core_area(web_distance=web_distance)
         )
         single_face_area = self.get_face_area(web_distance=web_distance)
-        exposed_ends = (not self.inhibited_surfaces.upper_end) + (
-            not self.inhibited_surfaces.lower_end
-        )
-        total_face_area = exposed_ends * single_face_area
+        total_face_area = self.exposed_end_count * single_face_area
         return core_area + total_face_area
 
     def get_volume(self, web_distance: float) -> float:
@@ -311,10 +322,7 @@ class GrainSegment3D(GrainSegment, ABC):
 
     def get_length(self, web_distance: float) -> float:
         """Return the segment length at a given web distance [m]."""
-        exposed_ends = (not self.inhibited_surfaces.upper_end) + (
-            not self.inhibited_surfaces.lower_end
-        )
-        return self.length - web_distance * exposed_ends
+        return max(0.0, self.length - web_distance * self.exposed_end_count)
 
 
 class Grain:

--- a/machwave/models/grain/geometries/bates.py
+++ b/machwave/models/grain/geometries/bates.py
@@ -77,9 +77,14 @@ class BatesSegment(grain.GrainSegment2D):
         """
         Return the BATES web thickness [m].
 
+        The segment is consumed by whichever comes first: the radial wall
+        between the core and the outer surface, or the uninhibited end faces
+        meeting axially.
+
         See: https://www.nakka-rocketry.net/design1.html.
         """
-        return 0.5 * (self.outer_diameter - self.core_diameter)
+        radial_web_thickness = 0.5 * (self.outer_diameter - self.core_diameter)
+        return min(radial_web_thickness, self.get_axial_web_thickness())
 
     def get_optimal_length(self) -> float:
         """

--- a/tests/test_models/test_propulsion/test_grain/test_axial_burnout.py
+++ b/tests/test_models/test_propulsion/test_grain/test_axial_burnout.py
@@ -1,0 +1,55 @@
+"""Axial burnout limit and length clamp shared by every grain segment."""
+
+import math
+
+import pytest
+
+import machwave.models.grain as grain_models
+import machwave.models.grain.geometries as grain_geometries
+
+LENGTH = 100e-3
+
+STAR_PARAMS = dict(
+    length=LENGTH,
+    outer_diameter=50e-3,
+    number_of_points=5,
+    point_length=15e-3,
+    point_width=8e-3,
+)
+
+
+def _star(**inhibition):
+    return grain_geometries.StarGrainSegment(
+        **STAR_PARAMS,
+        inhibited_surfaces=grain_models.InhibitedSurfaces(**inhibition),
+    )
+
+
+def test_two_exposed_ends_halve_the_axial_limit():
+    segment = _star()
+
+    assert segment.exposed_end_count == 2
+    assert segment.get_axial_web_thickness() == pytest.approx(LENGTH / 2)
+
+
+def test_one_exposed_end_takes_the_full_length():
+    segment = _star(upper_end=True)
+
+    assert segment.exposed_end_count == 1
+    assert segment.get_axial_web_thickness() == pytest.approx(LENGTH)
+
+
+def test_inhibited_ends_never_limit_the_burn():
+    segment = _star(upper_end=True, lower_end=True)
+
+    assert segment.exposed_end_count == 0
+    assert segment.get_axial_web_thickness() == math.inf
+    assert segment.get_length(LENGTH) == pytest.approx(LENGTH)
+
+
+def test_length_is_clamped_at_zero():
+    segment = _star()
+
+    assert segment.get_length(LENGTH / 4) == pytest.approx(LENGTH / 2)
+    assert segment.get_length(LENGTH / 2) == 0.0
+    assert segment.get_length(LENGTH) == 0.0

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/test_bates.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/test_bates.py
@@ -1,7 +1,28 @@
+import numpy as np
 import pytest
 
 import machwave.models.grain as grain_models
 import machwave.models.grain.geometries as grain_geometries
+
+IDEAL_DENSITY = 1700.0
+
+
+def _radially_limited_segment():
+    """Long segment: the radial wall runs out before the ends meet."""
+    return grain_geometries.BatesSegment(
+        outer_diameter=40e-3,
+        core_diameter=15e-3,
+        length=120e-3,
+    )
+
+
+def _axially_limited_segment():
+    """Short segment: the ends meet before the radial wall runs out."""
+    return grain_geometries.BatesSegment(
+        outer_diameter=40e-3,
+        core_diameter=15e-3,
+        length=10e-3,
+    )
 
 
 def test_bates_segment_geometry_validation():
@@ -35,6 +56,46 @@ def test_bates_segment_geometry_validation():
             core_diameter=30e-3,
             length=-120e-3,
         )
+
+
+def test_web_thickness_is_the_radial_wall_when_it_is_exhausted_first():
+    assert _radially_limited_segment().get_web_thickness() == pytest.approx(12.5e-3)
+
+
+def test_web_thickness_is_the_axial_limit_when_the_ends_meet_first():
+    """Both ends burn, so a 10 mm segment is consumed after 5 mm of web."""
+    assert _axially_limited_segment().get_web_thickness() == pytest.approx(5e-3)
+
+
+def test_length_is_clamped_at_zero_past_burnout():
+    segment = _axially_limited_segment()
+
+    assert segment.get_length(2e-3) == pytest.approx(6e-3)
+    for web_distance in (5e-3, 6e-3, 12.5e-3):
+        assert segment.get_length(web_distance) == 0.0
+
+
+def test_volume_is_zero_at_axial_burnout():
+    segment = _axially_limited_segment()
+
+    assert segment.get_volume(0.0) > 0.0
+    assert segment.get_volume(segment.get_web_thickness()) == pytest.approx(0.0)
+
+
+def test_volume_mass_and_burn_area_stay_non_negative_past_burnout():
+    """Axial consumption used to outrun the radial web and go negative."""
+    segment = _axially_limited_segment()
+
+    for web_distance in np.linspace(0.0, 15e-3, 61):
+        assert segment.get_volume(web_distance) >= 0.0
+        assert segment.get_mass(web_distance, ideal_density=IDEAL_DENSITY) >= 0.0
+        assert segment.get_burn_area(web_distance) >= 0.0
+
+
+def test_burn_area_is_zero_past_burnout():
+    segment = _axially_limited_segment()
+
+    assert segment.get_burn_area(segment.get_web_thickness() * 1.1) == 0.0
 
 
 def test_olympus_grain_total_length_property(bates_grain_olympus):


### PR DESCRIPTION
Closes #344. Also closes the folded-in defect from #338.

`BatesSegment.get_web_thickness` returned `0.5 * (outer_diameter - core_diameter)`, the radial wall only. For a segment short enough that its two uninhibited end faces meet before the wall is consumed, the burn-area and volume cutoffs keyed on a web thickness the grain never reaches. It now returns the smaller of the radial wall and the axial end-burn limit.

`GrainSegment2D.get_length` and `GrainSegment3D.get_length` are clamped at zero. Previously, once axial consumption outran the radial web, the length went negative and volume, mass and burn area followed: outer diameter 40 mm, core diameter 15 mm, length 10 mm gave -1.37 cm^3 at a web of 6 mm.

The exposed-end count and the axial limit are now shared helpers on `GrainSegment` (`exposed_end_count`, `get_axial_web_thickness`), replacing the inline recomputation in the two `get_length` overrides and in `GrainSegment2D.get_burn_area`.

Not addressed here: `FMMGrainSegment.get_web_thickness` derives the web from the cross-section distance map, so 2D fast marching method geometries carry the same radial-only limit. Worth a follow-up issue.