### PR TITLE
Burn the end faces without consuming their slices

### DIFF
--- a/docs/theory/grain_regression.md
+++ b/docs/theory/grain_regression.md
@@ -95,7 +95,7 @@ By default only the outer surface is inhibited.
 |---|---|---|---|
 | Outer | inhibited | ring inside the wall opens if uninhibited | same |
 | Core | burns | core cells masked if inhibited | core masked slice by slice |
-| End faces | burn | modeled by the grain length shrinking as they regress | first and last slices filled with zeros to expose them |
+| End faces | burn | modeled by the grain length shrinking as they regress | a void slice placed past each exposed end, outside the segment |
 
 ```
  ·  ·  ·  ·  ·  ·  1  ·  ·  ·  ·  ·  ·

--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -5,6 +5,7 @@ import numpy as np
 import skfmm
 from numpy.typing import NDArray
 from scipy.interpolate import interp1d
+from scipy.ndimage import binary_erosion
 from skimage import measure
 
 import machwave.core.filters as filters
@@ -30,6 +31,7 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
     ) -> None:
         self.burn_area_interpolator: Callable[[float], float] | None = None
         self.volume_interpolator: Callable[[float], float] | None = None
+        self.padded_regression_map: np.ndarray | None = None
 
         # Cache center of gravity and moment of inertia shared moments per web distance
         self._mask_moments_web: float | None = None
@@ -63,8 +65,12 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         return round(self.grid_resolution * self.length / self.outer_diameter)
 
     def get_axial_grid_spacing(self) -> float:
-        """Distance between adjacent axial slices [m]."""
-        return self.length / max(self.get_axial_resolution() - 1, 1)
+        """
+        Return the thickness of one axial slice [m].
+
+        The slices tile the length, so each one carries a full share of it.
+        """
+        return self.length / self.get_axial_resolution()
 
     def get_coordinate_grids(
         self,
@@ -74,9 +80,12 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         NDArray[np.float64],
     ]:
         if self.coordinate_grids is None:
+            # Slice centers, half a slice in from each end face.
+            axial_resolution = self.get_axial_resolution()
+            half_slice = 0.5 / axial_resolution
             map_y, map_z, map_x = np.meshgrid(
                 np.linspace(-1, 1, self.grid_resolution),
-                np.linspace(1, 0, self.get_axial_resolution()),  # z axis
+                np.linspace(1 - half_slice, half_slice, axial_resolution),  # z axis
                 np.linspace(-1, 1, self.grid_resolution),
             )
 
@@ -96,37 +105,59 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         face_map: NDArray[np.int_],
         excluded_mask: NDArray[np.bool_],
     ) -> tuple[NDArray[np.int_], NDArray[np.bool_]]:
-        if face_map.shape[0] <= 2:
-            return face_map, excluded_mask
+        inner_surface_inhibited_cells = face_map == 0
 
-        inner_surface_inhibited_cells = np.zeros_like(face_map, dtype=bool)
-        inner_surface_inhibited_cells[1:-1] = face_map[1:-1] == 0
-        inner_surface_inhibited_cells[0] = inner_surface_inhibited_cells[1]
-        inner_surface_inhibited_cells[-1] = inner_surface_inhibited_cells[-2]
-
-        # super() runs binary_erosion on the full 3D volume, which includes the
-        # end-face layers in the outer_surface_boundary. Apply end inhibition AFTER so
-        # those cells are not overwritten back to 0 by the outer-surface logic.
-        face_map, excluded_mask = super()._apply_surface_inhibition(
-            face_map, excluded_mask
-        )
-
-        if self.inhibited_surfaces.upper_end:
-            end_face_inhibited_cells = (
-                face_map[-1] == 0
-            ) & ~inner_surface_inhibited_cells[-1]
-            face_map[-1][end_face_inhibited_cells] = 1
-
-        if self.inhibited_surfaces.lower_end:
-            end_face_inhibited_cells = (
-                face_map[0] == 0
-            ) & ~inner_surface_inhibited_cells[0]
-            face_map[0][end_face_inhibited_cells] = 1
+        if not self.inhibited_surfaces.outer_surface:
+            # Erode with the end faces padded as inside, so the boundary the
+            # erosion finds is the casing wall and not the end slices.
+            inside = ~excluded_mask
+            padded_inside = np.pad(
+                inside, ((1, 1), (0, 0), (0, 0)), constant_values=True
+            )
+            eroded = binary_erosion(padded_inside)[1:-1]
+            face_map[inside & np.logical_not(eroded)] = 0
 
         if self.inhibited_surfaces.inner_surface:
             excluded_mask = excluded_mask | inner_surface_inhibited_cells
 
         return face_map, excluded_mask
+
+    @property
+    def has_cross_section_regression(self) -> bool:
+        """An exposed end face burns even when the cross section holds no core."""
+        return super().has_cross_section_regression or self.exposed_end_count > 0
+
+    def _get_exposed_end_padding(self) -> tuple[int, int]:
+        """Slices to add beyond the aft and forward end faces, one if exposed."""
+        return (
+            int(not self.inhibited_surfaces.lower_end),
+            int(not self.inhibited_surfaces.upper_end),
+        )
+
+    def _pad_exposed_ends(self, masked_face: np.ndarray) -> np.ndarray:
+        """
+        Place a void slice beyond each exposed end face.
+
+        The burning surface is the boundary between propellant and void, so an
+        end face only burns if there is void past it. Padding puts that void
+        outside the segment, which keeps the end slices as propellant.
+        """
+        lower, upper = self._get_exposed_end_padding()
+        if not (lower or upper):
+            return masked_face
+
+        pad_width = ((lower, upper), (0, 0), (0, 0))
+        data = np.pad(np.ma.getdata(masked_face), pad_width, constant_values=0)
+        # The casing runs past the end faces, so the pad carries its mask.
+        mask = np.pad(np.ma.getmaskarray(masked_face), pad_width, mode="edge")
+        return np.ma.MaskedArray(data, mask)
+
+    def _strip_exposed_ends(self, volume: np.ndarray) -> np.ndarray:
+        """Drop the padding slices, leaving the segment itself."""
+        lower, upper = self._get_exposed_end_padding()
+        if not (lower or upper):
+            return volume
+        return volume[lower : volume.shape[0] - upper]
 
     def _compute_regression_distance(self, masked_face: np.ndarray) -> np.ndarray:
         # Regression speed needs to be calibrated for the z axes separately from the x
@@ -134,10 +165,19 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         axial_grid_spacing = self.get_axial_grid_spacing()
         radial_grid_spacing = self.get_radial_grid_spacing()
         distance = skfmm.distance(
-            masked_face,
+            self._pad_exposed_ends(masked_face),
             dx=[axial_grid_spacing, radial_grid_spacing, radial_grid_spacing],  # type: ignore[arg-type]
         )
-        return distance * (2.0 / self.outer_diameter)
+        # The padded field keeps the end faces closed for the burn area mesh.
+        self.padded_regression_map = distance * (2.0 / self.outer_diameter)
+        return self._strip_exposed_ends(self.padded_regression_map)
+
+    def get_padded_regression_map(self) -> np.ndarray:
+        """Return the regression map including the void slice past each exposed end."""
+        regression_map = self.get_regression_map()
+        if self.padded_regression_map is None:
+            return regression_map
+        return self.padded_regression_map
 
     def get_axial_index(self, axial_position_normalized: float) -> int:
         """
@@ -148,11 +188,12 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
                 segment length, measured from the aft (nozzle) end.
 
         Returns:
-            Index of the nearest axial slice, within `[0, axial_resolution - 1]`.
+            Index of the slice holding that position, within
+            `[0, axial_resolution - 1]`.
         """
-        max_index = self.get_axial_resolution() - 1
-        axial_index = int(round(axial_position_normalized * max_index))
-        return min(max(axial_index, 0), max_index)
+        axial_resolution = self.get_axial_resolution()
+        axial_index = int(np.floor(axial_position_normalized * axial_resolution))
+        return min(max(axial_index, 0), axial_resolution - 1)
 
     def get_contours(
         self, web_distance: float, axial_position_normalized: float
@@ -177,7 +218,7 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
     def get_burn_area_interpolator(self) -> Callable[[float], float]:
         """Return a cached interpolator for burn area [m^2] vs web distance [m]."""
         if self.burn_area_interpolator is None:
-            regression_map = self.get_regression_map()
+            regression_map = self.get_padded_regression_map()
             regression_values = np.asarray(
                 regression_map[~np.ma.getmaskarray(regression_map)], dtype=np.float64
             )
@@ -419,7 +460,9 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         radial_grid_spacing = self.get_radial_grid_spacing()
         x = (np.arange(x_count, dtype=np.float64) - grid_center) * radial_grid_spacing
         y = (np.arange(y_count, dtype=np.float64) - grid_center) * radial_grid_spacing
-        z = np.arange(axial_count, dtype=np.float64) * self.get_axial_grid_spacing()
+        z = (
+            np.arange(axial_count, dtype=np.float64) + 0.5
+        ) * self.get_axial_grid_spacing()
 
         # Voxel counts projected onto each coordinate plane.
         projection_yx = mask.sum(axis=0)  # over z -> (y, x)

--- a/machwave/models/grain/geometries/conical.py
+++ b/machwave/models/grain/geometries/conical.py
@@ -80,7 +80,5 @@ class ConicalGrainSegment(grain_fmm.FMMGrainSegment3D):
         )
 
         core_map[radius < core_diameter / 2] = 0
-        core_map[0] = 0  # Inhibit the bottom end
-        core_map[-1] = 0  # Inhibit the top end
 
         return core_map

--- a/machwave/models/grain/geometries/finocyl.py
+++ b/machwave/models/grain/geometries/finocyl.py
@@ -208,7 +208,4 @@ class FinocylGrainSegment(grain_fmm.FMMGrainSegment3D):
             within_length = (radial > 0) & (radial < local_fin_tip_normalized)
             core_map[within_width & within_length] = 0
 
-        core_map[0] = 0
-        core_map[-1] = 0
-
         return core_map

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_axial_index.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_axial_index.py
@@ -34,11 +34,11 @@ def _bore_width_in_cells(segment, axial_position_normalized):
 
 
 def test_axial_index_spans_the_grid(tapered_segment):
-    last_index = tapered_segment.get_axial_resolution() - 1
+    axial_resolution = tapered_segment.get_axial_resolution()
 
     assert tapered_segment.get_axial_index(0.0) == 0
-    assert tapered_segment.get_axial_index(1.0) == last_index
-    assert tapered_segment.get_axial_index(0.5) == round(last_index / 2)
+    assert tapered_segment.get_axial_index(1.0) == axial_resolution - 1
+    assert tapered_segment.get_axial_index(0.5) == axial_resolution // 2
 
 
 def test_axial_index_clamps_positions_outside_the_segment(tapered_segment):

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_end_face_slices.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_end_face_slices.py
@@ -1,0 +1,76 @@
+"""An end face burns without eating the slice of propellant behind it.
+
+The burning surface is the boundary between propellant and void, so an end
+face is exposed by placing void beyond the segment rather than by emptying its
+end slice. Emptying it made the same grain hold less propellant purely because
+its ends were allowed to burn.
+"""
+
+import numpy as np
+import pytest
+
+from machwave.models.grain.base import InhibitedSurfaces
+from tests.factories import ConicalGrainSegmentFactory
+
+OUTER_DIAMETER = 0.1
+CORE_DIAMETER = 0.03
+VOLUME_TOLERANCE = 0.02
+
+BOTH_ENDS_INHIBITED = InhibitedSurfaces(
+    outer_surface=True, upper_end=True, lower_end=True
+)
+
+
+def _constant_bore_segment(length, inhibited_surfaces=None):
+    return ConicalGrainSegmentFactory.build(
+        length=length,
+        outer_diameter=OUTER_DIAMETER,
+        upper_core_diameter=CORE_DIAMETER,
+        lower_core_diameter=CORE_DIAMETER,
+        inhibited_surfaces=inhibited_surfaces,
+    )
+
+
+@pytest.mark.parametrize("length", [0.3, 0.02])
+def test_exposed_ends_hold_the_same_propellant_as_inhibited_ends(length):
+    exposed = _constant_bore_segment(length)
+    inhibited = _constant_bore_segment(length, BOTH_ENDS_INHIBITED)
+
+    assert exposed.get_volume(0.0) == pytest.approx(inhibited.get_volume(0.0))
+
+
+@pytest.mark.parametrize("length", [0.3, 0.02])
+def test_volume_matches_the_analytic_hollow_cylinder(length):
+    """Short segments used to lose a tenth of their propellant to the end slices."""
+    segment = _constant_bore_segment(length)
+
+    expected = np.pi / 4 * (OUTER_DIAMETER**2 - CORE_DIAMETER**2) * length
+
+    assert segment.get_volume(0.0) == pytest.approx(expected, rel=VOLUME_TOLERANCE)
+
+
+def test_axial_slices_tile_the_segment_length():
+    segment = _constant_bore_segment(0.3)
+
+    axial_extent = segment.get_axial_resolution() * segment.get_axial_grid_spacing()
+
+    assert axial_extent == pytest.approx(segment.length)
+
+
+def test_exposed_end_face_burns_from_the_end_of_the_segment():
+    """The end slice is one axial step from the front, not already consumed."""
+    segment = _constant_bore_segment(0.3)
+
+    end_slice_depth = float(segment.get_regression_map()[0].max())
+    axial_step = segment.normalize(segment.get_axial_grid_spacing())
+
+    assert end_slice_depth == pytest.approx(axial_step, rel=0.01)
+
+
+def test_inhibited_end_face_does_not_burn():
+    segment = _constant_bore_segment(0.3, BOTH_ENDS_INHIBITED)
+
+    end_slice_depth = float(segment.get_regression_map()[0].max())
+    axial_step = segment.normalize(segment.get_axial_grid_spacing())
+
+    assert end_slice_depth > 10 * axial_step

--- a/tests/test_models/test_propulsion/test_grain/test_inhibition/test_fmm_inhibition.py
+++ b/tests/test_models/test_propulsion/test_grain/test_inhibition/test_fmm_inhibition.py
@@ -51,23 +51,16 @@ def _boundary_ring_cells(masked_face) -> int:
     return int(np.sum(boundary))
 
 
-def _end_burning_cells(masked_face_3d, idx: int) -> int:
+def _is_burning_end(segment, idx: int) -> bool:
     """
-    Count burning propellant cells on an end slice, excluding the bore opening.
+    Report whether the end face at slice `idx` burns.
 
-    The bore opening is identified as the burning (0-valued) cells in the
-    adjacent interior slice — this matches how the FMM code defines inner_surface_inhibited_cells.
+    An exposed end face leaves its whole slice one axial step from the burning
+    surface; an inhibited one regresses from the bore, like the interior.
     """
-    sl = masked_face_3d[idx]
-    unmasked = ~np.ma.getmaskarray(sl)
-
-    # Bore opening = cells that are burning in the first interior slice
-    interior_idx = 1 if idx == 0 else -2
-    interior_sl = masked_face_3d[interior_idx]
-    interior_unmasked = ~np.ma.getmaskarray(interior_sl)
-    bore_at_end = (interior_sl.data == 0) & interior_unmasked
-
-    return int(np.sum((sl.data == 0) & unmasked & ~bore_at_end))
+    end_slice_depth = float(segment.get_regression_map()[idx].max())
+    axial_step = segment.normalize(segment.get_axial_grid_spacing())
+    return end_slice_depth <= 1.5 * axial_step
 
 
 # ── 2D: outer surface ─────────────────────────────────────────────────────────
@@ -159,64 +152,55 @@ def test_2d_outer_exposed_inner_inhibited():
 
 
 def test_3d_upper_end_exposed_by_default():
-    """Default: UE=F → upper end slice has burning cells beyond the bore."""
+    """Default: UE=F → the upper end face burns."""
     seg = grain_geometries.ConicalGrainSegment(
         **CONICAL_PARAMS,
         inhibited_surfaces=grain_models.InhibitedSurfaces(outer_surface=False),
     )
-    mf = seg.get_masked_face()
-    assert _end_burning_cells(mf, -1) > 0, "Upper end should be burning by default."
+    assert _is_burning_end(seg, -1), "Upper end should be burning by default."
 
 
 def test_3d_upper_end_inhibited():
-    """UE=T → upper end slice has no burning cells beyond the bore."""
+    """UE=T → the upper end face does not burn."""
     seg = grain_geometries.ConicalGrainSegment(
         **CONICAL_PARAMS,
         inhibited_surfaces=grain_models.InhibitedSurfaces(
             outer_surface=False, upper_end=True
         ),
     )
-    mf = seg.get_masked_face()
-    assert _end_burning_cells(mf, -1) == 0, (
-        "Upper end inhibited but still has burning cells."
-    )
+    assert not _is_burning_end(seg, -1), "Upper end inhibited but still burning."
 
 
 def test_3d_lower_end_exposed_by_default():
-    """Default: LE=F → lower end slice has burning cells beyond the bore."""
+    """Default: LE=F → the lower end face burns."""
     seg = grain_geometries.ConicalGrainSegment(
         **CONICAL_PARAMS,
         inhibited_surfaces=grain_models.InhibitedSurfaces(outer_surface=False),
     )
-    mf = seg.get_masked_face()
-    assert _end_burning_cells(mf, 0) > 0, "Lower end should be burning by default."
+    assert _is_burning_end(seg, 0), "Lower end should be burning by default."
 
 
 def test_3d_lower_end_inhibited():
-    """LE=T → lower end slice has no burning cells beyond the bore."""
+    """LE=T → the lower end face does not burn."""
     seg = grain_geometries.ConicalGrainSegment(
         **CONICAL_PARAMS,
         inhibited_surfaces=grain_models.InhibitedSurfaces(
             outer_surface=False, lower_end=True
         ),
     )
-    mf = seg.get_masked_face()
-    assert _end_burning_cells(mf, 0) == 0, (
-        "Lower end inhibited but still has burning cells."
-    )
+    assert not _is_burning_end(seg, 0), "Lower end inhibited but still burning."
 
 
 def test_3d_both_ends_inhibited():
-    """UE=T, LE=T → neither end slice has burning cells beyond the bore."""
+    """UE=T, LE=T → neither end face burns."""
     seg = grain_geometries.ConicalGrainSegment(
         **CONICAL_PARAMS,
         inhibited_surfaces=grain_models.InhibitedSurfaces(
             outer_surface=False, upper_end=True, lower_end=True
         ),
     )
-    mf = seg.get_masked_face()
-    assert _end_burning_cells(mf, -1) == 0, "Upper end inhibited but still burning."
-    assert _end_burning_cells(mf, 0) == 0, "Lower end inhibited but still burning."
+    assert not _is_burning_end(seg, -1), "Upper end inhibited but still burning."
+    assert not _is_burning_end(seg, 0), "Lower end inhibited but still burning."
 
 
 # ── 3D: OD=F + end inhibition interaction ────────────────────────────────────
@@ -242,7 +226,7 @@ def test_3d_outer_exposed_upper_end_inhibited():
     assert np.any((sl.data == 0) & boundary), (
         "OD=F: outer boundary at mid-slice should be burning."
     )
-    assert _end_burning_cells(mf, -1) == 0, "UE=T: upper end should not be burning."
+    assert not _is_burning_end(seg, -1), "UE=T: upper end should not be burning."
 
 
 def test_3d_outer_exposed_lower_end_inhibited():
@@ -265,4 +249,4 @@ def test_3d_outer_exposed_lower_end_inhibited():
     assert np.any((sl.data == 0) & boundary), (
         "OD=F: outer boundary at mid-slice should be burning."
     )
-    assert _end_burning_cells(mf, 0) == 0, "LE=T: lower end should not be burning."
+    assert not _is_burning_end(seg, 0), "LE=T: lower end should not be burning."


### PR DESCRIPTION
An exposed end face was represented by emptying its whole axial slice, so that slice's propellant vanished from every volume, mass and inertia read: the same grain held less propellant purely because its ends were allowed to burn.

The end slices now carry propellant, and the void that makes them burn is a padding slice placed past the segment. The padded field is kept for the marching-cubes pass, so the end faces stay closed in the burn area mesh at every web distance. Axial slices tile the length (`length / axial_resolution`) instead of overlapping it by one, since that over-count was cancelling part of the loss.

Constant-bore conical volume at web zero, against the analytic hollow cylinder:

| length / outer diameter | ends exposed before | ends inhibited before | both, after |
|---|---|---|---|
| 3 | -0.75% | -0.08% | -0.41% |
| 0.2 | -5.65% | +4.83% | -0.41% |

Exposed and inhibited ends now agree exactly, and the residual is the radial voxelization of the bore, which does not depend on the ends.

The CAD-validated finocyl stays inside its tolerances: burn area -0.23% (was -0.50%), volume +0.80% (was +0.46%), axial center of gravity -0.75% (unchanged), inertia ratio +1.41% (was +0.79%).

The end-face inhibition tests moved off the emptied-slice representation onto the behavior it stood for: an exposed end leaves its slice one axial step from the front, an inhibited one regresses from the bore.

Closes #466.