### PR TITLE
Scale and clamp the axial position in 3D grain contours

### DIFF
--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -135,12 +135,39 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         )
         return distance * (2.0 / self.outer_diameter)
 
+    def get_axial_index(self, axial_position_normalized: float) -> int:
+        """
+        Return the slice index for an axial position, clamped to the grid.
+
+        Args:
+            axial_position_normalized: Axial position as a fraction of the
+                segment length, measured from the aft (nozzle) end.
+
+        Returns:
+            Index of the nearest axial slice, within `[0, axial_resolution - 1]`.
+        """
+        max_index = self.get_axial_resolution() - 1
+        axial_index = int(round(axial_position_normalized * max_index))
+        return min(max(axial_index, 0), max_index)
+
     def get_contours(
         self, web_distance: float, axial_position_normalized: float
     ) -> list[NDArray[np.float64]]:
+        """
+        Return the contours of one axial slice at a given web distance.
+
+        Args:
+            web_distance: Distance traveled into the grain web [m].
+            axial_position_normalized: Axial position as a fraction of the
+                segment length, measured from the aft (nozzle) end.
+
+        Returns:
+            Contour arrays of the slice, each an `(N, 2)` array of points.
+        """
         iso_level = self.normalize(web_distance)
-        axial_index = int(round(axial_position_normalized))
-        axial_slice = self.get_regression_map()[axial_index]
+        axial_slice = self.get_regression_map()[
+            self.get_axial_index(axial_position_normalized)
+        ]
         return fmm_contours.get_iso_contours(axial_slice, iso_level)
 
     def get_burn_area_interpolator(self) -> Callable[[float], float]:
@@ -252,14 +279,7 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         valid = np.logical_not(self.get_outer_diameter_mask())
         solid = np.logical_and(self.get_regression_map() > iso_level, valid)
 
-        normalized_z = z / self.length
-        max_index = self.get_axial_resolution() - 1
-        axial_index = int(round(normalized_z * max_index))
-        axial_index = (
-            0
-            if axial_index < 0
-            else (max_index if axial_index > max_index else axial_index)
-        )
+        axial_index = self.get_axial_index(z / self.length)
 
         face_area = float(
             self.cells_to_square_meters(float(np.count_nonzero(solid[axial_index])))

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_axial_index.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_axial_index.py
@@ -1,0 +1,75 @@
+"""Axial positions map onto slice indices the same way everywhere in 3D FMM.
+
+An axial position is a fraction of the segment length measured from the aft
+end, so it has to be scaled by the axial resolution and clamped to the grid
+before it indexes a slice.
+"""
+
+import numpy as np
+import pytest
+
+from tests.factories import ConicalGrainSegmentFactory
+
+LENGTH = 68e-3
+OUTER_DIAMETER = 41e-3
+LOWER_CORE_DIAMETER = 30e-3  # aft (nozzle) end
+UPPER_CORE_DIAMETER = 8e-3  # forward (bulkhead) end
+BORE_TOLERANCE_IN_CELLS = 3.0
+
+
+@pytest.fixture(scope="module")
+def tapered_segment():
+    return ConicalGrainSegmentFactory.build(
+        length=LENGTH,
+        outer_diameter=OUTER_DIAMETER,
+        upper_core_diameter=UPPER_CORE_DIAMETER,
+        lower_core_diameter=LOWER_CORE_DIAMETER,
+    )
+
+
+def _bore_width_in_cells(segment, axial_position_normalized):
+    """Width of the single traced bore contour, in cells."""
+    (contour,) = segment.get_contours(0.0, axial_position_normalized)
+    return float(np.ptp(contour[:, 0]))
+
+
+def test_axial_index_spans_the_grid(tapered_segment):
+    last_index = tapered_segment.get_axial_resolution() - 1
+
+    assert tapered_segment.get_axial_index(0.0) == 0
+    assert tapered_segment.get_axial_index(1.0) == last_index
+    assert tapered_segment.get_axial_index(0.5) == round(last_index / 2)
+
+
+def test_axial_index_clamps_positions_outside_the_segment(tapered_segment):
+    last_index = tapered_segment.get_axial_resolution() - 1
+
+    assert tapered_segment.get_axial_index(-2.0) == 0
+    assert tapered_segment.get_axial_index(3.0) == last_index
+
+
+def _assert_same_contours(actual, expected):
+    assert len(actual) == len(expected)
+    for actual_contour, expected_contour in zip(actual, expected):
+        np.testing.assert_allclose(actual_contour, expected_contour)
+
+
+def test_contours_outside_the_segment_are_clamped_to_the_ends(tapered_segment):
+    _assert_same_contours(
+        tapered_segment.get_contours(0.0, -2.0), tapered_segment.get_contours(0.0, 0.0)
+    )
+    _assert_same_contours(
+        tapered_segment.get_contours(0.0, 3.0), tapered_segment.get_contours(0.0, 1.0)
+    )
+
+
+@pytest.mark.parametrize("axial_position_normalized", [0.05, 0.5, 0.95])
+def test_contours_follow_the_bore_taper(tapered_segment, axial_position_normalized):
+    bore_diameter = LOWER_CORE_DIAMETER + axial_position_normalized * (
+        UPPER_CORE_DIAMETER - LOWER_CORE_DIAMETER
+    )
+    expected_width = bore_diameter / OUTER_DIAMETER * tapered_segment.grid_resolution
+
+    assert _bore_width_in_cells(
+        tapered_segment, axial_position_normalized
+    ) == pytest.approx(expected_width, abs=BORE_TOLERANCE_IN_CELLS)


### PR DESCRIPTION
`get_contours` rounded the normalized axial position straight into a slice index: it never scaled by the axial resolution, so every position landed on one of the first two slices, and a position outside the segment raised `IndexError`. The conversion now lives in `get_axial_index`, shared with `get_port_area`, and clamps to the grid.

Closes #455. Part of #369.