### PR TITLE
Reuse the per-segment volumes across the grain mass properties

### DIFF
--- a/machwave/models/grain/base.py
+++ b/machwave/models/grain/base.py
@@ -181,13 +181,20 @@ class GrainSegment(ABC):
         """
         pass
 
-    def get_mass(self, web_distance: float, ideal_density: float) -> float:
+    def get_mass(
+        self,
+        web_distance: float,
+        ideal_density: float,
+        volume: float | None = None,
+    ) -> float:
         """
         Return the mass of the segment at a given web distance.
 
         Args:
             web_distance: Web distance traveled [m].
             ideal_density: Ideal propellant density [kg/m^3].
+            volume: Segment volume at `web_distance` [m^3], for callers that
+                already hold it. Computed here when omitted.
 
         Returns:
             Mass of the segment [kg].
@@ -195,7 +202,10 @@ class GrainSegment(ABC):
         if ideal_density <= 0:
             raise ValueError(f"ideal_density must be > 0 (got {ideal_density})")
 
-        return self.get_volume(web_distance) * ideal_density * self.density_ratio
+        if volume is None:
+            volume = self.get_volume(web_distance)
+
+        return volume * ideal_density * self.density_ratio
 
     def validate(self) -> None:
         """
@@ -422,7 +432,10 @@ class Grain:
         return len(self.segments)
 
     def get_center_of_gravity(
-        self, web_distance: float
+        self,
+        web_distance: float,
+        *,
+        volume_per_segment: np.typing.NDArray[np.float64] | None = None,
     ) -> np.typing.NDArray[np.float64]:
         """
         Return the center of gravity of the grain.
@@ -432,6 +445,8 @@ class Grain:
 
         Args:
             web_distance: Web distance traveled [m].
+            volume_per_segment: Per-segment volume at `web_distance` [m^3], for
+                callers that already hold it. Computed here when omitted.
 
         Returns:
             A 1D array of shape (3,) with the [x, y, z] coordinates of the
@@ -444,12 +459,20 @@ class Grain:
         if not self.segments:
             raise ValueError("No segments found, cannot compute CoG.")
 
+        volumes = (
+            self.get_propellant_volume_per_segment(web_distance)
+            if volume_per_segment is None
+            else volume_per_segment
+        )
+        density_ratios = self.get_density_ratio_per_segment()
+
         weighted_cogs = []
         global_cogs = []
         # Iterate segments in reverse order (last added is closest to port)
         axial_position = 0.0
 
-        for segment in reversed(self.segments):
+        for index in reversed(range(self.segment_count)):
+            segment = self.segments[index]
             # Segment's local CoG, relative to its own port
             local_cog = segment.get_center_of_gravity(web_distance=web_distance)
 
@@ -458,13 +481,10 @@ class Grain:
             global_cog[0] = axial_position + local_cog[0]
             global_cogs.append(global_cog)
 
-            mass = segment.get_volume(web_distance=web_distance) * segment.density_ratio
-            weighted_cogs.append(global_cog * mass)
+            weighted_cogs.append(global_cog * (volumes[index] * density_ratios[index]))
 
             axial_position += segment.length + self.spacing
 
-        volumes = self.get_propellant_volume_per_segment(web_distance)
-        density_ratios = self.get_density_ratio_per_segment()
         total_mass_normalized = float(np.sum(volumes * density_ratios))
 
         if total_mass_normalized <= 0.0:
