### PR TITLE
Round the 3D grain axial resolution to the nearest slice

### DIFF
--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -60,7 +60,7 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
             )
 
     def get_axial_resolution(self) -> int:
-        return int(self.grid_resolution * self.length / self.outer_diameter)
+        return round(self.grid_resolution * self.length / self.outer_diameter)
 
     def get_coordinate_grids(
         self,

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_conical.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_conical.py
@@ -161,7 +161,7 @@ def test_taper_places_lower_diameter_at_the_nozzle_end():
 
 
 def test_segment_too_short_for_axial_map_is_rejected():
-    """int(100 * 0.002 / 0.1) == 2 slices -> rejected."""
+    """round(100 * 0.002 / 0.1) == 2 slices -> rejected."""
     with pytest.raises(grain_models.GrainGeometryError):
         ConicalGrainSegmentFactory.build(
             length=2e-3,
@@ -172,9 +172,20 @@ def test_segment_too_short_for_axial_map_is_rejected():
 
 
 def test_three_axial_slices_is_accepted():
-    """int(100 * 0.0035 / 0.1) == 3, the minimum that validates."""
+    """round(100 * 0.003 / 0.1) == 3, the minimum that validates."""
     segment = ConicalGrainSegmentFactory.build(
-        length=3.5e-3,
+        length=3e-3,
+        outer_diameter=100e-3,
+        upper_core_diameter=15e-3,
+        lower_core_diameter=10e-3,
+    )
+    assert segment.get_axial_resolution() == 3
+
+
+def test_axial_resolution_rounds_to_the_nearest_slice():
+    """100 * 0.0028 / 0.1 == 2.8 rounds up to 3 slices instead of truncating to 2."""
+    segment = ConicalGrainSegmentFactory.build(
+        length=2.8e-3,
         outer_diameter=100e-3,
         upper_core_diameter=15e-3,
         lower_core_diameter=10e-3,


### PR DESCRIPTION
`get_axial_resolution` truncated `grid_resolution * length / outer_diameter`, so the axial grid was systematically coarser than the radial grid. It now rounds.

Closes #452. Part of #369.