### PR TITLE
Let a tank cool as it drains

### DIFF
--- a/docs/api/models/feed_systems/tank.md
+++ b/docs/api/models/feed_systems/tank.md
@@ -1,6 +1,8 @@
 # models.feed_systems.tank
 
-Stateless two-phase propellant tank model backed by CoolProp. The `Tank` carries no propellant-mass state: pressure and density are pure functions of a fluid mass supplied by the caller, so the integrator owns the mass and the model stays re-runnable. `get_pressure(fluid_mass)` returns the tank pressure from two-phase equilibrium (saturation pressure while liquid is present, single-phase vapour from the real-gas equation of state otherwise), and `get_density(fluid_mass)` the density at current conditions.
+Stateless two-phase propellant tank model backed by CoolProp. The `Tank` carries no propellant state: pressure and density are pure functions of the state supplied by the caller, so the integrator owns that state and the model stays re-runnable. `get_pressure(fluid_mass)` returns the tank pressure from two-phase equilibrium (saturation pressure while liquid is present, single-phase vapour from the real-gas equation of state otherwise), and `get_density(fluid_mass)` the density at current conditions.
+
+A tank is isothermal by default: its temperature is held where it was loaded, so a self-pressurizing tank holds its saturation pressure flat for as long as any liquid remains. Passing `isothermal=False` runs an energy balance instead. The tank's internal energy then becomes a second state variable the integrator carries beside the mass, starting from `initial_internal_energy` and falling by the enthalpy of whatever drains out (`get_outflow_specific_enthalpy`). The fluid left behind boils to refill the ullage and cools doing it, so the temperature and the saturation pressure decay over the burn. Every query on such a tank takes that internal energy alongside the mass, and says so when it is missing.
 
 Tanks are identified by CoolProp fluid name (e.g., `"N2O"`, `"Oxygen"`, `"Hydrogen"`).
 

--- a/machwave/core/mass_balance.py
+++ b/machwave/core/mass_balance.py
@@ -49,7 +49,11 @@ def compute_chamber_pressure_mass_balance(
     volume_rate = free_chamber_volume_rate(chamber_pressure)
 
     critical_pressure_ratio = get_critical_pressure_ratio(k=k)
-    pressure_ratio = external_pressure / chamber_pressure
+    # A chamber at or below ambient drives nothing out of the nozzle. Holding
+    # the ratio at one takes the sub-critical branch to zero outflow there,
+    # rather than to the root of a negative number; flow back in through the
+    # nozzle is not modeled.
+    pressure_ratio = min(external_pressure / chamber_pressure, 1.0)
 
     if pressure_ratio <= critical_pressure_ratio:  # choked
         isentropic_flow_function = (k**0.5) * (2 / (k + 1)) ** (

--- a/machwave/models/feed_systems/base.py
+++ b/machwave/models/feed_systems/base.py
@@ -29,6 +29,7 @@ class FeedSystem(ABC):
         *,
         injector: injector_models.BipropellantInjector,
         oxidizer_mass: float,
+        oxidizer_internal_energy: float | None = None,
     ) -> float:
         """
         Compute and return the current oxidizer mass flow rate [kg/s].
@@ -37,6 +38,9 @@ class FeedSystem(ABC):
             chamber_pressure: Chamber pressure [Pa].
             injector: Bipropellant injector handling the orifice dispatch.
             oxidizer_mass: Current oxidizer mass in the tank [kg].
+            oxidizer_internal_energy: Current internal energy of the oxidizer
+                [J]. Required for a tank running an energy balance, unused
+                otherwise.
 
         Returns:
             Oxidizer mass flow rate [kg/s].
@@ -51,6 +55,8 @@ class FeedSystem(ABC):
         injector: injector_models.BipropellantInjector,
         fuel_mass: float,
         oxidizer_mass: float,
+        fuel_internal_energy: float | None = None,
+        oxidizer_internal_energy: float | None = None,
     ) -> float:
         """
         Compute and return the current fuel mass flow rate [kg/s].
@@ -61,6 +67,12 @@ class FeedSystem(ABC):
             fuel_mass: Current fuel mass in the tank [kg].
             oxidizer_mass: Current oxidizer mass in the tank [kg]. Needed because
                 some feed systems pressurize the fuel from the oxidizer side.
+            fuel_internal_energy: Current internal energy of the fuel [J].
+                Required for a tank running an energy balance, unused
+                otherwise.
+            oxidizer_internal_energy: Current internal energy of the oxidizer
+                [J]. Required for a tank running an energy balance, unused
+                otherwise.
 
         Returns:
             Fuel mass flow rate [kg/s].
@@ -68,7 +80,9 @@ class FeedSystem(ABC):
         pass
 
     @abstractmethod
-    def get_oxidizer_tank_pressure(self, *, oxidizer_mass: float) -> float:
+    def get_oxidizer_tank_pressure(
+        self, *, oxidizer_mass: float, oxidizer_internal_energy: float | None = None
+    ) -> float:
         """
         Compute and return the oxidizer pressure at the injector inlet [Pa].
 
@@ -77,12 +91,20 @@ class FeedSystem(ABC):
 
         Args:
             oxidizer_mass: Current oxidizer mass in the tank [kg].
+            oxidizer_internal_energy: Current internal energy of the oxidizer
+                [J]. Required for a tank running an energy balance, unused
+                otherwise.
         """
         pass
 
     @abstractmethod
     def get_fuel_tank_pressure(
-        self, *, oxidizer_mass: float, fuel_mass: float
+        self,
+        *,
+        oxidizer_mass: float,
+        fuel_mass: float,
+        fuel_internal_energy: float | None = None,
+        oxidizer_internal_energy: float | None = None,
     ) -> float:
         """
         Compute and return the fuel pressure at the injector inlet [Pa].
@@ -93,5 +115,11 @@ class FeedSystem(ABC):
         Args:
             oxidizer_mass: Current oxidizer mass in the tank [kg].
             fuel_mass: Current fuel mass in the tank [kg].
+            fuel_internal_energy: Current internal energy of the fuel [J].
+                Required for a tank running an energy balance, unused
+                otherwise.
+            oxidizer_internal_energy: Current internal energy of the oxidizer
+                [J]. Required for a tank running an energy balance, unused
+                otherwise.
         """
         pass

--- a/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
+++ b/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
@@ -69,6 +69,7 @@ class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
         *,
         injector: injector_models.BipropellantInjector,
         oxidizer_mass: float,
+        oxidizer_internal_energy: float | None = None,
     ) -> float:
         """
         Compute the current oxidizer mass flow rate by delegating to the injector.
@@ -77,6 +78,9 @@ class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
             chamber_pressure: Chamber pressure [Pa].
             injector: Bipropellant injector handling the orifice dispatch.
             oxidizer_mass: Current oxidizer mass in the tank [kg].
+            oxidizer_internal_energy: Current internal energy of the oxidizer
+                [J]. Required for a tank running an energy balance, unused
+                otherwise.
 
         Returns:
             Oxidizer mass flow rate [kg/s].
@@ -84,10 +88,12 @@ class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
         return injector.get_mass_flow_ox(
             tank=self.oxidizer_tank,
             pressure_upstream=self.get_oxidizer_tank_pressure(
-                oxidizer_mass=oxidizer_mass
+                oxidizer_mass=oxidizer_mass,
+                oxidizer_internal_energy=oxidizer_internal_energy,
             ),
             chamber_pressure=chamber_pressure,
             fluid_mass=oxidizer_mass,
+            internal_energy=oxidizer_internal_energy,
         )
 
     def get_mass_flow_fuel(
@@ -97,6 +103,8 @@ class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
         injector: injector_models.BipropellantInjector,
         fuel_mass: float,
         oxidizer_mass: float,
+        fuel_internal_energy: float | None = None,
+        oxidizer_internal_energy: float | None = None,
     ) -> float:
         """
         Compute the current fuel mass flow rate by delegating to the injector.