@@ -479,7 +499,12 @@ class Grain:
         return (total_weighted_cogs / total_mass_normalized).astype(np.float64)
 
     def get_moment_of_inertia(
-        self, ideal_density: float, web_distance: float = 0.0
+        self,
+        ideal_density: float,
+        web_distance: float = 0.0,
+        *,
+        volume_per_segment: np.typing.NDArray[np.float64] | None = None,
+        center_of_gravity: np.typing.NDArray[np.float64] | None = None,
     ) -> np.typing.NDArray[np.float64]:
         """
         Combine the inertia tensors of all grain segments.
@@ -490,6 +515,10 @@ class Grain:
         Args:
             ideal_density: Propellant ideal density [kg/m^3].
             web_distance: Web distance traveled [m].
+            volume_per_segment: Per-segment volume at `web_distance` [m^3], for
+                callers that already hold it. Computed here when omitted.
+            center_of_gravity: Grain center of gravity at `web_distance` [m],
+                for callers that already hold it. Computed here when omitted.
 
         Returns:
             A 3x3 inertia tensor [kg-m^2] at the grain's center of gravity:
@@ -508,18 +537,30 @@ class Grain:
         if not self.segments:
             raise ValueError("No segments found, cannot compute moment of inertia.")
 
-        grain_cog = self.get_center_of_gravity(web_distance)
+        volumes = (
+            self.get_propellant_volume_per_segment(web_distance)
+            if volume_per_segment is None
+            else volume_per_segment
+        )
+        grain_cog = (
+            self.get_center_of_gravity(web_distance, volume_per_segment=volumes)
+            if center_of_gravity is None
+            else center_of_gravity
+        )
         total_inertia = np.zeros((3, 3), dtype=np.float64)
 
         axial_position = 0.0
-        for segment in reversed(self.segments):  # last added is closest to port
+        for index in reversed(range(self.segment_count)):  # last added is at the port
+            segment = self.segments[index]
             local_cog = segment.get_center_of_gravity(web_distance=web_distance)
 
             global_cog = local_cog.copy()
             global_cog[0] = axial_position + local_cog[0]
 
             segment_mass = segment.get_mass(
-                web_distance=web_distance, ideal_density=ideal_density
+                web_distance=web_distance,
+                ideal_density=ideal_density,
+                volume=float(volumes[index]),
             )
             segment_moi = segment.get_moment_of_inertia(
                 web_distance=web_distance, ideal_density=ideal_density

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -181,10 +181,14 @@ class SolidMotorState(simulation_states.MotorState):
 
         if propellant_mass > 0.0:
             propellant_cog = self.motor.grain.get_center_of_gravity(
-                web_distance=web_distance
+                web_distance=web_distance,
+                volume_per_segment=propellant_volume_per_segment,
             )
             propellant_moi = self.motor.grain.get_moment_of_inertia(
-                ideal_density=ideal_propellant_density, web_distance=web_distance
+                ideal_density=ideal_propellant_density,
+                web_distance=web_distance,
+                volume_per_segment=propellant_volume_per_segment,
+                center_of_gravity=propellant_cog,
             )
         else:  # no propellant left: CoG is undefined and inertia is zero
             propellant_cog = np.full(3, np.nan)

--- a/tests/test_models/test_propulsion/test_grain/test_mass_property_reuse.py
+++ b/tests/test_models/test_propulsion/test_grain/test_mass_property_reuse.py
@@ -1,0 +1,170 @@
+"""Passing already-computed volumes into the Grain mass properties.
+
+The assembly layer used to recompute per-segment volumes several times for one
+web distance: once in the center of gravity loop, once more for the mass
+normalization, and again for every segment mass in the inertia tensor. Callers
+that already hold the volumes can now hand them over. Results must not move,
+and the redundant calls must be gone.
+"""
+
+import numpy as np
+import pytest
+
+import machwave.models.grain as grain_models
+from tests.factories import BatesSegmentFactory, FinocylGrainSegmentFactory
+
+IDEAL_DENSITY = 1750.0
+WEB_DISTANCE = 0.004
+
+
+@pytest.fixture
+def bates_grain():
+    grain = grain_models.Grain(spacing=0.01)
+    for core_diameter, length, density_ratio in (
+        (0.04, 0.20, 1.0),
+        (0.05, 0.18, 0.95),
+        (0.06, 0.16, 0.90),
+    ):
+        grain.add_segment(
+            BatesSegmentFactory.build(
+                outer_diameter=0.10,
+                core_diameter=core_diameter,
+                length=length,
+                density_ratio=density_ratio,
+            )
+        )
+    return grain
+
+
+@pytest.fixture
+def finocyl_grain():
+    grain = grain_models.Grain(spacing=0.005)
+    grain.add_segment(FinocylGrainSegmentFactory.build())
+    grain.add_segment(FinocylGrainSegmentFactory.build(density_ratio=0.92))
+    return grain
+
+
+def count_volume_calls(grain, monkeypatch):
+    """Count `get_volume` calls across every segment of the grain."""
+    calls = []
+    for segment in grain.segments:
+        original = segment.get_volume
+
+        def counting_get_volume(web_distance, _original=original):
+            calls.append(web_distance)
+            return _original(web_distance)
+
+        monkeypatch.setattr(segment, "get_volume", counting_get_volume)
+    return calls
+
+
+class TestResultsAreUnchanged:
+    def test_center_of_gravity_matches(self, bates_grain):
+        volumes = bates_grain.get_propellant_volume_per_segment(WEB_DISTANCE)
+
+        np.testing.assert_array_equal(
+            bates_grain.get_center_of_gravity(WEB_DISTANCE, volume_per_segment=volumes),
+            bates_grain.get_center_of_gravity(WEB_DISTANCE),
+        )
+
+    def test_moment_of_inertia_matches(self, bates_grain):
+        volumes = bates_grain.get_propellant_volume_per_segment(WEB_DISTANCE)
+        center_of_gravity = bates_grain.get_center_of_gravity(WEB_DISTANCE)
+
+        np.testing.assert_array_equal(
+            bates_grain.get_moment_of_inertia(
+                ideal_density=IDEAL_DENSITY,
+                web_distance=WEB_DISTANCE,
+                volume_per_segment=volumes,
+                center_of_gravity=center_of_gravity,
+            ),
+            bates_grain.get_moment_of_inertia(
+                ideal_density=IDEAL_DENSITY, web_distance=WEB_DISTANCE
+            ),
+        )
+
+    def test_fmm_center_of_gravity_matches(self, finocyl_grain):
+        volumes = finocyl_grain.get_propellant_volume_per_segment(WEB_DISTANCE)
+
+        np.testing.assert_array_equal(
+            finocyl_grain.get_center_of_gravity(
+                WEB_DISTANCE, volume_per_segment=volumes
+            ),
+            finocyl_grain.get_center_of_gravity(WEB_DISTANCE),
+        )
+
+    def test_fmm_moment_of_inertia_matches(self, finocyl_grain):
+        volumes = finocyl_grain.get_propellant_volume_per_segment(WEB_DISTANCE)
+        center_of_gravity = finocyl_grain.get_center_of_gravity(WEB_DISTANCE)
+
+        np.testing.assert_array_equal(
+            finocyl_grain.get_moment_of_inertia(
+                ideal_density=IDEAL_DENSITY,
+                web_distance=WEB_DISTANCE,
+                volume_per_segment=volumes,
+                center_of_gravity=center_of_gravity,
+            ),
+            finocyl_grain.get_moment_of_inertia(
+                ideal_density=IDEAL_DENSITY, web_distance=WEB_DISTANCE
+            ),
+        )
+
+    def test_segment_mass_matches(self, bates_grain):
+        segment = bates_grain.segments[0]
+        volume = segment.get_volume(WEB_DISTANCE)
+
+        assert segment.get_mass(
+            web_distance=WEB_DISTANCE, ideal_density=IDEAL_DENSITY, volume=volume
+        ) == segment.get_mass(web_distance=WEB_DISTANCE, ideal_density=IDEAL_DENSITY)
+
+    def test_segment_mass_still_rejects_non_positive_density(self, bates_grain):
+        segment = bates_grain.segments[0]
+
+        with pytest.raises(ValueError, match="ideal_density must be > 0"):
+            segment.get_mass(web_distance=WEB_DISTANCE, ideal_density=0.0, volume=1.0)
+
+
+class TestVolumeIsComputedOncePerSegment:
+    def test_center_of_gravity_without_volumes(self, bates_grain, monkeypatch):
+        calls = count_volume_calls(bates_grain, monkeypatch)
+
+        bates_grain.get_center_of_gravity(WEB_DISTANCE)
+
+        assert len(calls) == bates_grain.segment_count
+
+    def test_center_of_gravity_with_volumes(self, bates_grain, monkeypatch):
+        volumes = bates_grain.get_propellant_volume_per_segment(WEB_DISTANCE)
+        calls = count_volume_calls(bates_grain, monkeypatch)
+
+        bates_grain.get_center_of_gravity(WEB_DISTANCE, volume_per_segment=volumes)
+
+        assert calls == []
+
+    def test_moment_of_inertia_without_volumes(self, bates_grain, monkeypatch):
+        calls = count_volume_calls(bates_grain, monkeypatch)
+
+        bates_grain.get_moment_of_inertia(
+            ideal_density=IDEAL_DENSITY, web_distance=WEB_DISTANCE
+        )
+
+        # One for the assembly layer, one inside each segment's own tensor.
+        assert len(calls) == 2 * bates_grain.segment_count
+
+    def test_moment_of_inertia_with_volumes_and_center_of_gravity(
+        self, bates_grain, monkeypatch
+    ):
+        volumes = bates_grain.get_propellant_volume_per_segment(WEB_DISTANCE)
+        center_of_gravity = bates_grain.get_center_of_gravity(
+            WEB_DISTANCE, volume_per_segment=volumes
+        )
+        calls = count_volume_calls(bates_grain, monkeypatch)
+
+        bates_grain.get_moment_of_inertia(
+            ideal_density=IDEAL_DENSITY,
+            web_distance=WEB_DISTANCE,
+            volume_per_segment=volumes,
+            center_of_gravity=center_of_gravity,
+        )
+
+        # Only the segments' own tensors are left computing a volume.
+        assert len(calls) == bates_grain.segment_count


### PR DESCRIPTION
Closes #356.

Each solid motor timestep computed the same per-segment volumes several times for one web distance:

- `Grain.get_center_of_gravity` called `segment.get_volume` once per segment for its mass weighting, then again through `get_propellant_volume_per_segment` for the normalization.
- `Grain.get_moment_of_inertia` recomputed the whole grain center of gravity, and every `segment.get_mass` went back to `get_volume`.
- `SolidMotorState.run_timestep` had already computed the volumes for the propellant mass before either ran.

## What changed

Three additive, keyword-only parameters, each defaulting to the previous behaviour:

- `Grain.get_center_of_gravity(web_distance, *, volume_per_segment=None)`
- `Grain.get_moment_of_inertia(ideal_density, web_distance=0.0, *, volume_per_segment=None, center_of_gravity=None)`
- `GrainSegment.get_mass(web_distance, ideal_density, volume=None)`, keeping the `ideal_density > 0` guard

`Grain.get_center_of_gravity(web_distance=...)` keeps its signature, so `adapters/rocketpy/solid_motor.py` and the rest of the call sites are untouched. The solid timestep passes the volumes it already holds, plus the center of gravity it just computed, into the inertia tensor.

## Results are unchanged

The arithmetic runs in the same order over the same values, so every quantity is bit-identical; the new tests assert exact array equality between the threaded and recomputed paths for both a Bates grain and a 3D fast marching method grain, and `test_per_segment_aggregators`, `test_cog` and `test_moi` still pass unchanged.

## Cost

Timing the volume, center of gravity and inertia block that runs once per timestep, median of 5:

| grain | recomputed | volumes threaded | saved |
| --- | ---: | ---: | ---: |
| Bates, 3 segments | 34.9 us | 24.6 us | 29% |
| Finocyl 3D, 2 segments | 37.7 us | 21.9 us | 42% |

New call counts, pinned by test: the center of gravity computes one volume per segment instead of two and none when handed them; the inertia tensor drops from four per segment to one. That last one is each segment computing its own tensor, which lives in the segment layer and is left to the companion issue.

Density ratios are deliberately not threaded through. `get_density_ratio_per_segment` reads one attribute per segment and costs a few microseconds per timestep against the volume work above, so passing it in would widen the API for no measurable gain.