### PR TITLE
Center the grain cell grid on its true center index

### DIFF
--- a/machwave/models/grain/fmm/_2d.py
+++ b/machwave/models/grain/fmm/_2d.py
@@ -295,7 +295,7 @@ class FMMGrainSegment2D(fmm_base.FMMGrainSegment, grain.GrainSegment2D, ABC):
         Returns:
             Tuple of (x_grid, y_grid) in normalized units.
         """
-        grid_center_index = self.grid_resolution / 2
+        grid_center_index = (self.grid_resolution - 1) / 2
         x_grid = (x_indices - grid_center_index).astype(np.float64)
         y_grid = (y_indices - grid_center_index).astype(np.float64)
         return x_grid, y_grid

--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -367,7 +367,7 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
             return None
 
         axial_count, y_count, x_count = mask.shape
-        grid_center = self.grid_resolution / 2
+        grid_center = (self.grid_resolution - 1) / 2
         x = np.asarray(
             self.cells_to_meters(np.arange(x_count) - grid_center), dtype=np.float64
         )

--- a/tests/test_models/test_propulsion/test_grain/test_cog/test_fmm_grid_center.py
+++ b/tests/test_models/test_propulsion/test_grain/test_cog/test_fmm_grid_center.py
@@ -1,0 +1,41 @@
+"""Concentric grains put their center of gravity on the motor axis.
+
+The cell grid spans -1 to 1 over grid_resolution samples, so its center index
+is (grid_resolution - 1) / 2. Taking it as grid_resolution / 2 offsets every
+cell by half a cell and drags the transverse center of gravity off the axis.
+"""
+
+import pytest
+
+from tests.factories import ConicalGrainSegmentFactory, RodAndTubeGrainSegmentFactory
+
+OUTER_DIAMETER = 0.1
+LENGTH = 0.2
+OFF_AXIS_TOLERANCE_IN_CELLS = 0.01
+
+
+def test_2d_concentric_segment_center_of_gravity_is_on_the_axis():
+    segment = RodAndTubeGrainSegmentFactory.build(
+        length=LENGTH, outer_diameter=OUTER_DIAMETER
+    )
+
+    center_of_gravity = segment.get_center_of_gravity(web_distance=0.0)
+    tolerance = segment.cells_to_meters(OFF_AXIS_TOLERANCE_IN_CELLS)
+
+    assert center_of_gravity[1] == pytest.approx(0.0, abs=tolerance)
+    assert center_of_gravity[2] == pytest.approx(0.0, abs=tolerance)
+
+
+def test_3d_concentric_segment_center_of_gravity_is_on_the_axis():
+    segment = ConicalGrainSegmentFactory.build(
+        length=LENGTH,
+        outer_diameter=OUTER_DIAMETER,
+        upper_core_diameter=0.03,
+        lower_core_diameter=0.03,
+    )
+
+    center_of_gravity = segment.get_center_of_gravity(web_distance=0.0)
+    tolerance = segment.cells_to_meters(OFF_AXIS_TOLERANCE_IN_CELLS)
+
+    assert center_of_gravity[1] == pytest.approx(0.0, abs=tolerance)
+    assert center_of_gravity[2] == pytest.approx(0.0, abs=tolerance)


### PR DESCRIPTION
Both Fast Marching Method paths took the grid center index as `grid_resolution / 2`, but for a grid of `grid_resolution` samples spanning -1 to 1 the center is `(grid_resolution - 1) / 2`. The half-cell offset pushed the transverse center of gravity off the axis; concentric geometries now land on it exactly.

Closes #454. Part of #369.