@@ -109,6 +117,12 @@ class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
             injector: Bipropellant injector handling the orifice dispatch.
             fuel_mass: Current fuel mass in the tank [kg].
             oxidizer_mass: Current oxidizer mass in the tank [kg].
+            fuel_internal_energy: Current internal energy of the fuel [J].
+                Required for a tank running an energy balance, unused
+                otherwise.
+            oxidizer_internal_energy: Current internal energy of the oxidizer
+                [J], which pressurizes the fuel through the piston. Required
+                for a tank running an energy balance, unused otherwise.
 
         Returns:
             Fuel mass flow rate [kg/s].
@@ -116,22 +130,42 @@ class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
         return injector.get_mass_flow_fuel(
             tank=self.fuel_tank,
             pressure_upstream=self.get_fuel_tank_pressure(
-                oxidizer_mass=oxidizer_mass, fuel_mass=fuel_mass
+                oxidizer_mass=oxidizer_mass,
+                fuel_mass=fuel_mass,
+                fuel_internal_energy=fuel_internal_energy,
+                oxidizer_internal_energy=oxidizer_internal_energy,
             ),
             chamber_pressure=chamber_pressure,
             fluid_mass=fuel_mass,
+            internal_energy=fuel_internal_energy,
         )
 
-    def get_oxidizer_tank_pressure(self, *, oxidizer_mass: float) -> float:
+    def get_oxidizer_tank_pressure(
+        self, *, oxidizer_mass: float, oxidizer_internal_energy: float | None = None
+    ) -> float:
         """
         Returns the oxidizer-side pressure delivered to the injector [Pa].
 
         The tank pressure less what the oxidizer line takes.
+
+        Args:
+            oxidizer_mass: Current oxidizer mass in the tank [kg].
+            oxidizer_internal_energy: Current internal energy of the oxidizer
+                [J]. Required for a tank running an energy balance, unused
+                otherwise.
         """
-        return self.oxidizer_tank.get_pressure(oxidizer_mass) - self.oxidizer_line_loss
+        return (
+            self.oxidizer_tank.get_pressure(oxidizer_mass, oxidizer_internal_energy)
+            - self.oxidizer_line_loss
+        )
 
     def get_fuel_tank_pressure(
-        self, *, oxidizer_mass: float, fuel_mass: float
+        self,
+        *,
+        oxidizer_mass: float,
+        fuel_mass: float,
+        fuel_internal_energy: float | None = None,
+        oxidizer_internal_energy: float | None = None,
     ) -> float:
         """
         Returns the fuel-side pressure delivered to the injector [Pa].
@@ -139,11 +173,19 @@ class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
         In a stacked-tank system the fuel is pressurized by the oxidizer
         through the piston, so the fuel side starts from the oxidizer tank
         pressure less the piston pressure loss, and then loses what the fuel
-        line takes. The oxidizer line is not on this path, and ``fuel_mass`` is
-        unused here.
+        line takes. The oxidizer line is not on this path, and neither
+        ``fuel_mass`` nor ``fuel_internal_energy`` is used here.
+
+        Args:
+            oxidizer_mass: Current oxidizer mass in the tank [kg].
+            fuel_mass: Current fuel mass in the tank [kg].
+            fuel_internal_energy: Current internal energy of the fuel [J].
+            oxidizer_internal_energy: Current internal energy of the oxidizer
+                [J], which sets the pressure the piston passes on. Required for
+                a tank running an energy balance, unused otherwise.
         """
         return (
-            self.oxidizer_tank.get_pressure(oxidizer_mass)
+            self.oxidizer_tank.get_pressure(oxidizer_mass, oxidizer_internal_energy)
             - self.piston_loss
             - self.fuel_line_loss
         )

--- a/machwave/models/feed_systems/tank.py
+++ b/machwave/models/feed_systems/tank.py
@@ -1,21 +1,54 @@
+import dataclasses
+import functools
+
 import machwave.services.coolprop as coolprop_service
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class TankFluidState:
+    """
+    The fluid in a tank at one mass and internal energy.
+
+    Attributes:
+        temperature: Fluid temperature [K].
+        pressure: Tank pressure [Pa].
+        saturated_liquid_density: Saturated liquid density at the temperature
+            [kg/m^3].
+        saturated_vapor_density: Saturated vapor density at the temperature
+            [kg/m^3].
+    """
+
+    temperature: float
+    pressure: float
+    saturated_liquid_density: float
+    saturated_vapor_density: float
 
 
 class Tank:
     """
     A generic two-phase tank model for any single fluid recognized by CoolProp.
 
-    This is a static description of the tank: it carries no propellant-mass
-    state. Pressure and density are pure functions of a fluid mass passed in by
-    the caller, which lets the integrator own the mass and keeps the model
+    This is a static description of the tank: it carries no propellant state.
+    Pressure and density are pure functions of the state passed in by the
+    caller, which lets the integrator own that state and keeps the model
     re-runnable.
 
+    An isothermal tank is a pure function of the fluid mass. Its temperature is
+    held where it was loaded, so a self-pressurizing tank holds its saturation
+    pressure flat for as long as any liquid remains.
+
+    A tank running an energy balance is a function of the fluid mass and of the
+    internal energy the integrator carries alongside it. Draining takes enthalpy
+    out with the fluid, the fluid left behind cools as it boils to refill the
+    ullage, and the saturation pressure follows the temperature down over the
+    burn.
+
     Assumptions:
-      - Constant temperature (isothermal).
       - Two-phase equilibrium if there's enough mass to form liquid + vapor.
       - If insufficient mass for liquid, treat it as single-phase vapor via
         the real-gas equation of state.
-      - Ignores temperature changes upon phase change (no thermal balance).
+      - Nothing crosses the tank wall: no heat in, and no work other than what
+        the leaving fluid carries.
     """
 
     def __init__(
@@ -25,6 +58,7 @@ class Tank:
         temperature: float,
         initial_fluid_mass: float,
         overfill_tolerance: float = 0.01,
+        isothermal: bool = True,
     ) -> None:
         """
         Initialize a two-phase tank model.
@@ -32,11 +66,17 @@ class Tank:
         Args:
             fluid_name: Name of the fluid in the CoolProp database.
             volume: Internal volume of the tank [m^3] (>0).
-            temperature: Absolute temperature [K], assumed constant (>0).
+            temperature: Absolute temperature [K] the tank is loaded at (>0).
+                An isothermal tank stays there; a tank running an energy
+                balance starts there and cools from it.
             initial_fluid_mass: Initial total mass of fluid [kg] (>=0). This is
                 the tank's loading; the integrator owns the mass thereafter.
             overfill_tolerance: Allowed fraction over the saturated liquid
                 density, e.g. 0.01 = 1% (>=0).
+            isothermal: Whether the temperature is held where the tank was
+                loaded. False runs an energy balance instead, and every query
+                then needs the internal energy the integrator carries beside
+                the mass, starting from `initial_internal_energy`.
 
         Raises:
             ValueError: If the fluid is unknown to CoolProp, if any argument is
@@ -48,6 +88,7 @@ class Tank:
         self.temperature = temperature
         self.initial_fluid_mass = initial_fluid_mass
         self.overfill_tolerance = overfill_tolerance
+        self.isothermal = isothermal
 
         self._coolprop = coolprop_service.CoolPropService(fluid_name)
 
@@ -64,6 +105,8 @@ class Tank:
         )
         # Vapor pressure at the tank temperature, memoized per fluid mass.
         self._pressure_by_mass: dict[float, float] = {}
+        # Energy balance state, memoized per fluid mass and internal energy.
+        self._fluid_state_by_state: dict[tuple[float, float], TankFluidState] = {}
 
         self._check_not_overfilled()
 
@@ -138,9 +181,134 @@ class Tank:
                 f"{self.fluid_name} at {self.temperature} K"
             )
 
-    def get_pressure(self, fluid_mass: float) -> float:
+    @functools.cached_property
+    def initial_internal_energy(self) -> float:
         """
