### PR TITLE
Solve exit Mach number on a stated branch of the area-Mach relation

### DIFF
--- a/machwave/core/compressible_flow/__init__.py
+++ b/machwave/core/compressible_flow/__init__.py
@@ -7,10 +7,12 @@ from .nozzle import (
     get_thrust_from_thrust_coefficient,
 )
 from .isentropic import (
+    FlowBranch,
     get_critical_pressure_ratio,
     get_exit_mach_from_expansion_ratio,
     get_exit_pressure,
     get_expansion_ratio_from_exit_mach,
+    get_maximum_expansion_ratio,
     is_flow_choked,
 )
 
@@ -21,9 +23,11 @@ __all__ = [
     "get_ideal_thrust_coefficient_terms",
     "get_thrust_from_thrust_coefficient",
     # isentropic
+    "FlowBranch",
     "get_critical_pressure_ratio",
     "get_expansion_ratio_from_exit_mach",
     "get_exit_mach_from_expansion_ratio",
     "get_exit_pressure",
+    "get_maximum_expansion_ratio",
     "is_flow_choked",
 ]

--- a/machwave/core/compressible_flow/isentropic.py
+++ b/machwave/core/compressible_flow/isentropic.py
@@ -1,6 +1,22 @@
+import enum
 from typing import cast
 
 import scipy.optimize
+
+SONIC_MACH = 1.0
+
+
+class FlowBranch(enum.StrEnum):
+    """Branch of the area-Mach relation that a solution is taken from."""
+
+    SUBSONIC = "subsonic"
+    SUPERSONIC = "supersonic"
+
+
+MACH_LIMITS: dict[FlowBranch, float] = {
+    FlowBranch.SUBSONIC: 1e-6,
+    FlowBranch.SUPERSONIC: 20.0,
+}
 
 
 def get_critical_pressure_ratio(k: float) -> float:
@@ -32,40 +48,73 @@ def get_expansion_ratio_from_exit_mach(mach: float, k: float) -> float:
     return (1 / mach) * (term1**term2)
 
 
-def get_exit_mach_from_expansion_ratio(k: float, expansion_ratio: float) -> float:
+def get_maximum_expansion_ratio(k: float, branch: FlowBranch) -> float:
+    """
+    Get the largest expansion ratio the exit Mach solver resolves on a branch.
+
+    Args:
+        k: Isentropic exponent.
+        branch: Branch of the area-Mach relation.
+
+    Returns:
+        Expansion ratio at the Mach limit of the branch.
+    """
+    return get_expansion_ratio_from_exit_mach(MACH_LIMITS[branch], k)
+
+
+def get_exit_mach_from_expansion_ratio(
+    k: float,
+    expansion_ratio: float,
+    branch: FlowBranch = FlowBranch.SUPERSONIC,
+) -> float:
     """
     Get exit Mach number from expansion ratio.
+
+    Every expansion ratio above unity satisfies the area-Mach relation at one
+    subsonic and one supersonic Mach number. The supersonic root is returned by
+    default, which is the started nozzle flowing full. A nozzle that is not started
+    carries a normal shock in its divergent section and leaves subsonically, so its
+    physical root is the subsonic one and has to be asked for explicitly.
 
     Args:
         k: Isentropic exponent.
         expansion_ratio: Expansion ratio (A_exit / A_throat).
+        branch: Branch of the area-Mach relation to solve on.
 
     Returns:
         Exit Mach number.
 
     Raises:
-        ValueError: If solver fails to converge.
+        ValueError: If the expansion ratio lies outside the range the branch covers.
     """
-    try:
-        exit_mach = cast(
-            float,
-            scipy.optimize.brentq(
-                lambda m: get_expansion_ratio_from_exit_mach(m, k) - expansion_ratio,
-                a=1.001,  # Just above sonic
-                b=20.0,  # High supersonic
-            ),
-        )
-        return exit_mach
-    except ValueError as e:
+    mach_limit = MACH_LIMITS[branch]
+    maximum_expansion_ratio = get_maximum_expansion_ratio(k, branch)
+    if not 1.0 <= expansion_ratio <= maximum_expansion_ratio:
         raise ValueError(
-            f"Failed to converge for expansion_ratio={expansion_ratio}, k={k}"
-        ) from e
+            f"Expansion ratio {expansion_ratio} has no {branch} solution for "
+            f"isentropic exponent {k}. The {branch} branch covers expansion ratios "
+            f"from 1 at the sonic throat to {maximum_expansion_ratio:.6g} at the "
+            f"Mach {mach_limit:g} limit of the solver."
+        )
+
+    if expansion_ratio <= get_expansion_ratio_from_exit_mach(SONIC_MACH, k):
+        return SONIC_MACH  # Both roots meet at the throat.
+
+    return cast(
+        float,
+        scipy.optimize.brentq(
+            lambda m: get_expansion_ratio_from_exit_mach(m, k) - expansion_ratio,
+            a=min(SONIC_MACH, mach_limit),
+            b=max(SONIC_MACH, mach_limit),
+        ),
+    )
 
 
 def get_exit_pressure(
     k_exhaust: float,
     expansion_ratio: float,
     chamber_pressure: float,
+    branch: FlowBranch = FlowBranch.SUPERSONIC,
 ) -> float:
     """
     Get exit pressure from isentropic relations.
@@ -74,11 +123,12 @@ def get_exit_pressure(
         k_exhaust: Isentropic exponent at exit.
         expansion_ratio: Expansion ratio.
         chamber_pressure: Chamber pressure [Pa].
+        branch: Branch of the area-Mach relation to solve the exit Mach number on.
 
     Returns:
         Exit pressure [Pa].
     """
