### PR TITLE
Validate the tank temperature against the fluid two-phase range

### DIFF
--- a/machwave/models/feed_systems/tank.py
+++ b/machwave/models/feed_systems/tank.py
@@ -39,8 +39,9 @@ class Tank:
                 density, e.g. 0.01 = 1% (>=0).
 
         Raises:
-            ValueError: If any argument is outside its valid physical range, or
-                if the initial fill is denser than the saturated liquid.
+            ValueError: If the fluid is unknown to CoolProp, if any argument is
+                outside its valid physical range, or if the initial fill is
+                denser than the saturated liquid.
         """
         self.fluid_name = fluid_name
         self.volume = volume
@@ -48,9 +49,9 @@ class Tank:
         self.initial_fluid_mass = initial_fluid_mass
         self.overfill_tolerance = overfill_tolerance
 
-        self._validate()
-
         self._coolprop = coolprop_service.CoolPropService(fluid_name)
+
+        self._validate()
 
         # The tank is isothermal with a fixed fluid, so these properties are constant
         # and cached
@@ -88,6 +89,37 @@ class Tank:
             raise ValueError(
                 "overfill_tolerance must be non-negative, got "
                 f"{self.overfill_tolerance}"
+            )
+
+        self._validate_temperature_range()
+
+    def _validate_temperature_range(self) -> None:
+        """
+        Validate the temperature against the two-phase range of the fluid.
+
+        The range spans the triple point up to, but not including, the critical
+        temperature: at and above the critical point the liquid and vapor phases
+        are no longer distinct, so the saturation model does not hold.
+
+        Raises:
+            ValueError: If the fluid is unknown to CoolProp, or if the
+                temperature lies outside the two-phase range of the fluid.
+        """
+        try:
+            triple_point_temperature = self._coolprop.get_triple_point_temperature()
+            critical_temperature = self._coolprop.get_critical_temperature()
+        except ValueError as error:
+            raise ValueError(
+                "fluid_name must be a fluid recognized by CoolProp, got "
+                f"{self.fluid_name!r}"
+            ) from error
+
+        if not triple_point_temperature <= self.temperature < critical_temperature:
+            raise ValueError(
+                f"temperature {self.temperature} K is outside the two-phase range "
+                f"of {self.fluid_name}, which spans {triple_point_temperature} K "
+                f"(triple point) up to but excluding {critical_temperature} K "
+                f"(critical point)"
             )
 
     def _check_not_overfilled(self) -> None:

--- a/machwave/services/coolprop.py
+++ b/machwave/services/coolprop.py
@@ -24,6 +24,24 @@ class CoolPropService:
         """
         return CP.PropsSI("M", self.fluid_name)
 