-        Return the tank pressure [Pa] for a given fluid mass.
+        Internal energy of the fluid the tank is loaded with [J].
+
+        Where a tank running an energy balance starts. The integrator carries
+        it from here, taking out the enthalpy of whatever leaves.
+        """
+        if self.initial_fluid_mass <= 0.0:
+            return 0.0
+
+        return (
+            self._coolprop.get_internal_energy_at_temperature_density(
+                self.temperature, self.initial_fluid_mass / self.volume
+            )
+            * self.initial_fluid_mass
+        )
+
+    def _get_fluid_state(
+        self, fluid_mass: float, internal_energy: float | None
+    ) -> TankFluidState:
+        """
+        Resolve the fluid at a mass and internal energy, memoized on the pair.
+
+        The bulk density and the specific internal energy fix the state, and
+        the temperature that comes out of it fixes the saturation densities the
+        fill state is read against.
+
+        Raises:
+            ValueError: If no internal energy was given, or if the fluid has
+                left the range CoolProp holds it over.
+        """
+        if internal_energy is None:
+            raise ValueError(
+                "A tank running an energy balance needs the internal energy of "
+                "its fluid alongside the mass; it starts at "
+                "initial_internal_energy."
+            )
+
+        memo_key = (fluid_mass, internal_energy)
+        fluid_state = self._fluid_state_by_state.get(memo_key)
+        if fluid_state is not None:
+            return fluid_state
+
+        density = fluid_mass / self.volume
+        specific_internal_energy = internal_energy / fluid_mass
+        try:
+            temperature = self._coolprop.get_temperature_at_density_internal_energy(
+                density, specific_internal_energy
+            )
+            fluid_state = TankFluidState(
+                temperature=temperature,
+                pressure=self._coolprop.get_pressure_at_density_internal_energy(
+                    density, specific_internal_energy
+                ),
+                saturated_liquid_density=(
+                    self._coolprop.get_saturated_liquid_density(temperature)
+                ),
+                saturated_vapor_density=(
+                    self._coolprop.get_saturated_vapor_density(temperature)
+                ),
+            )
+        except ValueError as error:
+            raise ValueError(
+                f"{self.fluid_name} at {density:.3f} kg/m^3 and "
+                f"{specific_internal_energy:.1f} J/kg is outside the range "
+                "CoolProp holds it over; the tank has drained or cooled past "
+                "what the two-phase model covers."
+            ) from error
+
+        self._fluid_state_by_state[memo_key] = fluid_state
+        return fluid_state
+
+    def get_temperature(
+        self, fluid_mass: float, internal_energy: float | None = None
+    ) -> float:
+        """
+        Return the fluid temperature [K].
+
+        An isothermal tank stays where it was loaded. A tank running an energy
+        balance follows its fluid down as the fluid boils to refill the ullage.
+
+        Args:
+            fluid_mass: Current total mass of fluid in the tank [kg].
+            internal_energy: Current internal energy of that fluid [J].
+                Required for a tank running an energy balance, unused
+                otherwise.
+
+        Returns:
+            Fluid temperature [K].
+        """
+        if self.isothermal or fluid_mass <= 0:
+            return self.temperature
+
+        return self._get_fluid_state(fluid_mass, internal_energy).temperature
+
+    def is_delivering_liquid(
+        self, fluid_mass: float, internal_energy: float | None = None
+    ) -> bool:
+        """
+        Whether the tank still holds liquid to feed, rather than vapor alone.
+
+        True while the fluid mass exceeds the mass of saturated vapor that
+        fills the tank, which is where the two-phase equilibrium holds.
+
+        Args:
+            fluid_mass: Current total mass of fluid in the tank [kg].
+            internal_energy: Current internal energy of that fluid [J].
+                Required for a tank running an energy balance, unused
+                otherwise.
+
+        Returns:
+            True if liquid remains in the tank.
+        """
+        if self.isothermal:
+            saturated_vapor_density = self.saturated_vapor_density
+        else:
+            saturated_vapor_density = self._get_fluid_state(
+                fluid_mass, internal_energy
+            ).saturated_vapor_density
+
+        return fluid_mass > saturated_vapor_density * self.volume
+
+    def get_pressure(
+        self, fluid_mass: float, internal_energy: float | None = None
+    ) -> float:
+        """
+        Return the tank pressure [Pa] for a given fluid state.
 
         1) An empty tank has zero pressure.
         2) If the fluid mass exceeds the mass of saturated vapor that fills the tank,
@@ -150,8 +318,15 @@ class Tank:
             pressure at the phase boundary, so pressure stays continuous as the tank
             crosses out of the two-phase regime.
 
+        A tank running an energy balance reads both off the state its mass and
+        internal energy fix, which walks the saturation pressure down with the
+        temperature instead of holding it flat.
+
         Args:
             fluid_mass: Current total mass of fluid in the tank [kg].
+            internal_energy: Current internal energy of that fluid [J].
+                Required for a tank running an energy balance, unused
+                otherwise.
 
         Returns:
             Tank pressure [Pa].
@@ -159,7 +334,10 @@ class Tank:
         if fluid_mass <= 0:
             return 0.0
 
-        if fluid_mass > self.saturated_vapor_density * self.volume:
+        if not self.isothermal:
+            return self._get_fluid_state(fluid_mass, internal_energy).pressure
+
+        if self.is_delivering_liquid(fluid_mass):
             return self.saturation_pressure
 
         if fluid_mass not in self._pressure_by_mass:
