### PR TITLE
Take a stated feed line loss off the pressure the injector sees

### DIFF
--- a/examples/1kn_biliquid_engine.py
+++ b/examples/1kn_biliquid_engine.py
@@ -47,13 +47,11 @@ def main():
     )
 
     feed_system = feed_systems.StackedTankPressureFedFeedSystem(
-        oxidizer_line_diameter=7.925e-3,
-        oxidizer_line_length=0.5,
-        fuel_line_diameter=5.715e-3,
-        fuel_line_length=0.5,
         oxidizer_tank=oxidizer_tank,
         fuel_tank=fuel_tank,
         piston_loss=1e5,
+        oxidizer_line_loss=2e5,
+        fuel_line_loss=2e5,
     )
 
     nozzle = thrust_chamber_models.Nozzle(

--- a/machwave/models/feed_systems/base.py
+++ b/machwave/models/feed_systems/base.py
@@ -70,7 +70,10 @@ class FeedSystem(ABC):
     @abstractmethod
     def get_oxidizer_tank_pressure(self, *, oxidizer_mass: float) -> float:
         """
-        Compute and return the current oxidizer tank pressure [Pa].
+        Compute and return the oxidizer pressure at the injector inlet [Pa].
+
+        Whatever the feed system takes between the tank and the injector comes
+        off here, so the value is what the injector has to push with.
 
         Args:
             oxidizer_mass: Current oxidizer mass in the tank [kg].
@@ -82,7 +85,10 @@ class FeedSystem(ABC):
         self, *, oxidizer_mass: float, fuel_mass: float
     ) -> float:
         """
-        Compute and return the current fuel-side upstream pressure [Pa].
+        Compute and return the fuel pressure at the injector inlet [Pa].
+
+        Whatever the feed system takes between the tank and the injector comes
+        off here, so the value is what the injector has to push with.
 
         Args:
             oxidizer_mass: Current oxidizer mass in the tank [kg].

--- a/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
+++ b/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
@@ -14,37 +14,54 @@ class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
 
     def __init__(
         self,
-        oxidizer_line_diameter: float,
-        oxidizer_line_length: float,
-        fuel_line_diameter: float,
-        fuel_line_length: float,
         fuel_tank: tank.Tank,
         oxidizer_tank: tank.Tank,
         piston_loss: float = 0.0,
+        oxidizer_line_loss: float = 0.0,
+        fuel_line_loss: float = 0.0,
     ):
         """
         Initialize the StackedTankPressureFedFeedSystem.
 
         Args:
-            oxidizer_line_diameter: Diameter of the oxidizer feedline [m].
-            oxidizer_line_length: Length of the oxidizer feedline [m].
-            fuel_line_diameter: Diameter of the fuel feedline [m].
-            fuel_line_length: Length of the fuel feedline [m].
             fuel_tank: An instance representing the fuel tank.
             oxidizer_tank: An instance representing the oxidizer tank.
             piston_loss: Pressure loss across the piston [Pa]. Default is 0.0.
+            oxidizer_line_loss: Pressure loss along the oxidizer feedline [Pa],
+                stated for the design flow rather than computed from it.
+                Default is 0.0, no line.
+            fuel_line_loss: Pressure loss along the fuel feedline [Pa], stated
+                for the design flow rather than computed from it. Default is
+                0.0, no line.
+
+        Raises:
+            ValueError: If any pressure loss is negative.
         """
         super().__init__(fuel_tank, oxidizer_tank)
 
-        self.oxidizer_line_diameter = oxidizer_line_diameter
-        self.oxidizer_line_length = oxidizer_line_length
-        self.fuel_line_diameter = fuel_line_diameter
-        self.fuel_line_length = fuel_line_length
-
         self.piston_loss = piston_loss
+        self.oxidizer_line_loss = oxidizer_line_loss
+        self.fuel_line_loss = fuel_line_loss
 
         self.fuel_tank = fuel_tank
         self.oxidizer_tank = oxidizer_tank
+
+        self._validate()
+
+    def _validate(self) -> None:
+        """
+        Validate the pressure losses.
+
+        Raises:
+            ValueError: If any pressure loss is negative.
+        """
+        for name, value in (
+            ("piston_loss", self.piston_loss),
+            ("oxidizer_line_loss", self.oxidizer_line_loss),
+            ("fuel_line_loss", self.fuel_line_loss),
+        ):
+            if value < 0.0:
+                raise ValueError(f"{name} must be non-negative, got {value}")
 
     def get_mass_flow_ox(
         self,
@@ -106,20 +123,27 @@ class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
         )
 
     def get_oxidizer_tank_pressure(self, *, oxidizer_mass: float) -> float:
-        """Returns the tank pressure [Pa]."""
-        return self.oxidizer_tank.get_pressure(oxidizer_mass)
+        """
+        Returns the oxidizer-side pressure delivered to the injector [Pa].
+
+        The tank pressure less what the oxidizer line takes.
+        """
+        return self.oxidizer_tank.get_pressure(oxidizer_mass) - self.oxidizer_line_loss
 
     def get_fuel_tank_pressure(
         self, *, oxidizer_mass: float, fuel_mass: float
     ) -> float:
         """
-        Returns the fuel-side upstream pressure [Pa].
+        Returns the fuel-side pressure delivered to the injector [Pa].
 
         In a stacked-tank system the fuel is pressurized by the oxidizer
-        through the piston, so the fuel-side pressure is the oxidizer tank
-        pressure minus the piston pressure loss; ``fuel_mass`` is unused here.
+        through the piston, so the fuel side starts from the oxidizer tank
+        pressure less the piston pressure loss, and then loses what the fuel
+        line takes. The oxidizer line is not on this path, and ``fuel_mass`` is
+        unused here.
         """
         return (
-            self.get_oxidizer_tank_pressure(oxidizer_mass=oxidizer_mass)
+            self.oxidizer_tank.get_pressure(oxidizer_mass)
             - self.piston_loss
+            - self.fuel_line_loss
         )

--- a/tests/factories/feed_systems.py
+++ b/tests/factories/feed_systems.py
@@ -33,10 +33,6 @@ class StackedTankPressureFedFeedSystemFactory:
         kwargs: dict[str, Any] = dict(
             oxidizer_tank=oxidizer_tank,
             fuel_tank=fuel_tank,
-            oxidizer_line_diameter=0.01,
-            oxidizer_line_length=0.5,
-            fuel_line_diameter=0.008,
-            fuel_line_length=0.5,
         )
         kwargs.update(overrides)
         return feed_systems_models.StackedTankPressureFedFeedSystem(**kwargs)

--- a/tests/test_models/test_propulsion/test_feed_systems/test_stacked_tank_pressure_fed.py
+++ b/tests/test_models/test_propulsion/test_feed_systems/test_stacked_tank_pressure_fed.py
@@ -55,11 +55,81 @@ def test_get_mass_flow_fuel_uses_piston_pressurized_upstream():
     )
     expected = injector.get_mass_flow_fuel(
         tank=feed_system.fuel_tank,
-        pressure_upstream=feed_system.get_oxidizer_tank_pressure(
-            oxidizer_mass=oxidizer_mass
-        )
-        - 2e5,
+        pressure_upstream=feed_system.oxidizer_tank.get_pressure(oxidizer_mass) - 2e5,
         chamber_pressure=chamber_pressure,
         fluid_mass=fuel_mass,
     )
     assert actual == pytest.approx(expected)