+    def get_triple_point_temperature(self) -> float:
+        """
+        Get the triple point temperature of the fluid.
+
+        Returns:
+            Triple point temperature [K].
+        """
+        return CP.PropsSI("Ttriple", self.fluid_name)
+
+    def get_critical_temperature(self) -> float:
+        """
+        Get the critical temperature of the fluid.
+
+        Returns:
+            Critical temperature [K].
+        """
+        return CP.PropsSI("Tcrit", self.fluid_name)
+
     def get_saturation_pressure(self, temperature: float) -> float:
         """
         Get the saturation pressure on the liquid side of the saturation curve.

--- a/tests/test_models/test_propulsion/test_feed_systems/test_tank.py
+++ b/tests/test_models/test_propulsion/test_feed_systems/test_tank.py
@@ -294,3 +294,104 @@ def test_init_rejects_invalid_inputs(overrides, match):
 
     with pytest.raises(ValueError, match=match):
         tank_models.Tank(**kwargs)
+
+
+@pytest.mark.parametrize("fluid_name", ["N2O", "Ethanol"])
+def test_init_rejects_supercritical_temperature(fluid_name):
+    """
+    Above the critical temperature no distinct liquid phase exists, so the
+    saturation lookups have no answer and the tank must reject the input with a
+    clean error instead of letting CoolProp fail.
+    """
+    temperature = CP.PropsSI("Tcrit", fluid_name) + 50.0
+
+    with pytest.raises(ValueError, match="outside the two-phase range"):
+        tank_models.Tank(
+            fluid_name=fluid_name,
+            volume=0.01,
+            temperature=temperature,
+            initial_fluid_mass=0.5,
+        )
+
+
+@pytest.mark.parametrize("fluid_name", ["N2O", "Ethanol"])
+def test_init_rejects_critical_temperature(fluid_name):
+    """
+    The critical temperature itself is excluded: liquid and vapor are already
+    indistinguishable there, which the two-phase model cannot represent.
+    """
+    temperature = CP.PropsSI("Tcrit", fluid_name)
+
+    with pytest.raises(ValueError, match="outside the two-phase range"):
+        tank_models.Tank(
+            fluid_name=fluid_name,
+            volume=0.01,
+            temperature=temperature,
+            initial_fluid_mass=0.5,
+        )
+
+
+@pytest.mark.parametrize("fluid_name", ["N2O", "Ethanol"])
+def test_init_rejects_temperature_below_triple_point(fluid_name):
+    """
+    Below the triple point the fluid is solid, so the saturated-liquid lookups
+    are undefined and the tank must reject the input.
+    """
+    temperature = CP.PropsSI("Ttriple", fluid_name) - 10.0
+
+    with pytest.raises(ValueError, match="outside the two-phase range"):
+        tank_models.Tank(
+            fluid_name=fluid_name,
+            volume=0.01,
+            temperature=temperature,
+            initial_fluid_mass=0.5,
+        )
+
+
+@pytest.mark.parametrize("fluid_name", ["N2O", "Ethanol"])
+def test_init_accepts_triple_point_temperature(fluid_name):
+    """
+    The triple point is the inclusive lower end of the range: liquid and vapor
+    still coexist there, so the tank must accept it and resolve saturation.
+    """
+    temperature = CP.PropsSI("Ttriple", fluid_name)
+
+    tank = tank_models.Tank(
+        fluid_name=fluid_name,
+        volume=0.01,
+        temperature=temperature,
+        initial_fluid_mass=0.5,
+    )
+
+    assert tank.saturation_pressure > 0.0
+    assert tank.saturated_liquid_density > tank.saturated_vapor_density
+
+
+@pytest.mark.parametrize("fluid_name", ["N2O", "Ethanol"])
+def test_init_accepts_temperature_inside_two_phase_range(fluid_name):
+    """A temperature between the two bounds stays valid."""
+    triple_point_temperature = CP.PropsSI("Ttriple", fluid_name)
+    critical_temperature = CP.PropsSI("Tcrit", fluid_name)
+    temperature = 0.5 * (triple_point_temperature + critical_temperature)
+
+    tank = tank_models.Tank(
+        fluid_name=fluid_name,
+        volume=0.01,
+        temperature=temperature,
+        initial_fluid_mass=0.5,
+    )
+
+    assert tank.saturation_pressure == pytest.approx(
+        CP.PropsSI("P", "T", temperature, "Q", 0, fluid_name)
+    )
+
+
+def test_init_rejects_unknown_fluid():
+    """An unrecognized fluid must surface as a clean error, not a CoolProp one."""
+    with pytest.raises(ValueError, match="recognized by CoolProp"):
+        tank_models.Tank(
+            fluid_name="Unobtainium",
+            volume=0.01,
+            temperature=298.0,
+            initial_fluid_mass=0.5,
+        )

--- a/tests/test_services/test_coolprop.py
+++ b/tests/test_services/test_coolprop.py
@@ -18,6 +18,14 @@ def test_get_molar_mass(service):
     assert service.get_molar_mass() == CP.PropsSI("M", FLUID_NAME)
 
 
+def test_get_triple_point_temperature(service):
+    assert service.get_triple_point_temperature() == CP.PropsSI("Ttriple", FLUID_NAME)
+
+
+def test_get_critical_temperature(service):
+    assert service.get_critical_temperature() == CP.PropsSI("Tcrit", FLUID_NAME)
+
+
 def test_get_saturation_pressure(service):
     assert service.get_saturation_pressure(TEMPERATURE) == CP.PropsSI(
         "P", "T", TEMPERATURE, "Q", 0, FLUID_NAME


### PR DESCRIPTION
Validate the requested tank temperature against the two-phase range of the fluid, from the triple point (inclusive) up to the critical temperature (exclusive), before any saturation lookup runs, so out-of-range temperatures and unrecognized fluid names raise a clean `ValueError` naming the fluid, the temperature and the valid range instead of a raw CoolProp error. The bounds come from two new accessors on `CoolPropService`.

Closes #325
