### PR TITLE
Define burn time only from propellant depletion

### DIFF
--- a/machwave/simulation/biliquid/results.py
+++ b/machwave/simulation/biliquid/results.py
@@ -49,7 +49,7 @@ class BiliquidSimulationResult(
         print("\nBILIQUID ENGINE OPERATION RESULTS", file=file)
 
         print(f"Initial propellant mass: {self.propellant_mass[0]:.4f} kg", file=file)
-        print(f"Burnout time: {self.burn_time:.4f} s", file=file)
+        print(f"Burnout time: {self._format_burn_time(decimals=4)}", file=file)
         print(f"Thrust time: {self.thrust_time:.4f} s", file=file)
 
         print("\nCHAMBER PRESSURE (MPa)", file=file)

--- a/machwave/simulation/results.py
+++ b/machwave/simulation/results.py
@@ -30,7 +30,8 @@ class SimulationResult(ABC, Generic[StateT]):
     nozzle_efficiency: SimulationResultArray
     loss_fractions: dict[str, SimulationResultArray]
     loss_labels: dict[str, str]
-    burn_time: float
+    # None when the run terminated with propellant remaining.
+    burn_time: float | None
     thrust_time: float
     end_thrust: bool
     end_burn: bool
@@ -103,7 +104,13 @@ class SimulationResult(ABC, Generic[StateT]):
             label = self.loss_labels[name]
             print(f"  Average {label} fraction: {np.mean(series):.3%}", file=file)
 
-    def summary(self) -> dict[str, float]:
+    def _format_burn_time(self, decimals: int = 3) -> str:
+        """Format the burn time for a report, or flag it as never reached."""
+        if self.burn_time is None:
+            return "not reached"
+        return f"{self.burn_time:.{decimals}f} s"
+
+    def summary(self) -> dict[str, float | None]:
         """Return a mapping of headline scalar metrics for this result."""
         return {
             "burn_time": self.burn_time,

--- a/machwave/simulation/solid/results.py
+++ b/machwave/simulation/solid/results.py
@@ -187,7 +187,8 @@ class SolidSimulationResult(
             file=file,
         )
         print(
-            f" Burnout time, thrust time: {self.burn_time:.3f}, {self.thrust_time:.3f} s",
+            f" Burnout time: {self._format_burn_time()}, "
+            f"thrust time: {self.thrust_time:.3f} s",
             file=file,
         )
 

--- a/machwave/simulation/states.py
+++ b/machwave/simulation/states.py
@@ -184,8 +184,6 @@ class MotorState(ABC):
         if is_choked and not has_tailed_off:
             return False
 
-        if self._burn_time is None:
-            self._burn_time = time
         self._thrust_time = time
         self.end_thrust = True
         return True
@@ -212,15 +210,13 @@ class MotorState(ABC):
         return self._thrust_time
 
     @property
-    def burn_time(self) -> float:
+    def burn_time(self) -> float | None:
         """
-        Return the burn time [s].
+        Return the burn time [s], or None if burnout was never reached.
 
-        Raises:
-            ValueError: If the simulation has not yet completed.
+        Only propellant depletion defines a burn time: a run whose thrust
+        terminates with propellant remaining leaves it undefined.
         """
-        if self._burn_time is None:
-            raise ValueError("Burn time has not been set, run the simulation.")
         return self._burn_time
 
 

--- a/tests/test_simulations/test_biliquid_engine_simulation.py
+++ b/tests/test_simulations/test_biliquid_engine_simulation.py
@@ -248,6 +248,7 @@ def test_surviving_propellant_stops_draining_after_burnout(
     simulation_result: biliquid_simulation.BiliquidSimulationResult,
 ) -> None:
     """Tail-off is a blowdown: neither tank feeds the chamber past burnout."""
+    assert simulation_result.burn_time is not None
     after_burnout = simulation_result.time >= simulation_result.burn_time
     assert after_burnout.sum() > 1, "run ended at burnout, tail-off not exercised"
 
@@ -270,6 +271,29 @@ def test_tail_off_terminates_thrust_against_zero_ambient_pressure() -> None:
     assert state.thrust[-1] < (
         simulation_states.TAIL_OFF_THRUST_FRACTION * state.peak_thrust
     )
+
+
+def test_unchoked_run_with_propellant_remaining_leaves_burn_time_undefined() -> None:
+    """Thrust termination on its own never defines a burn time."""
+    state = _build_state_for_burnout_test()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        state.run_timestep(d_t=1e-4, external_pressure=1e5)
+        # Un-chokes the nozzle while both tanks still hold propellant.
+        state.run_timestep(d_t=1e-4, external_pressure=state.chamber_pressure[-1])
+
+    assert state.end_thrust is True
+    assert state.end_burn is False
+    assert state.propellant_mass[-1] > 0.0
+    assert state.burn_time is None
+
+    result = state.build_result()
+    assert result.burn_time is None
+
+    buffer = io.StringIO()
+    result.report(file=buffer)
+    assert "Burnout time: not reached" in buffer.getvalue()
 
 
 def test_live_mixture_ratio_drives_cea() -> None:

--- a/tests/test_simulations/test_solid_motor_simulation.py
+++ b/tests/test_simulations/test_solid_motor_simulation.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import dataclasses
 import io
+import warnings
 from typing import Callable
 
 import numpy as np
@@ -68,6 +69,8 @@ def test_simulation_completes_with_terminal_state(
 def test_burn_time_and_thrust_time_are_finite_and_ordered(
     simulation_result: solid_simulation.SolidSimulationResult,
 ) -> None:
+    # These motors burn out before the nozzle un-chokes, so burnout is defined.
+    assert simulation_result.burn_time is not None
     assert np.isfinite(simulation_result.burn_time)
     assert np.isfinite(simulation_result.thrust_time)
     assert simulation_result.burn_time > 0.0
@@ -217,6 +220,7 @@ def test_vacuum_run_terminates_on_tail_off() -> None:
 
     assert result.end_thrust is True
     assert result.end_burn is True
+    assert result.burn_time is not None
     assert result.thrust_time > result.burn_time
     peak_thrust = float(np.max(result.thrust))
     assert result.thrust[-1] < simulation_states.TAIL_OFF_THRUST_FRACTION * peak_thrust
@@ -236,6 +240,54 @@ def test_sea_level_run_still_ends_on_loss_of_choking() -> None:
     )
     peak_thrust = float(np.max(result.thrust))
     assert result.thrust[-1] > simulation_states.TAIL_OFF_THRUST_FRACTION * peak_thrust
+
+
+def _run_until_unchoked_with_propellant_remaining() -> solid_simulation.SolidMotorState:
+    """Step a solid motor until the nozzle un-chokes with grain left to burn.
+
+    Raising the ambient pressure to the chamber pressure un-chokes the nozzle
+    and terminates thrust long before the propellant is consumed.
+    """
+    motor, params = motor_builders.build_nero_motor()
+    state = solid_simulation.SolidMotorState(
+        motor=motor,
+        igniter_pressure=params.igniter_pressure,
+        external_pressure=params.external_pressure,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        for _ in range(3):
+            state.run_timestep(
+                d_t=params.d_t, external_pressure=params.external_pressure
+            )
+        state.run_timestep(d_t=params.d_t, external_pressure=state.chamber_pressure[-1])
+    return state
+
+
+def test_unchoked_run_with_propellant_remaining_leaves_burn_time_undefined() -> None:
+    """Thrust termination on its own never defines a burn time."""
+    state = _run_until_unchoked_with_propellant_remaining()
+
+    assert state.end_thrust is True
+    assert state.end_burn is False
+    assert state.propellant_mass[-1] > 0.0
+    assert state.burn_time is None
+    assert state.thrust_time > 0.0
+
+
+def test_undefined_burn_time_still_builds_a_result_and_a_report() -> None:
+    """A run that never burns out reports the thrust time and no burnout time."""
+    result = _run_until_unchoked_with_propellant_remaining().build_result()
+
+    assert result.burn_time is None
+    assert result.summary()["burn_time"] is None
+
+    buffer = io.StringIO()
+    result.report(file=buffer)
+    output = buffer.getvalue()
+
+    assert "Burnout time: not reached" in output
+    assert f"thrust time: {result.thrust_time:.3f} s" in output
 
 
 def test_moment_of_inertia_is_guarded_past_burnout() -> None:


### PR DESCRIPTION
Thrust termination no longer backfills the burn time, so a motor whose nozzle flow un-chokes with propellant remaining leaves burnout undefined instead of reporting a burn time equal to its thrust time. The undefined burn time is carried as `None` through the state property, the result field and the summary, and both reports print "not reached" rather than a misleading number.

Closes #347