+
+
+class TestFeedlineLoss:
+    def test_no_line_leaves_the_tank_pressure_alone(self):
+        feed_system = StackedTankPressureFedFeedSystemFactory.build()
+        oxidizer_mass = feed_system.oxidizer_tank.initial_fluid_mass
+
+        assert feed_system.get_oxidizer_tank_pressure(
+            oxidizer_mass=oxidizer_mass
+        ) == feed_system.oxidizer_tank.get_pressure(oxidizer_mass)
+
+    def test_the_oxidizer_line_comes_off_the_oxidizer_side(self):
+        oxidizer_line_loss = 3e5
+        feed_system = StackedTankPressureFedFeedSystemFactory.build(
+            oxidizer_line_loss=oxidizer_line_loss
+        )
+        oxidizer_mass = feed_system.oxidizer_tank.initial_fluid_mass
+
+        assert feed_system.get_oxidizer_tank_pressure(
+            oxidizer_mass=oxidizer_mass
+        ) == pytest.approx(
+            feed_system.oxidizer_tank.get_pressure(oxidizer_mass) - oxidizer_line_loss
+        )
+
+    def test_the_fuel_side_takes_the_piston_and_its_own_line(self):
+        piston_loss = 1e5
+        fuel_line_loss = 2e5
+        feed_system = StackedTankPressureFedFeedSystemFactory.build(
+            piston_loss=piston_loss,
+            fuel_line_loss=fuel_line_loss,
+            oxidizer_line_loss=3e5,
+        )
+        oxidizer_mass = feed_system.oxidizer_tank.initial_fluid_mass
+        fuel_mass = feed_system.fuel_tank.initial_fluid_mass
+
+        # The oxidizer line is not on the fuel path.
+        assert feed_system.get_fuel_tank_pressure(
+            oxidizer_mass=oxidizer_mass, fuel_mass=fuel_mass
+        ) == pytest.approx(
+            feed_system.oxidizer_tank.get_pressure(oxidizer_mass)
+            - piston_loss
+            - fuel_line_loss
+        )
+
+    def test_a_line_holds_the_flow_below_the_lossless_one(self):
+        with_line = StackedTankPressureFedFeedSystemFactory.build(fuel_line_loss=5e5)
+        without_line = StackedTankPressureFedFeedSystemFactory.build()
+        injector = BipropellantInjectorFactory.build()
+        chamber_pressure = 15e5
+        fuel_mass = with_line.fuel_tank.initial_fluid_mass
+        oxidizer_mass = with_line.oxidizer_tank.initial_fluid_mass
+
+        flows = [
+            feed_system.get_mass_flow_fuel(
+                chamber_pressure,
+                injector=injector,
+                fuel_mass=fuel_mass,
+                oxidizer_mass=oxidizer_mass,
+            )
+            for feed_system in (with_line, without_line)
+        ]
+
+        assert 0.0 < flows[0] < flows[1]
+
+
+class TestValidation:
+    @pytest.mark.parametrize(
+        "field",
+        ["piston_loss", "oxidizer_line_loss", "fuel_line_loss"],
+    )
+    def test_rejects_a_negative_pressure_loss(self, field):
+        with pytest.raises(ValueError, match=field):
+            StackedTankPressureFedFeedSystemFactory.build(**{field: -1.0})

