### PR TITLE
Ignore coverage artifacts and stop tracking editor configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Temporary Items
 
 # IDE
 .idea/
+.vscode/
 workspace.code-workspace
 
 # Temporary files:
@@ -74,4 +75,6 @@ machwave/_version.py
 .pytest_cache/
 .ruff_cache/
 .coverage
+.coverage.*
 htmlcov/
+coverage.xml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-    "makefile.extensionOutputFolder": "./.vscode",
-    "[python]": {
-        "editor.defaultFormatter": "charliermarsh.ruff",
-        "editor.formatOnSave": true
-    },
-    "python.formatting.provider": "none",
-    "python-envs.pythonProjects": []
-}


### PR DESCRIPTION
Prevention half of #374.

Stops tracking `.vscode/settings.json` and ignores the directory; the file stays on disk. Ignores the `coverage.xml` report written by the `coverage` make target, and the per-worker `.coverage.*` data files that pytest-cov writes when the suite runs under pytest-xdist.

The issue also proposed rules for the simulation output directories, Plotly HTML exports, SQLite databases and `.eng` exports. Those are left out on purpose: nothing in the current tree produces any of them, and an unused `*.eng` rule would silently shadow a future test fixture. Those paths are handled by the history purge alone.

`git ls-files -c --ignored --exclude-standard` is empty, so nothing else tracked becomes ignored.