### PR TITLE
Use the anisotropic cell volume for 3D grain voxels

### DIFF
--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -62,6 +62,14 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
     def get_axial_resolution(self) -> int:
         return round(self.grid_resolution * self.length / self.outer_diameter)
 
+    def get_axial_grid_spacing(self) -> float:
+        """Distance between adjacent axial slices [m]."""
+        return self.length / max(self.get_axial_resolution() - 1, 1)
+
+    def get_radial_grid_spacing(self) -> float:
+        """Distance between adjacent cross-section cells [m]."""
+        return self.outer_diameter / (self.grid_resolution - 1)
+
     def get_coordinate_grids(
         self,
     ) -> tuple[
@@ -127,8 +135,8 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
     def _compute_regression_distance(self, masked_face: np.ndarray) -> np.ndarray:
         # Regression speed needs to be calibrated for the z axes separately from the x
         # and y axes, because the 3D grid is anisotropic
-        axial_grid_spacing = self.length / max(self.get_axial_resolution() - 1, 1)
-        radial_grid_spacing = self.outer_diameter / (self.grid_resolution - 1)
+        axial_grid_spacing = self.get_axial_grid_spacing()
+        radial_grid_spacing = self.get_radial_grid_spacing()
         distance = skfmm.distance(
             masked_face,
             dx=[axial_grid_spacing, radial_grid_spacing, radial_grid_spacing],  # type: ignore[arg-type]
@@ -166,8 +174,8 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
             # Lift the inhibited casing above every iso level so marching cubes
             # meshes only the burning front, not the wall.
             distance_field = np.ma.filled(regression_map, max_iso_level + 1.0)
-            axial_grid_spacing = self.length / max(self.get_axial_resolution() - 1, 1)
-            radial_grid_spacing = self.outer_diameter / (self.grid_resolution - 1)
+            axial_grid_spacing = self.get_axial_grid_spacing()
+            radial_grid_spacing = self.get_radial_grid_spacing()
             grid_spacing = (
                 axial_grid_spacing,
                 radial_grid_spacing,
@@ -267,7 +275,8 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         return geometric.get_circle_area(self.outer_diameter) - face_area
 
     def get_voxel_volume(self) -> float:
-        return (float(self.denormalize(self.get_normalized_spacing())) * 2) ** 3
+        """Volume of one cell of the anisotropic grid [m^3]."""
+        return self.get_radial_grid_spacing() ** 2 * self.get_axial_grid_spacing()
 
     def get_volume_interpolator(self) -> Callable[[float], float]:
         """Return a cached interpolator for volume [m^3] for a web distance."""

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_voxel_volume.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_voxel_volume.py
@@ -1,0 +1,47 @@
+"""The 3D FMM grid is anisotropic, so its cell volume is not a cube.
+
+The axial spacing follows the axial resolution and the radial spacing follows
+the grid resolution; taking the cell as a radial cube biases every volume and
+mass derived from a voxel count.
+"""
+
+import numpy as np
+import pytest
+
+from tests.factories import ConicalGrainSegmentFactory
+
+OUTER_DIAMETER = 0.1
+CORE_DIAMETER = 0.03
+VOLUME_TOLERANCE = 0.02
+
+
+def _constant_bore_segment(length):
+    return ConicalGrainSegmentFactory.build(
+        length=length,
+        outer_diameter=OUTER_DIAMETER,
+        upper_core_diameter=CORE_DIAMETER,
+        lower_core_diameter=CORE_DIAMETER,
+    )
+
+
+def test_voxel_volume_is_the_anisotropic_cell():
+    segment = _constant_bore_segment(0.3)
+
+    axial_spacing = segment.get_axial_grid_spacing()
+    radial_spacing = segment.get_radial_grid_spacing()
+
+    assert axial_spacing != pytest.approx(radial_spacing)
+    assert segment.get_voxel_volume() == pytest.approx(
+        radial_spacing**2 * axial_spacing
+    )
+
+
+@pytest.mark.parametrize("length_to_diameter_ratio", [2.0, 3.0])
+def test_volume_matches_the_analytic_hollow_cylinder(length_to_diameter_ratio):
+    """A constant-bore conical is a hollow cylinder, whose volume is exact."""
+    length = length_to_diameter_ratio * OUTER_DIAMETER
+    segment = _constant_bore_segment(length)
+
+    expected = np.pi / 4 * (OUTER_DIAMETER**2 - CORE_DIAMETER**2) * length
+
+    assert segment.get_volume(0.0) == pytest.approx(expected, rel=VOLUME_TOLERANCE)


### PR DESCRIPTION
`get_voxel_volume` returned a radial cube while the grid is anisotropic, biasing propellant volume and mass. It now returns `radial_spacing ** 2 * axial_spacing`, with both spacings pulled into helpers shared with the regression field and the marching-cubes mesh.

Against the analytic hollow cylinder, the volume error drops from -3.4% to -0.9% at a length-to-diameter ratio of 2, and the CAD-validated finocyl volume moves from -1.9% to +0.5%.

Closes #453. Part of #369.