### PR TITLE
Evaluate solid thermochemistry at the chamber pressure of the step

### DIFF
--- a/machwave/models/propellants/categories/solid.py
+++ b/machwave/models/propellants/categories/solid.py
@@ -146,8 +146,12 @@ class SolidPropellant(propellant_base.Propellant):
         """
         Evaluate thermochemical properties.
 
-        If properties are pre-defined, returns them directly. Otherwise,
-        evaluates using the thermochemical service via the parent class.
+        Pre-defined properties are a fixed override: they are returned as given
+        for every chamber pressure, so a propellant carrying them holds the same
+        flame temperature, isentropic exponents, molecular weights and condensed
+        phase fractions for a whole burn. Without them the thermochemical
+        service is queried at the chamber pressure through the parent class, and
+        the properties follow it.
 
         Args:
             chamber_pressure: Chamber pressure [Pa].

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -12,6 +12,7 @@ import machwave.core.performance as performance
 import machwave.core.solvers.rk4 as rk4
 import machwave.models.motors as motors
 import machwave.models.propellants as propellants
+import machwave.models.propellants.properties as propellant_properties_models
 import machwave.simulation.solid.results as solid_results
 import machwave.simulation.states as simulation_states
 
@@ -81,26 +82,13 @@ class SolidMotorState(simulation_states.MotorState):
             motor: Solid motor to track.
             igniter_pressure: Initial chamber pressure from the igniter [Pa].
             external_pressure: Ambient pressure [Pa].
-
-        Raises:
-            ValueError: If the motor's propellant has no thermochemical
-                properties. Solid propellant properties are fixed for the
-                entire run, so a missing value is a configuration error and
-                the simulation refuses to start.
         """
-        propellant_properties = motor.propellant.properties
-        if propellant_properties is None:
-            raise ValueError(
-                "Propellant properties must be defined to run the simulation."
-            )
-
         super().__init__(
             motor=motor,
             igniter_pressure=igniter_pressure,
             external_pressure=external_pressure,
         )
 
-        self.propellant_properties = propellant_properties
         self.segment_density_ratios = motor.grain.get_density_ratio_per_segment()
 
         self.web: simulation_states.SimulationStateArray = [0.0]
@@ -118,6 +106,16 @@ class SolidMotorState(simulation_states.MotorState):
         self.propellant_cog: list[npt.NDArray[np.float64]] = []
         self.propellant_moi: list[npt.NDArray[np.float64]] = []
 