@@ -170,9 +348,42 @@ class Tank:
             )
         return self._pressure_by_mass[fluid_mass]
 
-    def get_density(self, fluid_mass: float) -> float:
+    def get_outflow_specific_enthalpy(
+        self, fluid_mass: float, internal_energy: float | None = None
+    ) -> float:
         """
-        Return fluid density [kg/m^3] for a given fluid mass.
+        Return the specific enthalpy of the fluid leaving the tank [J/kg].
+
+        What the energy balance takes out per unit mass drained. The feed
+        system draws liquid from the bottom while any remains, and vapor at the
+        bulk state once none does, so this steps up by the latent heat as the
+        last of the liquid goes.
+
+        Args:
+            fluid_mass: Current total mass of fluid in the tank [kg].
+            internal_energy: Current internal energy of that fluid [J].
+                Required for a tank running an energy balance, unused
+                otherwise.
+
+        Returns:
+            Specific enthalpy of the leaving fluid [J/kg].
+        """
+        if fluid_mass <= 0:
+            return 0.0
+
+        temperature = self.get_temperature(fluid_mass, internal_energy)
+        if self.is_delivering_liquid(fluid_mass, internal_energy):
+            return self._coolprop.get_saturated_liquid_enthalpy(temperature)
+
+        return self._coolprop.get_enthalpy_at_temperature_density(
+            temperature, fluid_mass / self.volume
+        )
+
+    def get_density(
+        self, fluid_mass: float, internal_energy: float | None = None
+    ) -> float:
+        """
+        Return fluid density [kg/m^3] for a given fluid state.
 
         1) An empty tank has zero density.
         2) Otherwise the fill state fixes the density: a partially liquid tank returns
@@ -181,6 +392,9 @@ class Tank:
 
         Args:
             fluid_mass: Current total mass of fluid in the tank [kg].
+            internal_energy: Current internal energy of that fluid [J].
+                Required for a tank running an energy balance, unused
+                otherwise.
 
         Returns:
             Fluid density [kg/m^3].
@@ -188,6 +402,11 @@ class Tank:
         if fluid_mass <= 0:
             return 0.0
 
-        if fluid_mass > self.saturated_vapor_density * self.volume:
+        if not self.is_delivering_liquid(fluid_mass, internal_energy):
+            return fluid_mass / self.volume
+
+        if self.isothermal:
             return self.saturated_liquid_density
-        return fluid_mass / self.volume
+        return self._get_fluid_state(
+            fluid_mass, internal_energy
+        ).saturated_liquid_density

--- a/machwave/models/thrust_chamber/injector.py
+++ b/machwave/models/thrust_chamber/injector.py
@@ -94,6 +94,7 @@ class BipropellantInjector:
         pressure_upstream: float,
         chamber_pressure: float,
         fluid_mass: float,
+        internal_energy: float | None = None,
     ) -> float:
         """
         Compute the fuel-side mass flow rate through this injector.
@@ -103,6 +104,8 @@ class BipropellantInjector:
             pressure_upstream: Upstream stagnation pressure [Pa].
             chamber_pressure: Chamber pressure [Pa].
             fluid_mass: Current fuel mass in the tank [kg].
+            internal_energy: Current internal energy of the fuel [J]. Required
+                for a tank running an energy balance, unused otherwise.
 
         Returns:
             Fuel mass flow rate [kg/s].
@@ -115,6 +118,7 @@ class BipropellantInjector:
             injector_area=self.area_fuel,
             mass_flow_model=self.mass_flow_model_fuel,
             fluid_mass=fluid_mass,
+            internal_energy=internal_energy,
         )
 
     def get_mass_flow_ox(
@@ -124,6 +128,7 @@ class BipropellantInjector:
         pressure_upstream: float,
         chamber_pressure: float,
         fluid_mass: float,
+        internal_energy: float | None = None,
     ) -> float:
         """
         Compute the oxidizer-side mass flow rate through this injector.
@@ -133,6 +138,9 @@ class BipropellantInjector:
             pressure_upstream: Upstream stagnation pressure [Pa].
             chamber_pressure: Chamber pressure [Pa].
             fluid_mass: Current oxidizer mass in the tank [kg].
+            internal_energy: Current internal energy of the oxidizer [J].
+                Required for a tank running an energy balance, unused
+                otherwise.
 
         Returns:
             Oxidizer mass flow rate [kg/s].
@@ -145,6 +153,7 @@ class BipropellantInjector:
             injector_area=self.area_ox,
             mass_flow_model=self.mass_flow_model_oxidizer,
             fluid_mass=fluid_mass,
+            internal_energy=internal_energy,
         )
 
     @staticmethod
@@ -157,6 +166,7 @@ class BipropellantInjector:
         injector_area: float,
         mass_flow_model: MassFlowModel,
         fluid_mass: float,
+        internal_energy: float | None = None,
     ) -> float:
         """
         Dispatch a mass flow calculation through the requested model.
@@ -169,6 +179,9 @@ class BipropellantInjector:
             injector_area: Effective flow area [m^2].
             mass_flow_model: Mass flow model for this side.
             fluid_mass: Current mass of fluid in the tank [kg].
+            internal_energy: Current internal energy of that fluid [J].
+                Required for a tank running an energy balance, unused
+                otherwise.
 
         Returns:
             Mass flow rate [kg/s].
@@ -176,7 +189,7 @@ class BipropellantInjector:
         if mass_flow_model == MassFlowModel.HEM:
             mass_flux = two_phase_flow.get_homogeneous_equilibrium_mass_flux(
                 fluid_name=tank.fluid_name,
-                temperature_upstream=tank.temperature,
+                temperature_upstream=tank.get_temperature(fluid_mass, internal_energy),
                 pressure_downstream=chamber_pressure,
                 pressure_upstream=pressure_upstream,
             )
@@ -185,7 +198,7 @@ class BipropellantInjector:
             return incompressible_flow.get_mass_flow_orifice(
                 discharge_coefficient=discharge_coefficient,
                 area=injector_area,
-                density=tank.get_density(fluid_mass),
+                density=tank.get_density(fluid_mass, internal_energy),
                 pressure_upstream=pressure_upstream,
                 pressure_downstream=chamber_pressure,
             )