--- a/tests/test_simulations/motor_builders.py
+++ b/tests/test_simulations/motor_builders.py
@@ -238,11 +238,9 @@ def build_1kn_biliquid_engine() -> tuple[
             temperature=300,
             initial_fluid_mass=1.55,
         ),
-        oxidizer_line_diameter=7.925e-3,
-        oxidizer_line_length=0.5,
-        fuel_line_diameter=5.715e-3,
-        fuel_line_length=0.5,
         piston_loss=1e5,
+        oxidizer_line_loss=2e5,
+        fuel_line_loss=2e5,
     )
 
     thrust_chamber = BiliquidEngineThrustChamberFactory.build(


### PR DESCRIPTION
Closes #329.

The stacked-tank feed system stored `oxidizer_line_diameter`, `oxidizer_line_length`, `fuel_line_diameter` and `fuel_line_length` and never read them; the only modeled loss between tank and chamber was `piston_loss`.

It now takes the loss as a stated value instead of computing one:

- `oxidizer_line_loss` and `fuel_line_loss`, in pascals, sitting alongside `piston_loss` and defaulting to zero.
- The four line dimensions are removed rather than left sitting unused, which is what the issue was about.

## Where the loss lands

Inside `get_oxidizer_tank_pressure` and `get_fuel_tank_pressure`, as the issue asked, so what each returns is the pressure delivered to the injector inlet. The simulation's feed guard and the injector both key off that value, so folding the losses in there keeps them correct with no other changes. That also settles the related cleanup in the issue without touching the core orifice: a line that leaves nothing above the chamber pressure fails the guard and stops the flow, so the single-phase incompressible orifice is never handed a negative pressure drop.

The oxidizer line is on the oxidizer path only. The fuel path, pressurized through the piston, takes the piston loss and the fuel line.

## Why not friction

The first cut of this branch computed the drop from Darcy-Weisbach with a Reynolds-dependent friction factor, as the issue sketched. It has been dropped in favour of a stated value:

- A stated loss is only right at the flow it was sized for, which is the same bargain `piston_loss` already offers, and it keeps the feed pressure an explicit design input.
- The friction drop depends on the flow, which depends on the drop, so it needed a bracketed solve on every call: seven to eight injector evaluations per call against one, which for a homogeneous-equilibrium orifice is a 200-point property sweep each. The full 1 kN run went from 4.3 s to 7.1 s.
- It needed a fluid viscosity for the Reynolds number, and CoolProp carries no transport model for nitrous oxide at all, so the project's own oxidizer could not be sized without shipping a correlation from outside CoolProp.

None of that buys much over a number the user states from their own plumbing. #480, which covered the missing nitrous oxide viscosity, is closed as moot.

The 1 kN example and the end-to-end builder now state 2 bar on each line, which is the order of what half a metre of their tubing takes at design flow.