### PR TITLE
Convert cells at the grid spacing, not the cell count

### DIFF
--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -66,10 +66,6 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         """Distance between adjacent axial slices [m]."""
         return self.length / max(self.get_axial_resolution() - 1, 1)
 
-    def get_radial_grid_spacing(self) -> float:
-        """Distance between adjacent cross-section cells [m]."""
-        return self.outer_diameter / (self.grid_resolution - 1)
-
     def get_coordinate_grids(
         self,
     ) -> tuple[

--- a/machwave/models/grain/fmm/base.py
+++ b/machwave/models/grain/fmm/base.py
@@ -109,37 +109,42 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
         """Convert a normalized input back into a dimensional value [m]."""
         return (value / 2) * (self.outer_diameter)
 
+    def get_radial_grid_spacing(self) -> float:
+        """
+        Return the distance between adjacent cross-section cells [m].
+
+        The grid spans the outer diameter over `grid_resolution` samples, so it
+        holds `grid_resolution - 1` intervals.
+        """
+        return self.outer_diameter / (self.grid_resolution - 1)
+
     def cells_to_meters(
         self, value: float | NDArray[np.float64]
     ) -> float | NDArray[np.float64]:
         """
-        Convert a pixel-distance value to [m].
+        Convert a cell-distance value to [m].
 
         Args:
-            value: Distance in pixel units.
+            value: Distance in cell units.
 
         Returns:
             Distance [m].
         """
-        return self.outer_diameter * (value / self.grid_resolution)
+        return value * self.get_radial_grid_spacing()
 
     def cells_to_square_meters(
         self, value: float | NDArray[np.float64]
     ) -> float | NDArray[np.float64]:
         """
-        Convert a pixel-area value to [m^2].
+        Convert a cell-area value to [m^2].
 
         Args:
-            value: Area in pixel units.
+            value: Area in cell units.
 
         Returns:
             Area [m^2].
         """
-        return (self.outer_diameter**2) * (value / (self.grid_resolution**2))
-
-    def get_normalized_spacing(self) -> float:
-        """Return the cell size in normalized coordinates (`1 / grid_resolution`)."""
-        return 1 / self.grid_resolution
+        return value * self.get_radial_grid_spacing() ** 2
 
     def _apply_surface_inhibition(
         self,
@@ -190,7 +195,8 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
 
     def _compute_regression_distance(self, masked_face: np.ndarray) -> np.ndarray:
         """Return the regression distance from the burning surface in normalized web units."""
-        return skfmm.distance(masked_face, dx=self.get_normalized_spacing()) * 2
+        distance = skfmm.distance(masked_face, dx=self.get_radial_grid_spacing())
+        return distance * (2.0 / self.outer_diameter)
 
     def get_regression_map(self):
         """

--- a/tests/test_models/test_propulsion/test_grain/test_cell_conversions.py
+++ b/tests/test_models/test_propulsion/test_grain/test_cell_conversions.py
@@ -1,0 +1,80 @@
+"""Cells convert to metres at the spacing of the grid they were sampled on.
+
+The cross-section grid spans the outer diameter over `grid_resolution`
+samples, so it holds `grid_resolution - 1` intervals. Dividing by the sample
+count instead shrinks every length and area read off the grid, and since the
+port area is the casing area less the face area, the whole deficit lands on
+the port.
+"""
+
+import numpy as np
+import pytest
+
+from tests.factories import ConicalGrainSegmentFactory, RodAndTubeGrainSegmentFactory
+
+OUTER_DIAMETER = 0.1
+ROD_OUTER_DIAMETER = 0.01
+TUBE_INNER_DIAMETER = 0.03
+PORT_AREA_TOLERANCE = 0.05
+
+
+@pytest.mark.parametrize("grid_resolution", [100, 200])
+def test_cells_span_the_outer_diameter(grid_resolution):
+    segment = RodAndTubeGrainSegmentFactory.build(
+        length=0.2, outer_diameter=OUTER_DIAMETER, grid_resolution=grid_resolution
+    )
+    interval_count = grid_resolution - 1
+
+    assert segment.cells_to_meters(interval_count) == pytest.approx(OUTER_DIAMETER)
+    assert segment.cells_to_square_meters(interval_count**2) == pytest.approx(
+        OUTER_DIAMETER**2
+    )
+
+
+@pytest.mark.parametrize("grid_resolution", [100, 200])
+def test_2d_port_area_matches_the_analytic_annulus(grid_resolution):
+    segment = RodAndTubeGrainSegmentFactory.build(
+        length=0.2,
+        outer_diameter=OUTER_DIAMETER,
+        rod_outer_diameter=ROD_OUTER_DIAMETER,
+        tube_inner_diameter=TUBE_INNER_DIAMETER,
+        grid_resolution=grid_resolution,
+    )
+
+    expected = np.pi / 4 * (TUBE_INNER_DIAMETER**2 - ROD_OUTER_DIAMETER**2)
+
+    assert segment.get_port_area(0.0) == pytest.approx(
+        expected, rel=PORT_AREA_TOLERANCE
+    )
+
+
+@pytest.mark.parametrize("grid_resolution", [100, 200])
+def test_3d_port_area_matches_the_analytic_bore(grid_resolution):
+    core_diameter = 0.03
+    segment = ConicalGrainSegmentFactory.build(
+        length=0.2,
+        outer_diameter=OUTER_DIAMETER,
+        upper_core_diameter=core_diameter,
+        lower_core_diameter=core_diameter,
+        grid_resolution=grid_resolution,
+    )
+
+    expected = np.pi / 4 * core_diameter**2
+
+    assert segment.get_port_area(0.0, 0.1) == pytest.approx(
+        expected, rel=PORT_AREA_TOLERANCE
+    )
+
+
+def test_web_thickness_matches_the_analytic_web():
+    """The tube burns from its bore out to the casing."""
+    segment = RodAndTubeGrainSegmentFactory.build(
+        length=0.2,
+        outer_diameter=OUTER_DIAMETER,
+        rod_outer_diameter=ROD_OUTER_DIAMETER,
+        tube_inner_diameter=TUBE_INNER_DIAMETER,
+    )
+
+    expected = (OUTER_DIAMETER - TUBE_INNER_DIAMETER) / 2
+
+    assert segment.get_web_thickness() == pytest.approx(expected, rel=0.01)

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl_solidworks.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_finocyl_solidworks.py
@@ -35,7 +35,11 @@ CASES = [  # only includes web distance of 0.0 mm (initial)
             moi_ratio=17763076.55 / 3108025.60,
             moi_rel=0.04,  # 4%
             end_face=6626.69e-6,
-            end_face_rel=0.02,  # 2%
+            # 4%: the traced slice sits within 0.2% of the modelled cross-section
+            # (bore annulus less six rectangular fins) at any grid resolution, and
+            # that cross-section is 3.5% above the CAD one, whose fins take more
+            # material at their root.
+            end_face_rel=0.04,
         ),
         id="web=0",
     ),


### PR DESCRIPTION
`cells_to_meters` and `cells_to_square_meters` divided by `grid_resolution`, but the coordinate grid spans the outer diameter over that many samples, so a cell is one of `grid_resolution - 1` intervals. Both now convert at `get_radial_grid_spacing`, promoted from the 3D class to the shared base and also used for the 2D regression field, which drops `get_normalized_spacing`.

Measured against analytic references:

| | before | after |
|---|---|---|
| 2D port area, grid 100 | +27.0% | +2.3% |
| 2D port area, grid 400 | +6.4% | +0.2% |
| 3D port area, grid 100 | +24.2% | +4.2% |
| 2D web thickness, grid 100 | -1.2% | -0.2% |
| 2D core perimeter | +1.5% | +0.5% |

Mass flux divides by the port area, so it was low by the same factor.

One reference moved: the finocyl end face against CAD was inside 2% only because the scale error cancelled part of a geometry difference. The traced slice now matches the modelled cross-section (bore annulus less six rectangular fins) to 0.2% at grid resolutions 100 through 300, and that cross-section is 3.5% above the CAD one, whose fins take more material at their root. Tolerance widened to 4% and the gap filed as #468.

Closes #465.