--- a/machwave/services/coolprop.py
+++ b/machwave/services/coolprop.py
@@ -132,6 +132,66 @@ class CoolPropService:
         """
         return CP.PropsSI("P", "T", temperature, "D", density, self.fluid_name)
 
+    def get_internal_energy_at_temperature_density(
+        self, temperature: float, density: float
+    ) -> float:
+        """
+        Get the specific internal energy at a given temperature and density.
+
+        Args:
+            temperature: Temperature [K].
+            density: Density [kg/m^3].
+
+        Returns:
+            Specific internal energy [J/kg].
+        """
+        return CP.PropsSI("U", "T", temperature, "D", density, self.fluid_name)
+
+    def get_temperature_at_density_internal_energy(
+        self, density: float, internal_energy: float
+    ) -> float:
+        """
+        Get the temperature at a given density and specific internal energy.
+
+        Args:
+            density: Density [kg/m^3].
+            internal_energy: Specific internal energy [J/kg].
+
+        Returns:
+            Temperature [K].
+        """
+        return CP.PropsSI("T", "D", density, "U", internal_energy, self.fluid_name)
+
+    def get_pressure_at_density_internal_energy(
+        self, density: float, internal_energy: float
+    ) -> float:
+        """
+        Get the pressure at a given density and specific internal energy.
+
+        Args:
+            density: Density [kg/m^3].
+            internal_energy: Specific internal energy [J/kg].
+
+        Returns:
+            Pressure [Pa].
+        """
+        return CP.PropsSI("P", "D", density, "U", internal_energy, self.fluid_name)
+
+    def get_enthalpy_at_temperature_density(
+        self, temperature: float, density: float
+    ) -> float:
+        """
+        Get the specific enthalpy at a given temperature and density.
+
+        Args:
+            temperature: Temperature [K].
+            density: Density [kg/m^3].
+
+        Returns:
+            Specific enthalpy [J/kg].
+        """
+        return CP.PropsSI("H", "T", temperature, "D", density, self.fluid_name)
+
     def get_enthalpy_at_temperature_pressure(
         self, temperature: float, pressure: float
     ) -> float:

--- a/machwave/simulation/biliquid/results.py
+++ b/machwave/simulation/biliquid/results.py
@@ -21,6 +21,9 @@ class BiliquidSimulationResult(
     fuel_mass: simulation_results.SimulationResultArray
     fuel_tank_pressure: simulation_results.SimulationResultArray
     oxidizer_tank_pressure: simulation_results.SimulationResultArray
+    # Flat for an isothermal tank, decaying for one running an energy balance.
+    fuel_tank_temperature: simulation_results.SimulationResultArray
+    oxidizer_tank_temperature: simulation_results.SimulationResultArray
     final_oxidizer_mass: float
     final_fuel_mass: float
 
@@ -35,6 +38,8 @@ class BiliquidSimulationResult(
             "fuel_mass": fuel_mass,
             "fuel_tank_pressure": np.asarray(state.fuel_tank_pressure),
             "oxidizer_tank_pressure": np.asarray(state.oxidizer_tank_pressure),
+            "fuel_tank_temperature": np.asarray(state.fuel_tank_temperature),
+            "oxidizer_tank_temperature": np.asarray(state.oxidizer_tank_temperature),
             "final_oxidizer_mass": float(oxidizer_mass[-1]),
             "final_fuel_mass": float(fuel_mass[-1]),
         }

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -9,6 +9,7 @@ import machwave.core.mass_balance as mass_balance
 import machwave.core.performance as performance
 import machwave.core.solvers.rk4 as rk4
 import machwave.models.feed_systems as feed_systems
+import machwave.models.feed_systems.tank as tank_models
 import machwave.models.motors as motors
 import machwave.models.propellants.properties as propellant_properties_models
 import machwave.models.thrust_chamber.injector as injector_models
@@ -23,6 +24,8 @@ def get_injector_mass_flows(
     injector: injector_models.BipropellantInjector,
     fuel_mass: float,
     oxidizer_mass: float,
+    fuel_internal_energy: float | None,
+    oxidizer_internal_energy: float | None,
     fuel_tank_pressure: float,
     oxidizer_tank_pressure: float,
     is_feeding: bool,
@@ -37,6 +40,8 @@ def get_injector_mass_flows(
             injector=injector,
             fuel_mass=fuel_mass,
             oxidizer_mass=oxidizer_mass,
+            fuel_internal_energy=fuel_internal_energy,
+            oxidizer_internal_energy=oxidizer_internal_energy,
         )
         if fuel_tank_pressure > chamber_pressure
         else 0.0
@@ -46,6 +51,7 @@ def get_injector_mass_flows(
             chamber_pressure=chamber_pressure,
             injector=injector,
             oxidizer_mass=oxidizer_mass,
+            oxidizer_internal_energy=oxidizer_internal_energy,
         )
         if oxidizer_tank_pressure > chamber_pressure
         else 0.0
@@ -76,6 +82,8 @@ class BiliquidTimestepConditions(simulation_states.TimestepConditions):
     oxidizer_to_fuel_ratio: float
     fuel_tank_pressure: float
     oxidizer_tank_pressure: float
+    fuel_tank_temperature: float
+    oxidizer_tank_temperature: float
 
 
 class BiliquidEngineState(simulation_states.MotorState):
@@ -104,18 +112,32 @@ class BiliquidEngineState(simulation_states.MotorState):
             external_pressure=external_pressure,
         )
 
+        oxidizer_tank = motor.feed_system.oxidizer_tank
+        fuel_tank = motor.feed_system.fuel_tank
+
         self.oxidizer_mass: simulation_states.SimulationStateArray = [
-            motor.feed_system.oxidizer_tank.initial_fluid_mass
+            oxidizer_tank.initial_fluid_mass
         ]
         self.fuel_mass: simulation_states.SimulationStateArray = [
-            motor.feed_system.fuel_tank.initial_fluid_mass
+            fuel_tank.initial_fluid_mass
         ]
+
+        # Second state variable of a tank running an energy balance, which the
+        # integrator carries beside the mass. An isothermal tank has none.
+        self.oxidizer_internal_energy: float | None = (
+            None if oxidizer_tank.isothermal else oxidizer_tank.initial_internal_energy
+        )
+        self.fuel_internal_energy: float | None = (
+            None if fuel_tank.isothermal else fuel_tank.initial_internal_energy
+        )
 
         self.fuel_mass_flow_rate: simulation_states.SimulationStateArray = []
         self.oxidizer_mass_flow_rate: simulation_states.SimulationStateArray = []
         self.oxidizer_to_fuel_ratio: simulation_states.SimulationStateArray = []
         self.fuel_tank_pressure: simulation_states.SimulationStateArray = []
         self.oxidizer_tank_pressure: simulation_states.SimulationStateArray = []
+        self.fuel_tank_temperature: simulation_states.SimulationStateArray = []
+        self.oxidizer_tank_temperature: simulation_states.SimulationStateArray = []
 
     def _evaluate_propellant_properties(
         self,
@@ -148,18 +170,33 @@ class BiliquidEngineState(simulation_states.MotorState):
         chamber_pressure = self.chamber_pressure[-1]
         fuel_mass = self.fuel_mass[-1]
         oxidizer_mass = self.oxidizer_mass[-1]
+        fuel_internal_energy = self.fuel_internal_energy
+        oxidizer_internal_energy = self.oxidizer_internal_energy
 
         propellant_mass = fuel_mass + oxidizer_mass
         self.propellant_mass.append(propellant_mass)
 
         fuel_tank_pressure = feed_system.get_fuel_tank_pressure(
-            oxidizer_mass=oxidizer_mass, fuel_mass=fuel_mass
+            oxidizer_mass=oxidizer_mass,
+            fuel_mass=fuel_mass,
+            fuel_internal_energy=fuel_internal_energy,
+            oxidizer_internal_energy=oxidizer_internal_energy,
         )
         self.fuel_tank_pressure.append(fuel_tank_pressure)
         oxidizer_tank_pressure = feed_system.get_oxidizer_tank_pressure(
-            oxidizer_mass=oxidizer_mass
+            oxidizer_mass=oxidizer_mass,
+            oxidizer_internal_energy=oxidizer_internal_energy,
         )
         self.oxidizer_tank_pressure.append(oxidizer_tank_pressure)
+
+        fuel_tank_temperature = feed_system.fuel_tank.get_temperature(
+            fuel_mass, fuel_internal_energy
+        )
+        self.fuel_tank_temperature.append(fuel_tank_temperature)
+        oxidizer_tank_temperature = feed_system.oxidizer_tank.get_temperature(
+            oxidizer_mass, oxidizer_internal_energy
+        )
+        self.oxidizer_tank_temperature.append(oxidizer_tank_temperature)
 
         is_feeding = (
             not self.end_burn
@@ -174,6 +211,8 @@ class BiliquidEngineState(simulation_states.MotorState):
             injector=self.motor.thrust_chamber.injector,
             fuel_mass=fuel_mass,
             oxidizer_mass=oxidizer_mass,
+            fuel_internal_energy=fuel_internal_energy,
+            oxidizer_internal_energy=oxidizer_internal_energy,
             fuel_tank_pressure=fuel_tank_pressure,
             oxidizer_tank_pressure=oxidizer_tank_pressure,
             is_feeding=is_feeding,
@@ -226,6 +265,8 @@ class BiliquidEngineState(simulation_states.MotorState):
             oxidizer_to_fuel_ratio=oxidizer_to_fuel_ratio,
             fuel_tank_pressure=fuel_tank_pressure,
             oxidizer_tank_pressure=oxidizer_tank_pressure,
+            fuel_tank_temperature=fuel_tank_temperature,
+            oxidizer_tank_temperature=oxidizer_tank_temperature,
         )
         self._apply_nozzle_losses(
             ideal_momentum_term,
@@ -274,3 +315,43 @@ class BiliquidEngineState(simulation_states.MotorState):
         self.chamber_pressure.append(new_chamber_pressure)
         self.fuel_mass.append(fuel_mass - fuel_consumed)
         self.oxidizer_mass.append(oxidizer_mass - oxidizer_consumed)
+
+        self.fuel_internal_energy = self._drain_internal_energy(
+            tank=feed_system.fuel_tank,
+            internal_energy=fuel_internal_energy,
+            fluid_mass=fuel_mass,
+            mass_drained=fuel_consumed,
+        )
+        self.oxidizer_internal_energy = self._drain_internal_energy(
+            tank=feed_system.oxidizer_tank,
+            internal_energy=oxidizer_internal_energy,
+            fluid_mass=oxidizer_mass,
+            mass_drained=oxidizer_consumed,
+        )
+
+    @staticmethod
+    def _drain_internal_energy(
+        *,
+        tank: tank_models.Tank,
+        internal_energy: float | None,
+        fluid_mass: float,
+        mass_drained: float,
+    ) -> float | None:
+        """
+        Take the enthalpy the drained fluid carries out of the tank [J].
+
+        The tank is adiabatic and does no work on anything but the fluid it
+        pushes out, so its internal energy falls by the enthalpy of what left.
+        The fluid behind boils to refill the ullage and cools doing it, which
+        is what walks the saturation pressure down over the burn.
+
+        Returns:
+            The internal energy left in the tank [J], or None for an
+            isothermal tank, which runs no energy balance.
+        """
+        if internal_energy is None or mass_drained <= 0.0:
+            return internal_energy
+
+        return internal_energy - mass_drained * tank.get_outflow_specific_enthalpy(
+            fluid_mass, internal_energy
+        )

--- a/tests/test_core/test_mass_balance.py
+++ b/tests/test_core/test_mass_balance.py
@@ -205,3 +205,44 @@ def test_staged_inflow_tracks_refined_reference_better_than_freezing():
 
     assert np.all(staged > 0.0)
     assert staged_error < 0.2 * frozen_error
+
+
+class TestChamberBelowAmbient:
+    """A chamber that falls to ambient stops driving the nozzle.
+
+    The sub-critical branch takes the square root of one minus a power of the
+    pressure ratio, which turns negative once the chamber drops below ambient.
+    A blowdown reaches that on the way out, and the derivative has to stay a
+    number for the integrator to land there.
+    """
+
+    @pytest.mark.parametrize(
+        "chamber_pressure",
+        [BASE_KWARGS["external_pressure"], 5.0e4, 1.0e3],
+    )
+    def test_derivative_stays_finite(self, chamber_pressure):
+        (derivative,) = mass_balance.compute_chamber_pressure_mass_balance(
+            chamber_pressure=chamber_pressure,
+            mass_flow_in=constant(0.0),
+            **BASE_KWARGS,
+        )
+
+        assert np.isfinite(derivative)
+
+    def test_no_inflow_leaves_the_pressure_alone(self):
+        (derivative,) = mass_balance.compute_chamber_pressure_mass_balance(
+            chamber_pressure=BASE_KWARGS["external_pressure"],
+            mass_flow_in=constant(0.0),
+            **BASE_KWARGS,
+        )
+
+        assert derivative == pytest.approx(0.0)
+
+    def test_inflow_still_raises_the_pressure(self):
+        (derivative,) = mass_balance.compute_chamber_pressure_mass_balance(
+            chamber_pressure=5.0e4,
+            mass_flow_in=constant(0.01),
+            **BASE_KWARGS,
+        )
+
+        assert derivative > 0.0

--- a/tests/test_models/test_propulsion/test_feed_systems/test_tank_energy_balance.py
+++ b/tests/test_models/test_propulsion/test_feed_systems/test_tank_energy_balance.py
@@ -1,0 +1,172 @@
+"""A tank running an energy balance cools as it drains.
+
+An isothermal tank holds its saturation pressure flat for as long as any
+liquid remains, which a self-pressurizing tank does not do: the fluid left
+behind boils to refill the ullage and cools doing it. The energy balance
+carries the tank's internal energy alongside its mass and takes out the
+enthalpy of whatever leaves.
+"""
+
+import CoolProp.CoolProp as CP
+import pytest
+
+import machwave.models.feed_systems.tank as tank_models
+
+FLUID = "N2O"
+VOLUME = 0.01
+TEMPERATURE = 293.0
+FLUID_MASS = 5.0
+
+
+def build(isothermal, **overrides):
+    arguments = dict(
+        fluid_name=FLUID,
+        volume=VOLUME,
+        temperature=TEMPERATURE,
+        initial_fluid_mass=FLUID_MASS,
+        isothermal=isothermal,
+    )
+    arguments.update(overrides)
+    return tank_models.Tank(**arguments)
+
+
+def drain(tank, mass_drained, fluid_mass=FLUID_MASS, internal_energy=None):
+    """Take one lump of fluid out, with the enthalpy it carries."""
+    if internal_energy is None:
+        internal_energy = tank.initial_internal_energy
+    outflow_enthalpy = tank.get_outflow_specific_enthalpy(fluid_mass, internal_energy)
+    return (
+        fluid_mass - mass_drained,
+        internal_energy - mass_drained * outflow_enthalpy,
+    )
+
+
+class TestInitialInternalEnergy:
+    def test_matches_the_loaded_state(self):
+        tank = build(isothermal=False)
+
+        assert tank.initial_internal_energy == pytest.approx(
+            FLUID_MASS
+            * CP.PropsSI("U", "T", TEMPERATURE, "D", FLUID_MASS / VOLUME, FLUID)
+        )
+
+    def test_an_empty_tank_carries_none(self):
+        tank = build(isothermal=False, initial_fluid_mass=0.0)
+
+        assert tank.initial_internal_energy == 0.0
+
+
+class TestIsothermalTankIgnoresIt:
+    def test_temperature_holds(self):
+        tank = build(isothermal=True)
+
+        assert tank.get_temperature(FLUID_MASS) == TEMPERATURE
+        assert tank.get_temperature(FLUID_MASS, 1.0) == TEMPERATURE
+
+    def test_pressure_holds(self):
+        tank = build(isothermal=True)
+
+        assert tank.get_pressure(FLUID_MASS, 1.0) == tank.get_pressure(FLUID_MASS)
+
+    def test_it_needs_no_internal_energy(self):
+        tank = build(isothermal=True)
+
+        assert tank.get_pressure(FLUID_MASS) == pytest.approx(tank.saturation_pressure)
+
+
+class TestEnergyBalanceTank:
+    def test_the_loaded_state_agrees_with_the_isothermal_one(self):
+        energy_balance = build(isothermal=False)
+        isothermal = build(isothermal=True)
+        internal_energy = energy_balance.initial_internal_energy
+
+        assert energy_balance.get_temperature(
+            FLUID_MASS, internal_energy
+        ) == pytest.approx(TEMPERATURE)
+        assert energy_balance.get_pressure(
+            FLUID_MASS, internal_energy
+        ) == pytest.approx(isothermal.get_pressure(FLUID_MASS), rel=1e-6)
+
+    def test_draining_cools_the_tank(self):
+        tank = build(isothermal=False)
+
+        fluid_mass, internal_energy = drain(tank, 1.0)
+
+        assert tank.get_temperature(fluid_mass, internal_energy) < TEMPERATURE
+
+    def test_the_pressure_follows_the_temperature_down(self):
+        tank = build(isothermal=False)
+
+        fluid_mass, internal_energy = drain(tank, 1.0)
+
+        assert tank.get_pressure(fluid_mass, internal_energy) < tank.get_pressure(
+            FLUID_MASS, tank.initial_internal_energy
+        )
+
+    def test_the_decay_keeps_going(self):
+        tank = build(isothermal=False)
+
+        pressures = []
+        fluid_mass, internal_energy = FLUID_MASS, tank.initial_internal_energy
+        for _ in range(4):
+            fluid_mass, internal_energy = drain(tank, 0.5, fluid_mass, internal_energy)
+            pressures.append(tank.get_pressure(fluid_mass, internal_energy))
+
+        assert pressures == sorted(pressures, reverse=True)
+
+    def test_the_pressure_stays_on_the_saturation_curve(self):
+        tank = build(isothermal=False)
+
+        fluid_mass, internal_energy = drain(tank, 1.0)
+
+        temperature = tank.get_temperature(fluid_mass, internal_energy)
+        assert tank.get_pressure(fluid_mass, internal_energy) == pytest.approx(
+            CP.PropsSI("P", "T", temperature, "Q", 0, FLUID), rel=1e-6
+        )
+
+    def test_the_density_follows_the_temperature(self):
+        tank = build(isothermal=False)
+
+        fluid_mass, internal_energy = drain(tank, 1.0)
+
+        # A colder liquid is a denser one.
+        assert tank.get_density(fluid_mass, internal_energy) > tank.get_density(
+            FLUID_MASS, tank.initial_internal_energy
+        )
+
+    def test_it_asks_for_the_internal_energy(self):
+        tank = build(isothermal=False)
+
+        with pytest.raises(ValueError, match="initial_internal_energy"):
+            tank.get_pressure(FLUID_MASS)
+
+    def test_a_state_off_the_chart_says_so(self):
+        tank = build(isothermal=False)
+
+        with pytest.raises(ValueError, match="outside the range CoolProp"):
+            tank.get_pressure(FLUID_MASS, -1e12)
+
+
+class TestOutflowEnthalpy:
+    def test_liquid_leaves_at_the_saturated_liquid_enthalpy(self):
+        tank = build(isothermal=False)
+        internal_energy = tank.initial_internal_energy
+
+        temperature = tank.get_temperature(FLUID_MASS, internal_energy)
+        assert tank.get_outflow_specific_enthalpy(
+            FLUID_MASS, internal_energy
+        ) == pytest.approx(CP.PropsSI("H", "T", temperature, "Q", 0, FLUID))
+
+    def test_vapor_leaves_at_the_bulk_state(self):
+        tank = build(isothermal=True)
+        # Below the saturated vapor fill, so no liquid is left to draw on.
+        vapor_mass = 0.5 * tank.saturated_vapor_density * VOLUME
+
+        assert tank.get_outflow_specific_enthalpy(vapor_mass) == pytest.approx(
+            CP.PropsSI("H", "T", TEMPERATURE, "D", vapor_mass / VOLUME, FLUID)
+        )
+
+    def test_an_empty_tank_carries_nothing_out(self):
+        tank = build(isothermal=False)
+
+        assert tank.get_outflow_specific_enthalpy(0.0, 0.0) == 0.0

--- a/tests/test_simulations/test_biliquid_tank_energy_balance.py
+++ b/tests/test_simulations/test_biliquid_tank_energy_balance.py
@@ -1,0 +1,130 @@
+"""A biliquid engine fed by a tank running an energy balance.
+
+The tank's internal energy is a second state variable the integrator carries
+beside its mass, so the tank cools as it drains and its pressure decays with
+it, instead of holding flat until the liquid runs out.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import machwave.models.feed_systems.tank as tank_models
+import machwave.simulation.biliquid as biliquid_simulation
+from tests.test_simulations import motor_builders
+from tests.test_simulations.conftest import (
+    assert_recorded_arrays_aligned,
+    run_simulation,
+)
+
+OXIDIZER_TANK = dict(
+    fluid_name="N2O",
+    volume=3.80e-3,
+    temperature=300.0,
+    initial_fluid_mass=2.78,
+)
+
+
+def build(isothermal):
+    motor, params = motor_builders.build_1kn_biliquid_engine()
+    motor.feed_system.oxidizer_tank = tank_models.Tank(
+        **OXIDIZER_TANK, isothermal=isothermal
+    )
+    return motor, params
+
+
+@pytest.fixture(scope="module")
+def results():
+    return {
+        isothermal: run_simulation(*build(isothermal)) for isothermal in (True, False)
+    }
+
+
+def test_the_tank_pressure_decays_over_the_burn(results):
+    pressure = results[False].oxidizer_tank_pressure
+
+    assert pressure[-1] < 0.5 * pressure[0]
+
+
+def test_the_tank_cools_over_the_burn(results):
+    temperature = results[False].oxidizer_tank_temperature
+
+    assert temperature[0] == pytest.approx(OXIDIZER_TANK["temperature"])
+    assert temperature[-1] < temperature[0]
+
+
+def test_the_decay_is_monotonic_while_the_tank_holds_liquid(results):
+    result = results[False]
+    tank = tank_models.Tank(**OXIDIZER_TANK, isothermal=False)
+    # The saturated vapor density only falls as the tank cools, so a mass above
+    # the vapor fill it started at holds liquid at any temperature it reaches.
+    # Past that the outflow enthalpy steps by the latent heat as the last of
+    # the liquid goes, and the decay picks up a jitter on the way out.
+    two_phase = result.oxidizer_mass > tank.saturated_vapor_density * tank.volume
+    temperature = result.oxidizer_tank_temperature[two_phase]
+
+    assert two_phase.sum() > 1
+    assert np.all(np.diff(temperature) <= 0.0)
+    assert np.all(np.diff(result.oxidizer_tank_pressure[two_phase]) <= 0.0)
+
+
+def test_an_isothermal_tank_holds_its_temperature(results):
+    temperature = results[True].oxidizer_tank_temperature
+
+    assert np.all(temperature == OXIDIZER_TANK["temperature"])
+
+
+def test_the_engine_runs_longer_on_a_decaying_tank(results):
+    # The same load pushes through a falling pressure, so it drains slower.
+    assert results[False].burn_time > results[True].burn_time
+
+
+def test_recorded_arrays_stay_aligned(results):
+    assert_recorded_arrays_aligned(results[False])
+
+
+def test_the_state_carries_the_energy_only_for_an_energy_balance():
+    isothermal_motor, params = build(isothermal=True)
+    energy_balance_motor, _ = build(isothermal=False)
+
+    isothermal_state = biliquid_simulation.BiliquidEngineState(
+        motor=isothermal_motor,
+        igniter_pressure=params.igniter_pressure,
+        external_pressure=params.external_pressure,
+    )
+    energy_balance_state = biliquid_simulation.BiliquidEngineState(
+        motor=energy_balance_motor,
+        igniter_pressure=params.igniter_pressure,
+        external_pressure=params.external_pressure,
+    )
+
+    assert isothermal_state.oxidizer_internal_energy is None
+    assert energy_balance_state.oxidizer_internal_energy == pytest.approx(
+        energy_balance_motor.feed_system.oxidizer_tank.initial_internal_energy
+    )
+
+
+def test_draining_takes_the_outflow_enthalpy_out():
+    motor, params = build(isothermal=False)
+    state = biliquid_simulation.BiliquidEngineState(
+        motor=motor,
+        igniter_pressure=params.igniter_pressure,
+        external_pressure=params.external_pressure,
+    )
+    tank = motor.feed_system.oxidizer_tank
+    internal_energy_before = state.oxidizer_internal_energy
+    assert internal_energy_before is not None
+    oxidizer_mass_before = state.oxidizer_mass[-1]
+
+    state.run_timestep(params.d_t, params.external_pressure)
+
+    mass_drained = oxidizer_mass_before - state.oxidizer_mass[-1]
+    assert mass_drained > 0.0
+    assert state.oxidizer_internal_energy == pytest.approx(
+        internal_energy_before
+        - mass_drained
+        * tank.get_outflow_specific_enthalpy(
+            oxidizer_mass_before, internal_energy_before
+        )
+    )