+    def _evaluate_propellant_properties(
+        self,
+        chamber_pressure: float,
+    ) -> propellant_properties_models.ThermochemicalProperties:
+        """Evaluate the propellant at the chamber pressure."""
+        return self.motor.propellant.evaluate(
+            chamber_pressure=chamber_pressure,
+            expansion_ratio=self.motor.thrust_chamber.nozzle.expansion_ratio,
+        )
+
     def run_timestep(
         self,
         d_t: float,
@@ -130,13 +128,16 @@ class SolidMotorState(simulation_states.MotorState):
             d_t: Time increment [s].
             external_pressure: External pressure [Pa].
         """
-        propellant_properties = self.propellant_properties
         nozzle = self.motor.thrust_chamber.nozzle
         ideal_propellant_density = self.motor.propellant.ideal_density
 
         time = self.time[-1]
         web_distance = self.web[-1]
         chamber_pressure = self.chamber_pressure[-1]
+
+        propellant_properties = self._evaluate_propellant_properties(
+            chamber_pressure=chamber_pressure
+        )
 
         burn_area_per_segment = self.motor.grain.get_burn_area_per_segment(web_distance)
         self.burn_area_per_segment.append(burn_area_per_segment)

--- a/tests/test_simulations/test_solid_thermochemistry.py
+++ b/tests/test_simulations/test_solid_thermochemistry.py
@@ -1,0 +1,144 @@
+"""Solid motor thermochemistry follows the chamber pressure.
+
+The solid state used to read the propellant's properties once, at
+construction, and reuse them for every timestep. It now evaluates the
+propellant at the chamber pressure of the step, the way the biliquid state
+does. Formulations that carry pre-defined properties still see them returned
+unchanged, which is what keeps their results identical.
+"""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+
+import numpy as np
+import pytest
+
+import machwave.models.propellants.categories as propellant_categories
+import machwave.simulation.solid as solid_simulation
+from tests.test_simulations import motor_builders
+from tests.test_simulations.conftest import run_simulation
+
+TIMESTEP_COUNT = 5
+
+
+def record_evaluations(propellant, monkeypatch, properties_for=None):
+    """Record the arguments every `evaluate` call receives."""
+    calls = []
+    original = propellant.evaluate
+
+    def recording_evaluate(chamber_pressure, expansion_ratio=8.0, mixture_ratio=None):
+        calls.append(
+            {
+                "chamber_pressure": chamber_pressure,
+                "expansion_ratio": expansion_ratio,
+                "mixture_ratio": mixture_ratio,
+            }
+        )
+        if properties_for is None:
+            return original(chamber_pressure, expansion_ratio, mixture_ratio)
+        return properties_for(chamber_pressure)
+
+    monkeypatch.setattr(propellant, "evaluate", recording_evaluate)
+    return calls
+
+
+@pytest.fixture
+def motor_and_params():
+    motor, params = motor_builders.build_nero_motor()
+    # The formulations are module-level singletons shared across tests.
+    motor.propellant = copy.deepcopy(motor.propellant)
+    return motor, params
+
+
+def test_properties_are_evaluated_at_every_timestep(motor_and_params, monkeypatch):
+    motor, params = motor_and_params
+    calls = record_evaluations(motor.propellant, monkeypatch)
+    state = solid_simulation.SolidMotorState(
+        motor=motor,
+        igniter_pressure=params.igniter_pressure,
+        external_pressure=params.external_pressure,
+    )
+
+    for _ in range(TIMESTEP_COUNT):
+        state.run_timestep(params.d_t, params.external_pressure)
+
+    assert len(calls) == TIMESTEP_COUNT
+    assert [call["chamber_pressure"] for call in calls] == (
+        state.chamber_pressure[:TIMESTEP_COUNT]
+    )
+    assert {call["expansion_ratio"] for call in calls} == {
+        motor.thrust_chamber.nozzle.expansion_ratio
+    }
+
+
+def test_chamber_pressure_reaches_the_propellant(motor_and_params, monkeypatch):
+    motor, params = motor_and_params
+    calls = record_evaluations(motor.propellant, monkeypatch)
+    state = solid_simulation.SolidMotorState(
+        motor=motor,
+        igniter_pressure=params.igniter_pressure,
+        external_pressure=params.external_pressure,
+    )
+
+    for _ in range(TIMESTEP_COUNT):
+        state.run_timestep(params.d_t, params.external_pressure)
+
+    # The motor pressurizes off the igniter, so the pressures must not repeat.
+    chamber_pressures = [call["chamber_pressure"] for call in calls]
+    assert len(set(chamber_pressures)) == TIMESTEP_COUNT
+
+
+def test_pressure_dependent_properties_change_the_run(motor_and_params, monkeypatch):
+    motor, params = motor_and_params
+    constant_properties = motor.propellant.properties
+    assert constant_properties is not None
+
+    def properties_for(chamber_pressure):
+        # A mild, monotonic drift with pressure, enough to move the thrust.
+        scale = 1.0 + 0.02 * (chamber_pressure / 1e6)
+        return dataclasses.replace(
+            constant_properties,
+            adiabatic_flame_temperature=(
+                constant_properties.adiabatic_flame_temperature * scale
+            ),
+        )
+
+    baseline = run_simulation(motor, params)
+    record_evaluations(motor.propellant, monkeypatch, properties_for=properties_for)
+    drifting = run_simulation(motor, params)
+
+    common_length = min(baseline.thrust.size, drifting.thrust.size)
+    assert common_length > 1
+    assert not np.allclose(
+        baseline.thrust[:common_length], drifting.thrust[:common_length]
+    )
+
+
+def test_propellant_without_pre_defined_properties_runs(motor_and_params, monkeypatch):
+    motor, params = motor_and_params
+    properties = motor.propellant.properties
+    assert properties is not None
+
+    propellant_without_properties = propellant_categories.SolidPropellant(
+        name=motor.propellant.name,
+        components=motor.propellant.components,
+        mass_fractions=motor.propellant.mass_fractions,
+        burn_rate_map=motor.propellant.burn_rate_map,
+    )
+    monkeypatch.setattr(
+        propellant_without_properties,
+        "evaluate",
+        lambda chamber_pressure, expansion_ratio=8.0, mixture_ratio=None: properties,
+    )
+    motor.propellant = propellant_without_properties
+
+    state = solid_simulation.SolidMotorState(
+        motor=motor,
+        igniter_pressure=params.igniter_pressure,
+        external_pressure=params.external_pressure,
+    )
+    state.run_timestep(params.d_t, params.external_pressure)
+
+    assert state.thrust[-1] > 0.0


### PR DESCRIPTION
Closes #341.

`SolidMotorState` read `motor.propellant.properties` once in its constructor and reused the same adiabatic flame temperature, isentropic exponents, molecular weights and condensed-phase fractions for every timestep, regardless of chamber pressure. The biliquid state already evaluates its propellant per step; the solid one now does the same.

## What changed

- `SolidMotorState._evaluate_propellant_properties(chamber_pressure)` mirrors the biliquid method, and `run_timestep` calls it with the chamber pressure of the step.
- The constructor no longer raises when the propellant has no pre-defined properties. That check existed because the properties were read exactly once; now a propellant without them is evaluated through the thermochemical service at each step, with the quantized cache in `Propellant.evaluate` (200 Pa wide) keeping repeat pressures off the service.
- `SolidPropellant.evaluate` states what pre-defined properties mean: a fixed override returned unchanged for every chamber pressure, so a propellant carrying them holds the same properties for a whole burn.

## Results

Every shipped solid formulation carries pre-defined properties, so `evaluate` returns them unchanged and all existing results are identical; the full suite passes unchanged. The behaviour only differs for a propellant defined by its components alone, which previously could not be simulated at all.

The cost follows the propellant. The pre-defined path is an early return per step. The service-backed path pays one thermochemistry evaluation per distinct quantized pressure, the same policy the biliquid loop already uses.

## Tests

`tests/test_simulations/test_solid_thermochemistry.py` pins that the propellant is evaluated once per timestep at that step's chamber pressure and the nozzle expansion ratio, that the pressures seen are the ones the run is actually at, that properties which drift with pressure move the thrust history, and that a propellant with no pre-defined properties now runs.

## Coordination

The expansion ratio passed to the evaluation is the nozzle's static value. #283 recomputes the expansion ratio per timestep for a variable throat area; it should feed that value into this call so the per-step expansion ratio and the pressure-dependent properties stay consistent, along with the kinetics and two-phase nozzle loss inputs of the milestone in #12.