-    exit_mach = get_exit_mach_from_expansion_ratio(k_exhaust, expansion_ratio)
+    exit_mach = get_exit_mach_from_expansion_ratio(k_exhaust, expansion_ratio, branch)
     return chamber_pressure * (1 + 0.5 * (k_exhaust - 1) * exit_mach**2) ** (
         -k_exhaust / (k_exhaust - 1)
     )

--- a/machwave/core/compressible_flow/nozzle.py
+++ b/machwave/core/compressible_flow/nozzle.py
@@ -52,7 +52,12 @@ def get_separated_exit_conditions(
         separation_pressure_ratio: Separation-to-ambient pressure ratio.
 
     Returns:
-        Effective expansion ratio and effective exit pressure [Pa].
+        Effective expansion ratio and effective exit pressure [Pa]. The effective
+        expansion ratio never falls below the throat value of unity.
+
+    Raises:
+        ValueError: If the geometric expansion ratio lies outside the range the
+            supersonic branch of the area-Mach relation covers.
 
     References:
         Summerfield, M., Foster, C. R., & Swan, W. C. (1954). Flow separation in
@@ -71,6 +76,8 @@ def get_separated_exit_conditions(
     if separation_pressure >= sonic_pressure:
         return 1.0, sonic_pressure
 
+    # The exit pressure falls monotonically from the sonic throat to the geometric
+    # exit, so bracketing from the throat always contains the separation point.
     effective_expansion_ratio = cast(
         float,
         scipy.optimize.brentq(
@@ -78,7 +85,7 @@ def get_separated_exit_conditions(
                 isentropic.get_exit_pressure(k_exhaust, ratio, chamber_pressure)
                 - separation_pressure
             ),
-            a=1.001,
+            a=1.0,
             b=expansion_ratio,
         ),
     )

--- a/tests/test_core/test_compressible_flow/test_isentropic.py
+++ b/tests/test_core/test_compressible_flow/test_isentropic.py
@@ -26,6 +26,73 @@ def test_get_exit_mach_from_expansion_ratio():
     assert exit_mach == pytest.approx(3.677229)
 
 
+@pytest.mark.parametrize("k", [1.15, 1.2, 1.4])
+@pytest.mark.parametrize("expansion_ratio", [1.0 + 1e-9, 1.001, 1.5, 8.0, 100.0])
+def test_get_exit_mach_from_expansion_ratio_round_trip(k, expansion_ratio):
+    exit_mach = isentropic.get_exit_mach_from_expansion_ratio(k, expansion_ratio)
+
+    assert exit_mach > 1.0
+    assert isentropic.get_expansion_ratio_from_exit_mach(exit_mach, k) == pytest.approx(
+        expansion_ratio
+    )
+
+
+def test_get_exit_mach_from_expansion_ratio_at_throat():
+    for branch in isentropic.FlowBranch:
+        assert isentropic.get_exit_mach_from_expansion_ratio(1.2, 1.0, branch) == 1.0
+
+
+def test_get_exit_mach_from_expansion_ratio_below_throat():
+    with pytest.raises(ValueError, match="no supersonic solution"):
+        isentropic.get_exit_mach_from_expansion_ratio(1.2, 0.999)
+
+
+def test_get_exit_mach_from_expansion_ratio_above_mach_limit():
+    k = 1.4
+    maximum_expansion_ratio = isentropic.get_maximum_expansion_ratio(
+        k, isentropic.FlowBranch.SUPERSONIC
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        isentropic.get_exit_mach_from_expansion_ratio(k, 2 * maximum_expansion_ratio)
+
+    message = str(excinfo.value)
+    assert "supersonic branch covers expansion ratios" in message
+    assert "sonic throat" in message
+    assert f"{maximum_expansion_ratio:.6g}" in message
+
+    assert isentropic.get_exit_mach_from_expansion_ratio(
+        k, maximum_expansion_ratio
+    ) == pytest.approx(20.0)
+
+
+def test_get_exit_mach_from_expansion_ratio_subsonic_branch():
+    k = 1.2
+    expansion_ratio = 8.0
+    subsonic_mach = isentropic.get_exit_mach_from_expansion_ratio(
+        k, expansion_ratio, isentropic.FlowBranch.SUBSONIC
+    )
+
+    assert subsonic_mach < 1.0
+    assert isentropic.get_expansion_ratio_from_exit_mach(
+        subsonic_mach, k
+    ) == pytest.approx(expansion_ratio)
+    assert subsonic_mach != pytest.approx(
+        isentropic.get_exit_mach_from_expansion_ratio(k, expansion_ratio)
+    )
+
+
+def test_get_exit_mach_from_expansion_ratio_subsonic_branch_above_mach_limit():
+    k = 1.2
+    branch = isentropic.FlowBranch.SUBSONIC
+    maximum_expansion_ratio = isentropic.get_maximum_expansion_ratio(k, branch)
+
+    with pytest.raises(ValueError, match="no subsonic solution"):
+        isentropic.get_exit_mach_from_expansion_ratio(
+            k, 2 * maximum_expansion_ratio, branch
+        )
+
+
 def test_get_exit_pressure():
     k_exhaust = 1.4
     expansion_ratio = 8.0
@@ -35,6 +102,32 @@ def test_get_exit_pressure():
     )
 
     assert exit_pressure == pytest.approx(71545.88, rel=1e-2)
+
+
+def test_get_exit_pressure_at_throat_is_sonic():
+    k_exhaust = 1.2
+    chamber_pressure = 7e6
+    exit_pressure = isentropic.get_exit_pressure(k_exhaust, 1.0, chamber_pressure)
+
+    assert exit_pressure == pytest.approx(
+        chamber_pressure * isentropic.get_critical_pressure_ratio(k_exhaust)
+    )
+
+
+def test_get_exit_pressure_subsonic_branch():
+    # An unstarted nozzle leaves subsonically and barely drops below chamber pressure.
+    k_exhaust = 1.2
+    expansion_ratio = 8.0
+    chamber_pressure = 7e6
+    subsonic_exit_pressure = isentropic.get_exit_pressure(
+        k_exhaust, expansion_ratio, chamber_pressure, isentropic.FlowBranch.SUBSONIC
+    )
+    supersonic_exit_pressure = isentropic.get_exit_pressure(
+        k_exhaust, expansion_ratio, chamber_pressure
+    )
+
+    assert subsonic_exit_pressure == pytest.approx(chamber_pressure, rel=1e-2)
+    assert supersonic_exit_pressure < 0.1 * subsonic_exit_pressure
 
 
 def test_is_flow_choked_true():

--- a/tests/test_core/test_compressible_flow/test_nozzle.py
+++ b/tests/test_core/test_compressible_flow/test_nozzle.py
@@ -73,6 +73,32 @@ def test_get_separated_exit_conditions_unchoked_limit():
     )
 
 
+@pytest.mark.parametrize("chamber_pressure", [71000, 72000, 73000, 73400])
+def test_get_separated_exit_conditions_near_sonic_separation(chamber_pressure):
+    # These chamber pressures put the separation pressure just below the sonic one.
+    k_exhaust = 1.2
+    expansion_ratio = 8.0
+    external_pressure = 1e5
+    separation_pressure_ratio = 0.4
+    effective_expansion_ratio, exit_pressure = (
+        core_nozzle.get_separated_exit_conditions(
+            k_exhaust,
+            expansion_ratio,
+            chamber_pressure,
+            external_pressure,
+            separation_pressure_ratio,
+        )
+    )
+
+    assert 1.0 < effective_expansion_ratio < 1.001
+    assert exit_pressure == pytest.approx(separation_pressure_ratio * external_pressure)
+
+
+def test_get_separated_exit_conditions_below_throat():
+    with pytest.raises(ValueError, match="no supersonic solution"):
+        core_nozzle.get_separated_exit_conditions(1.2, 0.9, 7e6, 1e5, 0.4)
+
+
 @pytest.mark.parametrize(
     "external_pressure, expected_pressure_term",
     [


### PR DESCRIPTION
Bracket the exit Mach number solver from the sonic throat, validate the expansion ratio against the range the solver actually covers with an explanatory error, and allow the subsonic root to be requested explicitly while the supersonic root stays the default. Separated exit conditions bracket from the throat too, closing the chamber pressure window whose separation point fell below the old lower bound.

Closes #135