### PR DESCRIPTION
Closes #327. Unblocked by #321, which gave the integrator ownership of the tank state this second state variable plugs into.

Replaces #481, which GitHub marked merged when its base branch (the feed line branch of #479) was deleted, though none of its commits reached master. This is the same work rebased onto master, with the feed line changes it was stacked on now landed.

`Tank` held its temperature where it was loaded, so a self-pressurizing tank held its saturation pressure flat through the whole liquid phase instead of decaying as a vapor-pressure-fed tank actually does.

## The mode

`Tank(..., isothermal=False)` runs an energy balance. The tank's internal energy becomes a second state variable the integrator carries beside the mass:

- `initial_internal_energy` is where it starts, the fluid the tank was loaded with at its load temperature.
- `get_outflow_specific_enthalpy(fluid_mass, internal_energy)` is what leaves per unit mass drained: saturated liquid while any remains, vapor at the bulk state once none does.
- The bulk density and the specific internal energy fix the state, so `get_temperature`, `get_pressure`, `get_density` and `is_delivering_liquid` all read off it. The two-phase pressure stays exactly on the saturation curve at the temperature the state lands on, which is pinned by a test.

The tank stays a static description with no state of its own, per #321. Every query takes the internal energy alongside the mass and says so when a tank running a balance is asked without one, rather than quietly answering from the loaded state. An isothermal tank ignores the argument entirely, so nothing about it changes.

