### PR TITLE
Mesh the burn area iso-levels across worker processes

### DIFF
--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -1,3 +1,7 @@
+import concurrent.futures
+import math
+import multiprocessing
+import os
 from abc import ABC
 from collections.abc import Callable
 
@@ -16,6 +20,136 @@ import machwave.models.grain.base as grain_base
 
 from . import base as fmm_base
 from . import contours as fmm_contours
+
+ISO_LEVEL_COUNT = 80
+
+# Meshing the iso-levels costs about a second per two million cells of the
+# distance field, so the cell count decides whether a process pool earns its
+# keep. A forking pool starts in milliseconds and hands the field to its workers
+# through copy-on-write; a spawning pool starts a fresh interpreter and pickles
+# the field once per worker, a few seconds of overhead no matter the field size.
+FORK_PARALLEL_CELL_COUNT = 2_000_000
+SPAWN_PARALLEL_CELL_COUNT = 12_000_000
+
+_worker_distance_field: NDArray[np.float64] | None = None
+_worker_grid_spacing: tuple[float, float, float] | None = None
+
+
+def _compute_iso_surface_area(
+    distance_field: NDArray[np.float64],
+    level: float,
+    grid_spacing: tuple[float, float, float],
+) -> float:
+    """Marching-cubes area [m^2] of one regression iso-level, 0 if empty."""
+    try:
+        vertices, faces, _, _ = measure.marching_cubes(
+            distance_field, level=level, spacing=grid_spacing
+        )
+    except (ValueError, RuntimeError):
+        return 0.0
+    return float(measure.mesh_surface_area(vertices, faces))
+
+
+def _load_iso_surface_worker(
+    distance_field: NDArray[np.float64],
+    grid_spacing: tuple[float, float, float],
+) -> None:
+    """Hold the distance field in a worker process, sent once at start-up."""
+    global _worker_distance_field, _worker_grid_spacing
+    _worker_distance_field = distance_field
+    _worker_grid_spacing = grid_spacing
+
+
+def _compute_iso_surface_area_in_worker(level: float) -> float:
+    """Mesh one iso-level against the field the worker was started with."""
+    if _worker_distance_field is None or _worker_grid_spacing is None:
+        raise RuntimeError("Iso-surface worker was not given a distance field.")
+    return _compute_iso_surface_area(
+        _worker_distance_field, level, _worker_grid_spacing
+    )
+
+
+def _is_parallel_meshing_worthwhile(cell_count: int) -> bool:
+    """
+    Whether a process pool beats meshing the iso-levels in this process.
+
+    A worker process never starts a pool of its own: nesting them oversubscribes
+    the machine, and a spawned worker would re-import the caller's script to do
+    it.
+    """
+    if multiprocessing.parent_process() is not None:
+        return False
+
+    if multiprocessing.get_start_method() == "fork":
+        return cell_count >= FORK_PARALLEL_CELL_COUNT
+    return cell_count >= SPAWN_PARALLEL_CELL_COUNT
+
+
+def _compute_iso_surface_areas_in_parallel(
+    distance_field: NDArray[np.float64],
+    iso_levels: NDArray[np.float64],
+    grid_spacing: tuple[float, float, float],
+) -> NDArray[np.float64] | None:
+    """
+    Mesh every iso-level across a process pool.
+
+    The levels are independent, so they split cleanly across processes. The
+    distance field goes to each worker once at start-up instead of riding along
+    with every level, which holds the transfer cost to one copy per worker.
+
+    Returns:
+        Areas [m^2] aligned with `iso_levels`, or None when no pool could be
+        started and the caller should mesh the levels itself.
+    """
+    worker_count = min(len(iso_levels), os.cpu_count() or 1)
+    if worker_count < 2:
+        return None
+
+    levels = [float(level) for level in iso_levels]
+    chunk_size = math.ceil(len(levels) / worker_count)
+    try:
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=worker_count,
+            initializer=_load_iso_surface_worker,
+            initargs=(distance_field, grid_spacing),
+        ) as executor:
+            areas = list(
+                executor.map(
+                    _compute_iso_surface_area_in_worker, levels, chunksize=chunk_size
+                )
+            )
+    except (OSError, ValueError, RuntimeError, concurrent.futures.BrokenExecutor):
+        return None
+
+    return np.asarray(areas, dtype=np.float64)
+
+
+def _compute_iso_surface_areas(
+    distance_field: NDArray[np.float64],
+    iso_levels: NDArray[np.float64],
+    grid_spacing: tuple[float, float, float],
+) -> NDArray[np.float64]:
+    """
+    Marching-cubes area [m^2] of every regression iso-level.
+
+    This is the largest one-time setup cost of a 3D segment and it grows with
+    the grid, so fine grids spread the levels over worker processes. Coarse
+    grids, and any grid whose pool fails to start, mesh the levels here.
+    """
+    if _is_parallel_meshing_worthwhile(distance_field.size):
+        iso_surface_areas = _compute_iso_surface_areas_in_parallel(
+            distance_field, iso_levels, grid_spacing
+        )
+        if iso_surface_areas is not None:
+            return iso_surface_areas
+
+    return np.array(
+        [
+            _compute_iso_surface_area(distance_field, float(level), grid_spacing)
+            for level in iso_levels
+        ],
+        dtype=np.float64,
+    )
 
 
 class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
