### PR TITLE
Evaluate mass flux at the tightest station of a segment

### DIFF
--- a/machwave/models/grain/base.py
+++ b/machwave/models/grain/base.py
@@ -112,6 +112,22 @@ class GrainSegment(ABC):
         """
         pass
 
+    def get_minimum_port_area(self, web_distance: float) -> float:
+        """
+        Return the smallest port area along the segment [m^2].
+
+        The cross section of a segment with no axial variation is the same at
+        every station, so this is its port area. Segments whose cross section
+        varies along the length must override this.
+
+        Args:
+            web_distance: Distance traveled into the grain web [m].
+
+        Returns:
+            Smallest port area along the segment [m^2].
+        """
+        return self.get_port_area(web_distance)
+
     @abstractmethod
     def get_burn_area(self, web_distance: float) -> float:
         """
@@ -621,7 +637,7 @@ class Grain:
 
         for j in range(self.segment_count):  # iterating through each segment
             for i in range(np.size(burn_rate)):
-                core_area = self.segments[j].get_port_area(web_distance[i])
+                core_area = self.segments[j].get_minimum_port_area(web_distance[i])
                 burn_area = 0
 
                 for k in range(j + 1):

--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -266,6 +266,29 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         )
         return geometric.get_circle_area(self.outer_diameter) - face_area
 
+    def get_minimum_port_area(self, web_distance: float) -> float:
+        """
+        Return the smallest port area along the segment [m^2].
+
+        The cross section of a 3D segment varies along its length, so the flow
+        passes a bottleneck: the station holding the most solid propellant.
+
+        Args:
+            web_distance: The distance traveled into the grain web.
+
+        Returns:
+            Smallest port area along the segment [m^2].
+        """
+        iso_level = self.normalize(web_distance)
+        valid = np.logical_not(self.get_outer_diameter_mask())
+        solid = np.logical_and(self.get_regression_map() > iso_level, valid)
+
+        solid_cells_per_slice = np.count_nonzero(solid, axis=(1, 2))
+        face_area = float(
+            self.cells_to_square_meters(float(solid_cells_per_slice.max()))
+        )
+        return geometric.get_circle_area(self.outer_diameter) - face_area
+
     def get_voxel_volume(self) -> float:
         return (float(self.denormalize(self.get_normalized_spacing())) * 2) ** 3
 

--- a/tests/test_models/test_propulsion/test_grain/test_mass_flux_bottleneck.py
+++ b/tests/test_models/test_propulsion/test_grain/test_mass_flux_bottleneck.py
@@ -1,0 +1,75 @@
+"""Mass flux passes the tightest cross section of a segment, not its aft end.
+
+The port area of a 3D segment varies along its length, so the mass flux has to
+be evaluated at the bottleneck. Reading the aft end instead understates it,
+badly for a tapered bore whose exposed end face reads as fully open.
+"""
+
+import numpy as np
+import pytest
+
+import machwave.models.grain as grain_models
+from tests.factories import ConicalGrainSegmentFactory, StarGrainSegmentFactory
+
+LENGTH = 68e-3
+OUTER_DIAMETER = 41e-3
+LOWER_CORE_DIAMETER = 30e-3  # aft (nozzle) end
+UPPER_CORE_DIAMETER = 8e-3  # forward (bulkhead) end
+
+IDEAL_DENSITY = 1750.0
+BURN_RATE = np.array([0.005])
+WEB_DISTANCE = np.array([0.002])
+
+
+@pytest.fixture(scope="module")
+def tapered_segment():
+    return ConicalGrainSegmentFactory.build(
+        length=LENGTH,
+        outer_diameter=OUTER_DIAMETER,
+        upper_core_diameter=UPPER_CORE_DIAMETER,
+        lower_core_diameter=LOWER_CORE_DIAMETER,
+    )
+
+
+def test_minimum_port_area_matches_the_tightest_station(tapered_segment):
+    web_distance = float(WEB_DISTANCE[0])
+    stations = np.linspace(
+        0.0, tapered_segment.length, tapered_segment.get_axial_resolution()
+    )
+
+    tightest = min(
+        tapered_segment.get_port_area(web_distance, float(z)) for z in stations
+    )
+
+    assert tapered_segment.get_minimum_port_area(web_distance) == pytest.approx(
+        tightest
+    )
+    assert tapered_segment.get_minimum_port_area(web_distance) < (
+        tapered_segment.get_port_area(web_distance)
+    )
+
+
+def test_mass_flux_uses_the_bottleneck_port_area(tapered_segment):
+    grain = grain_models.Grain(spacing=0.0)
+    grain.add_segment(tapered_segment)
+
+    mass_flux = grain.get_mass_flux_per_segment(BURN_RATE, IDEAL_DENSITY, WEB_DISTANCE)
+
+    web_distance = float(WEB_DISTANCE[0])
+    mass_flow_rate = (
+        tapered_segment.get_burn_area(web_distance) * IDEAL_DENSITY * BURN_RATE[0]
+    )
+    expected = mass_flow_rate / tapered_segment.get_minimum_port_area(web_distance)
+    aft_end_flux = mass_flow_rate / tapered_segment.get_port_area(web_distance)
+
+    assert mass_flux[0, 0] == pytest.approx(expected)
+    assert mass_flux[0, 0] > aft_end_flux
+
+
+def test_uniform_segment_bottleneck_is_its_port_area():
+    segment = StarGrainSegmentFactory.build(length=0.2, outer_diameter=OUTER_DIAMETER)
+    web_distance = float(WEB_DISTANCE[0])
+
+    assert segment.get_minimum_port_area(web_distance) == pytest.approx(
+        segment.get_port_area(web_distance)
+    )


### PR DESCRIPTION
`get_mass_flux_per_segment` called `get_port_area` with no axial position, so 3D segments read their aft end and axial port area variation was ignored. Segments now expose `get_minimum_port_area`, which for a segment with no axial variation is its port area and for a 3D segment is the station holding the most solid propellant.

For a conical segment tapering from a 30 mm bore at the nozzle to 8 mm at the bulkhead, the aft end reads 1320 mm² (its exposed end face is fully open) against a 82 mm² bottleneck, so the reported mass flux was low by more than an order of magnitude.

Closes #456. Part of #369.