## Through the engine

`FeedSystem`, `StackedTankPressureFedFeedSystem` and `BipropellantInjector` pass the internal energy through, so the delivered pressure, the liquid density feeding the single-phase orifice and the upstream temperature feeding the two-phase one all see the tank where it actually is rather than where it was loaded. `BiliquidEngineState` carries the energy for a tank that runs a balance and `None` for one that does not, integrates it as `U - m_dot * h_out * dt` alongside the mass, and records both tank temperatures beside their pressures in the result.

## What it does

The 1 kN engine with its oxidizer tank on an energy balance, against the same engine isothermal:

| | isothermal | energy balance |
| --- | ---: | ---: |
| oxidizer tank pressure | 56.9 bar, flat | 58.6 -> 19.5 bar |
| oxidizer tank temperature | 300 K, flat | 300 -> 259 K |
| burn time | 3.13 s | 4.09 s |
| total impulse | 5956 N-s | 6445 N-s |

The two start at different pressures because that tank is loaded just above its saturated liquid density, which the energy balance reads as compressed liquid and the isothermal branch reads as saturated.

## One fix ahead of it

First commit on the branch, separable if you would rather it went on its own: `compute_chamber_pressure_mass_balance` had no guard for a chamber below ambient, where its sub-critical branch roots a negative number and returns NaN. Thrust termination fires on the chamber pressure at the start of a step, so a Runge-Kutta stage inside a fast enough tail-off still lands below ambient, and the deeper blowdown this branch produces reaches it on the 1 kN engine. A chamber at or below ambient drives nothing out of the nozzle, so the ratio holds at one and the outflow goes to zero there.

## Limits

Temperature and pressure fall monotonically for as long as the tank holds liquid, which the simulation test pins over that whole span. Past it the outflow enthalpy steps up by the latent heat as the last of the liquid goes, and the decay picks up a jitter of a few hundredths of a kelvin on the way out. The tank is adiabatic: no heat crosses the wall, so this is the fastest decay the tank can have, and a real one warmed by its surroundings decays more slowly.