### PR TITLE
Express the web thickness cutoff the same way in 2D grain segments

### DIFF
--- a/machwave/models/grain/base.py
+++ b/machwave/models/grain/base.py
@@ -280,7 +280,7 @@ class GrainSegment2D(GrainSegment, ABC):
     def get_burn_area(self, web_distance: float) -> float:
         """Return the segment burn area at a given web distance [m^2]."""
         if web_distance > self.get_web_thickness():
-            return 0
+            return 0.0
 
         core_area = (
             0.0
@@ -293,12 +293,12 @@ class GrainSegment2D(GrainSegment, ABC):
 
     def get_volume(self, web_distance: float) -> float:
         """Return the segment volume at a given web distance [m^3]."""
-        if self.get_web_thickness() >= web_distance:
-            return self.get_length(web_distance=web_distance) * self.get_face_area(
-                web_distance=web_distance
-            )
-        else:
-            return 0
+        if web_distance > self.get_web_thickness():
+            return 0.0
+
+        return self.get_length(web_distance=web_distance) * self.get_face_area(
+            web_distance=web_distance
+        )
 
 
 class GrainSegment3D(GrainSegment, ABC):

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/test_web_thickness_cutoff.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment2d/test_web_thickness_cutoff.py
@@ -1,0 +1,54 @@
+"""Burn area and volume share one web thickness cutoff.
+
+Areas are held constant so the cutoff is what drives the results to zero,
+rather than the geometry running out on its own.
+"""
+
+import numpy as np
+import pytest
+
+import machwave.models.grain as grain_models
+
+LENGTH = 200e-3
+OUTER_DIAMETER = 100e-3
+WEB_THICKNESS = 10e-3
+CORE_AREA = 2e-3
+FACE_AREA = 1e-3
+
+
+class _ConstantAreaSegment(grain_models.GrainSegment2D):
+    """Segment whose areas do not vary with the web distance."""
+
+    def get_web_thickness(self) -> float:
+        return WEB_THICKNESS
+
+    def get_core_area(self, web_distance: float) -> float:
+        return CORE_AREA
+
+    def get_face_area(self, web_distance: float) -> float:
+        return FACE_AREA
+
+    def get_port_area(self, web_distance: float) -> float:
+        return FACE_AREA
+
+    def get_center_of_gravity(self, *args, **kwargs) -> np.typing.NDArray[np.float64]:
+        return np.zeros(3, dtype=np.float64)
+
+    def get_moment_of_inertia(self, *args, **kwargs) -> np.typing.NDArray[np.float64]:
+        return np.zeros((3, 3), dtype=np.float64)
+
+
+@pytest.fixture
+def segment():
+    return _ConstantAreaSegment(length=LENGTH, outer_diameter=OUTER_DIAMETER)
+
+
+def test_burn_area_and_volume_are_nonzero_at_the_web_thickness(segment):
+    assert segment.get_burn_area(WEB_THICKNESS) > 0.0
+    assert segment.get_volume(WEB_THICKNESS) > 0.0
+
+
+def test_burn_area_and_volume_are_zero_past_the_web_thickness(segment):
+    for web_distance in (np.nextafter(WEB_THICKNESS, np.inf), WEB_THICKNESS * 1.1):
+        assert segment.get_burn_area(web_distance) == 0.0
+        assert segment.get_volume(web_distance) == 0.0


### PR DESCRIPTION
`GrainSegment2D.get_volume` now uses the same early-return guard as `get_burn_area` for the web thickness cutoff, instead of the mirror-image condition. This is a readability change only: both methods stay nonzero at exactly the web thickness and zero beyond it, which a new boundary test pins down.

Closes #343