### PR TITLE
Trace the whole core perimeter in 2D grains

### DIFF
--- a/docs/theory/grain_regression.md
+++ b/docs/theory/grain_regression.md
@@ -163,7 +163,7 @@ The mass-property reads, volume in 3D plus the center of gravity and moment of i
 
 **Contour the burn front: [`get_contours(w)`][machwave.models.grain.fmm._2d.FMMGrainSegment2D.get_contours].**
 A closed-loop curve is traced by `get_iso_contours` in `machwave.models.grain.fmm.contours`, for a given web distance.
-Then, `get_length` sums the curve to calculate the burning perimeter, discounting any stretch that lies on the casing wall.
+Then, `get_length` sums the curve to calculate the burning perimeter. Cells outside the casing are lifted above every iso level before tracing, so the curve follows the burning front only, right up to the casing.
 
 ```
 (9.0, 8.2) (8.2, 9.0) (8.0, 9.1) (7.0, 9.6) (6.0, 9.6) (5.0, 9.6) ...

--- a/machwave/models/grain/fmm/_2d.py
+++ b/machwave/models/grain/fmm/_2d.py
@@ -179,9 +179,7 @@ class FMMGrainSegment2D(fmm_base.FMMGrainSegment, grain.GrainSegment2D, ABC):
                 contours = fmm_contours.get_iso_contours(regression_map, float(dist))
                 core_perimeter_per_iso_level[i] = float(
                     sum(
-                        self.cells_to_meters(
-                            fmm_contours.get_length(contour, self.grid_resolution)
-                        )
+                        self.cells_to_meters(fmm_contours.get_length(contour))
                         for contour in contours
                     )
                 )
@@ -231,9 +229,7 @@ class FMMGrainSegment2D(fmm_base.FMMGrainSegment, grain.GrainSegment2D, ABC):
         contours = self.get_contours(web_distance)
         return float(
             sum(
-                self.cells_to_meters(
-                    fmm_contours.get_length(contour, self.grid_resolution)
-                )
+                self.cells_to_meters(fmm_contours.get_length(contour))
                 for contour in contours
             )
         )

--- a/machwave/models/grain/fmm/contours.py
+++ b/machwave/models/grain/fmm/contours.py
@@ -30,32 +30,20 @@ def get_iso_contours(
     )
 
 
-def get_length(
-    contour: np.ndarray, grid_resolution: int, tolerance: float = 1.0
-) -> float:
+def get_length(contour: np.ndarray) -> float:
     """
-    Return the total length of contour segments away from the disc edge.
+    Return the total length of a closed contour, in cells.
 
-    Segments within `tolerance` of the edge of a circle of diameter
-    `grid_resolution` are excluded, dropping the casing wall while keeping a
-    burning front that has regressed close to it.
+    Cells outside the casing are lifted above every iso level before tracing,
+    so a contour follows the burning front only, right up to the casing.
 
     Args:
         contour: The contour array.
-        grid_resolution: Grid points per axis of the map.
-        tolerance: The tolerance value. Defaults to 1.0.
 
     Returns:
-        The total length of the segments.
+        The total length of the contour segments, in cells.
     """
     shifted_vertices = np.roll(contour.T, 1, axis=1)
     segment_lengths = np.linalg.norm(contour.T - shifted_vertices, axis=0)
 
-    center_position = np.array([[grid_resolution / 2, grid_resolution / 2]])
-    distance_from_center = np.linalg.norm(contour - center_position, axis=1)
-
-    is_interior_contour_segment = (
-        distance_from_center < (grid_resolution / 2) - tolerance
-    )
-
-    return np.sum(segment_lengths[is_interior_contour_segment])
+    return float(np.sum(segment_lengths))

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/test_core_perimeter.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/test_core_perimeter.py
@@ -1,0 +1,56 @@
+"""The traced core perimeter holds up against an analytic front near the casing.
+
+A rod and tube grain burns as two concentric circles, so its core perimeter is
+known in closed form at every web distance. The traced perimeter has to match
+it at any grid resolution, including once the front has regressed to within a
+cell or two of the casing.
+"""
+
+import numpy as np
+import pytest
+
+import machwave.models.grain.fmm.contours as fmm_contours
+from tests.factories import RodAndTubeGrainSegmentFactory
+
+LENGTH = 0.2
+OUTER_DIAMETER = 0.1
+ROD_OUTER_DIAMETER = 0.01
+TUBE_INNER_DIAMETER = 0.03
+PERIMETER_TOLERANCE = 0.02
+
+
+def _analytic_core_perimeter(web_distance):
+    """Rod outer surface and tube inner surface, while each still exists."""
+    rod_radius = ROD_OUTER_DIAMETER / 2 - web_distance
+    tube_radius = TUBE_INNER_DIAMETER / 2 + web_distance
+
+    perimeter = 0.0
+    if rod_radius > 0:
+        perimeter += 2 * np.pi * rod_radius
+    if tube_radius < OUTER_DIAMETER / 2:
+        perimeter += 2 * np.pi * tube_radius
+    return perimeter
+
+
+@pytest.mark.parametrize("grid_resolution", [100, 200])
+@pytest.mark.parametrize("web_fraction", [0.5, 0.9, 0.98])
+def test_core_perimeter_matches_the_analytic_front(grid_resolution, web_fraction):
+    segment = RodAndTubeGrainSegmentFactory.build(
+        length=LENGTH,
+        outer_diameter=OUTER_DIAMETER,
+        rod_outer_diameter=ROD_OUTER_DIAMETER,
+        tube_inner_diameter=TUBE_INNER_DIAMETER,
+        grid_resolution=grid_resolution,
+    )
+
+    web_distance = web_fraction * segment.get_web_thickness()
+
+    assert segment.get_core_perimeter(web_distance) == pytest.approx(
+        _analytic_core_perimeter(web_distance), rel=PERIMETER_TOLERANCE
+    )
+
+
+def test_contour_length_is_the_closed_polygon_length():
+    square = np.array([[0.0, 0.0], [0.0, 2.0], [2.0, 2.0], [2.0, 0.0]])
+
+    assert fmm_contours.get_length(square) == pytest.approx(8.0)


### PR DESCRIPTION
The issue asked for the rim exclusion band to be expressed as a physical width instead of a pixel count. Measuring it first showed the band itself is the defect, so this removes it.

A rod and tube grain has a closed-form core perimeter. Tracing with no exclusion matches it to better than 0.5% at every web distance and every grid resolution; a one-pixel band collapses the perimeter to zero at 98% web (309 mm analytic, 0 mm traced), and a band of constant physical width collapses it earlier still, because it throws away the real burning front near the casing. The exclusion existed to drop a spurious contour along the casing wall, which no longer appears: cells outside the casing are lifted above every iso level before tracing.

The 3D path already traces without an exclusion, so this also lines the two paths up.

Closes #451. Part of #369.