@@ -248,18 +382,11 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
 
             # The iso-surface at level 0 lies on the voxelized initial face and is
             # degenerate, so sample above it and hold the first area back to web 0.
-            iso_level_count = 80
             iso_levels = np.linspace(
-                max_iso_level / iso_level_count, max_iso_level, iso_level_count
+                max_iso_level / ISO_LEVEL_COUNT, max_iso_level, ISO_LEVEL_COUNT
             )
-            iso_surface_areas = np.array(
-                [
-                    self._compute_iso_surface_area(
-                        distance_field, float(level), grid_spacing
-                    )
-                    for level in iso_levels
-                ],
-                dtype=np.float64,
+            iso_surface_areas = _compute_iso_surface_areas(
+                distance_field, iso_levels, grid_spacing
             )
             web_distances_denormalized = np.concatenate(
                 ([0.0], np.asarray(self.denormalize(iso_levels), dtype=np.float64))
@@ -283,21 +410,6 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
             )
 
         return self.burn_area_interpolator
-
-    @staticmethod
-    def _compute_iso_surface_area(
-        distance_field: NDArray[np.float64],
-        level: float,
-        grid_spacing: tuple[float, float, float],
-    ) -> float:
-        """Marching-cubes area [m^2] of one regression iso-level, 0 if empty."""
-        try:
-            vertices, faces, _, _ = measure.marching_cubes(
-                distance_field, level=level, spacing=grid_spacing
-            )
-        except (ValueError, RuntimeError):
-            return 0.0
-        return float(measure.mesh_surface_area(vertices, faces))
 
     def get_burn_area(self, web_distance: float) -> float:
         if web_distance > self.get_web_thickness():

--- a/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_iso_surface_parallelism.py
+++ b/tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_iso_surface_parallelism.py
@@ -1,0 +1,119 @@
+"""Meshing the burn-area iso-levels in worker processes must not change them.
+
+The pool is an optimization for fine grids only: small fields, worker
+processes, and pools that fail to start all mesh the levels in-process, and
+every path has to return the same areas.
+"""
+
+import numpy as np
+import pytest
+
+import machwave.models.grain.fmm._3d as fmm_3d
+from tests.factories import ConicalGrainSegmentFactory
+
+WEB_DISTANCES = (0.0, 0.002, 0.005, 0.01)
+
+
+def _segment():
+    return ConicalGrainSegmentFactory.build(length=0.05, outer_diameter=0.1)
+
+
+def _burn_areas():
+    segment = _segment()
+    return [segment.get_burn_area(web_distance) for web_distance in WEB_DISTANCES]
+
+
+def _force_parallel(monkeypatch):
+    monkeypatch.setattr(fmm_3d, "FORK_PARALLEL_CELL_COUNT", 0)
+    monkeypatch.setattr(fmm_3d, "SPAWN_PARALLEL_CELL_COUNT", 0)
+
+
+def test_pooled_areas_match_in_process_areas(monkeypatch):
+    serial = _burn_areas()
+
+    _force_parallel(monkeypatch)
+    assert _burn_areas() == serial
+
+
+def test_small_field_never_starts_a_pool(monkeypatch):
+    def fail(*args, **kwargs):
+        pytest.fail("A pool was started for a field below the parallel threshold")
+
+    monkeypatch.setattr(fmm_3d, "_compute_iso_surface_areas_in_parallel", fail)
+
+    # The default grid over a short segment holds ~0.5M cells, well under both
+    # thresholds.
+    assert _segment().get_burn_area(0.0) > 0.0
+
+
+def test_falls_back_when_the_pool_cannot_start(monkeypatch):
+    serial = _burn_areas()
+
+    def raise_os_error(*args, **kwargs):
+        raise OSError("no worker processes available")
+
+    _force_parallel(monkeypatch)
+    monkeypatch.setattr(
+        fmm_3d.concurrent.futures, "ProcessPoolExecutor", raise_os_error
+    )
+    assert _burn_areas() == serial
+
+
+def test_worker_processes_mesh_in_process(monkeypatch):
+    _force_parallel(monkeypatch)
+    monkeypatch.setattr(fmm_3d.multiprocessing, "parent_process", lambda: object())
+
+    assert not fmm_3d._is_parallel_meshing_worthwhile(10**9)
+
+
+@pytest.mark.parametrize(
+    ("start_method", "cell_count", "expected"),
+    [
+        ("fork", fmm_3d.FORK_PARALLEL_CELL_COUNT - 1, False),
+        ("fork", fmm_3d.FORK_PARALLEL_CELL_COUNT, True),
+        ("spawn", fmm_3d.FORK_PARALLEL_CELL_COUNT, False),
+        ("spawn", fmm_3d.SPAWN_PARALLEL_CELL_COUNT, True),
+    ],
+)
+def test_threshold_depends_on_the_start_method(
+    monkeypatch, start_method, cell_count, expected
+):
+    monkeypatch.setattr(
+        fmm_3d.multiprocessing, "get_start_method", lambda: start_method
+    )
+    monkeypatch.setattr(fmm_3d.multiprocessing, "parent_process", lambda: None)
+
+    assert fmm_3d._is_parallel_meshing_worthwhile(cell_count) is expected
+
+
+def test_worker_rejects_levels_before_it_holds_a_field(monkeypatch):
+    monkeypatch.setattr(fmm_3d, "_worker_distance_field", None)
+    monkeypatch.setattr(fmm_3d, "_worker_grid_spacing", None)
+
+    with pytest.raises(RuntimeError):
+        fmm_3d._compute_iso_surface_area_in_worker(0.5)
+
+
+def test_worker_meshes_the_field_it_was_loaded_with(monkeypatch):
+    segment = _segment()
+    regression_map = segment.get_padded_regression_map()
+    values = np.asarray(
+        regression_map[~np.ma.getmaskarray(regression_map)], dtype=np.float64
+    )
+    max_level = float(values.max())
+    distance_field = np.ma.filled(regression_map, max_level + 1.0)
+    grid_spacing = (
+        segment.get_axial_grid_spacing(),
+        segment.get_radial_grid_spacing(),
+        segment.get_radial_grid_spacing(),
+    )
+    level = max_level / 2
+
+    # Restored by monkeypatch once the test leaves the worker globals set.
+    monkeypatch.setattr(fmm_3d, "_worker_distance_field", None)
+    monkeypatch.setattr(fmm_3d, "_worker_grid_spacing", None)
+    fmm_3d._load_iso_surface_worker(distance_field, grid_spacing)
+
+    assert fmm_3d._compute_iso_surface_area_in_worker(level) == (
+        fmm_3d._compute_iso_surface_area(distance_field, level, grid_spacing)
+    )


### PR DESCRIPTION
Closes #417.

`get_burn_area_interpolator` ran 80 independent `marching_cubes` calls serially to build the burn-area curve. They now go through a process pool: the distance field reaches each worker once at start-up (via the pool initializer) instead of riding along with every level, and the levels are split into one chunk per worker.

## When the pool starts

The issue expected a grid-resolution gate. Measurements say the deciding factor is the number of cells in the distance field and, more strongly, the start method, so the gate is a cell count per start method. Measured on 14 cores, conical segments, grid resolutions 100 to 250 at length-to-outer-diameter ratios of 1 and 3, timing only the iso-surface stage:

| grid | L/D | field | in-process | forking pool | spawning pool | threads |
| ---: | --: | ----: | ---------: | -----------: | ------------: | ------: |
| 100 | 1 | 8 MB | 0.96 s | 0.13 s (7.4x) | 3.85 s (0.25x) | 0.74 s (1.3x) |
| 150 | 1 | 27 MB | 2.59 s | 0.38 s (6.9x) | 4.03 s (0.64x) | 1.96 s (1.3x) |
| 200 | 1 | 65 MB | 5.22 s | 0.73 s (7.1x) | 4.21 s (1.24x) | 4.07 s (1.3x) |
| 250 | 1 | 126 MB | 8.90 s | 1.16 s (7.7x) | 5.21 s (1.71x) | 7.49 s (1.2x) |
| 100 | 3 | 24 MB | 2.69 s | 0.35 s (7.7x) | 4.20 s (0.64x) | 2.00 s (1.3x) |
| 150 | 3 | 81 MB | 7.09 s | 0.98 s (7.2x) | 4.89 s (1.45x) | 5.38 s (1.3x) |
| 200 | 3 | 193 MB | 14.22 s | 1.92 s (7.4x) | 7.10 s (2.00x) | 11.35 s (1.3x) |
| 250 | 3 | 376 MB | 24.87 s | 5.53 s (4.5x) | 10.67 s (2.33x) | 20.70 s (1.2x) |

Reading the sweep:

- In-process meshing costs about one second per two million cells, near enough linear across the whole range, which is why the thresholds are stated in cells rather than in grid resolution: a long grain at the default resolution (3.0 M cells) costs more than a short one at resolution 150 (3.4 M cells is comparable, but a short grain at resolution 100 is only 1.0 M).
- A forking pool costs almost nothing to start and never copies the field, so it wins everywhere; the threshold is set at 2 M cells, just above the short default-resolution grain the issue asked to leave alone.
- A spawning pool pays a fixed 3.8 to 4.7 seconds of interpreter start-up, measured separately and near enough independent of field size, plus one pickled copy of the field per worker. It stays underwater until roughly 12 M cells and only reaches 2x at the top of the range, so its threshold is 12 M.
- Worker count barely matters for a spawning pool (7 workers and 14 workers land within 5 percent, it is start-up bound) and matters as expected for a forking one.
- Chunking matters for a spawning pool: one chunk per worker beats one level per task by 1.6 to 2.3x. A forking pool is indifferent.
- Threads were measured as an alternative with no start-up cost and no `__main__` re-import: `marching_cubes` releases the GIL only partly, and the ceiling is a flat 1.2 to 1.3x regardless of size. Not enough to be worth the concurrency.
- End to end, the fast marching stage that precedes the meshing is not parallelized here (15.7 s of the 39.8 s total at resolution 250, L/D 3), so the full precompute improves 1.9x with a forking pool and 1.5x with a spawning one at that size.

Which start method is in play is the platform default, and the default is not overridden. Linux (Python 3.11 to 3.13) forks, so it gets the large win; macOS and Windows spawn, and only pay for a pool on large fields. Forking is deliberately not forced on macOS, where forking a process that has already touched Apple's frameworks is unsafe.

## Safety

A worker process never starts a pool of its own. Nesting pools would oversubscribe the machine under, for instance, a Monte Carlo run, and under `spawn` a worker starting its own pool would re-import the caller's script recursively; a script without an `if __name__ == "__main__"` guard would otherwise fork-bomb itself. Any pool that fails to start (`OSError`, a broken executor) falls back to meshing in-process.

## Tests

`tests/test_models/test_propulsion/test_grain/test_grainsegment3d/test_iso_surface_parallelism.py` pins that pooled and in-process meshing return identical burn areas, that a small field never starts a pool, that a failed pool falls back, that a worker declines to start one, and that the threshold follows the start method.