### PR TITLE
Measure the motor center of gravity from the nozzle exit

### DIFF
--- a/docs/api/adapters/rocketpy.md
+++ b/docs/api/adapters/rocketpy.md
@@ -137,7 +137,7 @@ and its simulation result. The adapter currently provides:
 - RocketPy must be installed, otherwise adapter import or initialization raises `ImportError`.
 - The solid-motor adapter assumes RocketPy's segmented-grain model and uses the first Machwave grain segment as the representative geometry.
 - The thrust chamber must define `dry_mass_properties`; the adapter raises `ValueError` otherwise.
-- The coordinate system orientation is `nozzle_to_combustion_chamber`.
+- The coordinate system orientation is `nozzle_to_combustion_chamber`, and `nozzle_position` is zero, so RocketPy measures from the nozzle exit. Machwave's motor frame shares that origin, so the propellant and dry mass positions pass through unchanged.
 
 ## API Reference
 

--- a/docs/api/models/thrust_chamber.md
+++ b/docs/api/models/thrust_chamber.md
@@ -9,4 +9,19 @@ Thrust chamber assembly and sub-components.
 - `SolidMotorThrustChamber` — Bundles nozzle + chamber + the distance from nozzle exit to grain port.
 - `BiliquidEngineThrustChamber` — Bundles nozzle + chamber + injector.
 
+## Center Of Gravity Frames
+
+Machwave measures axial positions along three nested frames, all with positive x
+pointing toward the bulkhead:
+
+| Frame | Origin | Where it appears |
+| --- | --- | --- |
+| Grain segment | That segment's own port face, closest to the nozzle | `GrainSegment.get_center_of_gravity` |
+| Grain | The grain port face, closest to the nozzle | `Grain.get_center_of_gravity` |
+| Motor | The nozzle exit plane | `SolidSimulationResult.propellant_cog`, `DryMassProperties.center_of_gravity_coordinate` |
+
+`nozzle_exit_to_grain_port_distance` on `SolidMotorThrustChamber` is what carries
+the grain frame into the motor frame. A segment origin is the initial position of
+its port face and stays fixed as that face regresses.
+
 ::: machwave.models.thrust_chamber

--- a/machwave/adapters/rocketpy/base.py
+++ b/machwave/adapters/rocketpy/base.py
@@ -124,7 +124,7 @@ class RocketPyMotorAdapter(abc.ABC, typing.Generic[R]):
 
         Uses pre-computed values from the simulation result, extracts the
         x-coordinate (axial position) from the propellant's center of gravity
-        over time.
+        over time, already measured from the nozzle exit.
 
         Returns:
             `rocketpy.Function` with (time, position) data [m].

--- a/machwave/adapters/rocketpy/solid_motor.py
+++ b/machwave/adapters/rocketpy/solid_motor.py
@@ -48,9 +48,10 @@ class RocketPySolidMotorAdapter(
         grain_initial_height = first_segment.length
         grain_initial_inner_radius = first_segment.core_diameter / 2
         throat_radius = motor.thrust_chamber.nozzle.throat_diameter / 2
-        grains_center_of_mass_position = motor.grain.get_center_of_gravity(
-            web_distance=0.0
-        )[0]
+        grains_center_of_mass_position = (
+            motor.grain.get_center_of_gravity(web_distance=0.0)[0]
+            + motor.thrust_chamber.nozzle_exit_to_grain_port_distance
+        )
 
         # RocketPy handles real density internally
         grain_density = motor.propellant.ideal_density

--- a/machwave/models/grain/base.py
+++ b/machwave/models/grain/base.py
@@ -159,8 +159,10 @@ class GrainSegment(ABC):
         """
         Return the center of gravity of the segment.
 
-        The coordinate system origin is at the port, closest to the nozzle,
-        with positive x-direction pointing toward the bulkhead.
+        Implementations must place the origin at the segment's own port face,
+        the one closest to the nozzle, with positive x pointing toward the
+        bulkhead. The origin is the initial position of that face and does not
+        move as the face regresses.
 
         Returns:
             Center of gravity of the segment as `(x, y, z)` [m].
@@ -451,7 +453,9 @@ class Grain:
         Returns:
             A 1D array of shape (3,) with the [x, y, z] coordinates of the
             center of gravity [m]. Origin is at the port of the grain (closest
-            to nozzle), with positive x pointing toward bulkhead.
+            to nozzle), with positive x pointing toward bulkhead. Add
+            `SolidMotorThrustChamber.nozzle_exit_to_grain_port_distance` to
+            reach the motor frame, which is measured from the nozzle exit.
 
         Raises:
             ValueError: If no segments are found in the grain.

--- a/machwave/models/thrust_chamber/base.py
+++ b/machwave/models/thrust_chamber/base.py
@@ -77,7 +77,8 @@ class SolidMotorThrustChamber(ThrustChamber):
             nozzle: Nozzle instance.
             combustion_chamber: Combustion chamber instance.
             nozzle_exit_to_grain_port_distance: Axial distance from the nozzle
-                exit plane to the grain port [m].
+                exit plane to the grain port [m]. Shifts grain mass properties
+                into the motor frame, whose origin is the nozzle exit.
             dry_mass_properties: Dry mass properties of the assembly. Optional;
                 only consumed by the RocketPy trajectory adapter. Internal
                 ballistics simulations do not require it.

--- a/machwave/simulation/solid/results.py
+++ b/machwave/simulation/solid/results.py
@@ -27,6 +27,7 @@ class SolidSimulationResult(
     propellant_volume_per_segment: simulation_results.SimulationResultArray
     propellant_mass_per_segment: simulation_results.SimulationResultArray
     burn_rate: simulation_results.SimulationResultArray
+    # propellant_cog is measured from the nozzle exit, positive toward the bulkhead.
     propellant_cog: simulation_results.SimulationResultArray
     propellant_moi: simulation_results.SimulationResultArray
     # klemmung is filtered to burn_area > 0, so its length is < len(time).

--- a/machwave/simulation/solid/states.py
+++ b/machwave/simulation/solid/states.py
@@ -191,6 +191,10 @@ class SolidMotorState(simulation_states.MotorState):
                 volume_per_segment=propellant_volume_per_segment,
                 center_of_gravity=propellant_cog,
             )
+            # Shift after the parallel axis step, which needs the grain frame.
+            propellant_cog[0] += (
+                self.motor.thrust_chamber.nozzle_exit_to_grain_port_distance
+            )
         else:  # no propellant left: CoG is undefined and inertia is zero
             propellant_cog = np.full(3, np.nan)
             propellant_moi = np.zeros((3, 3))

--- a/tests/test_adapters/test_rocketpy_solid_motor.py
+++ b/tests/test_adapters/test_rocketpy_solid_motor.py
@@ -107,3 +107,18 @@ def test_dry_mass_properties_are_forwarded() -> None:
     assert attrs["dry_mass"] == pytest.approx(1.5)
     assert attrs["center_of_dry_mass_position"] == pytest.approx(0.2)
     assert attrs["dry_inertia"] == pytest.approx((0.12, 0.12, 0.03))
+
+
+@pytest.mark.parametrize("offset", [0.0, 0.01, 0.25])
+def test_grain_center_of_mass_is_measured_from_the_nozzle_exit(offset) -> None:
+    thrust_chamber = SolidMotorThrustChamberFactory.build(
+        nozzle_exit_to_grain_port_distance=offset
+    )
+    motor = SolidMotorFactory.build(thrust_chamber=thrust_chamber)
+    adapter = _build_adapter_without_init(motor)
+
+    attrs = adapter._get_rocketpy_attributes()
+
+    assert attrs["grains_center_of_mass_position"] == pytest.approx(
+        motor.grain.get_center_of_gravity(web_distance=0.0)[0] + offset
+    )

--- a/tests/test_models/test_propulsion/test_grain/test_cog/test_cog_frames.py
+++ b/tests/test_models/test_propulsion/test_grain/test_cog/test_cog_frames.py
@@ -1,0 +1,68 @@
+"""Center of gravity origin conventions at the segment and grain levels."""
+
+import pytest
+
+import machwave.models.grain as grain_models
+from tests.factories import (
+    BatesSegmentFactory,
+    ConicalGrainSegmentFactory,
+    DGrainSegmentFactory,
+    FinocylGrainSegmentFactory,
+    MultiPortGrainSegmentFactory,
+    RodAndTubeGrainSegmentFactory,
+    StarGrainSegmentFactory,
+    WagonWheelGrainSegmentFactory,
+)
+
+SEGMENT_FACTORIES = [
+    BatesSegmentFactory,
+    StarGrainSegmentFactory,
+    WagonWheelGrainSegmentFactory,
+    RodAndTubeGrainSegmentFactory,
+    MultiPortGrainSegmentFactory,
+    DGrainSegmentFactory,
+    ConicalGrainSegmentFactory,
+    FinocylGrainSegmentFactory,
+]
+
+all_geometries = pytest.mark.parametrize(
+    "segment_factory",
+    SEGMENT_FACTORIES,
+    ids=[factory.__name__ for factory in SEGMENT_FACTORIES],
+)
+
+
+@all_geometries
+def test_segment_origin_is_its_own_port_face(segment_factory) -> None:
+    segment = segment_factory.build()
+    cog = segment.get_center_of_gravity(web_distance=0.0)
+
+    assert cog.shape == (3,)
+    assert 0.0 < cog[0] < segment.length
+
+
+@all_geometries
+def test_grain_origin_matches_the_single_segment_it_holds(segment_factory) -> None:
+    segment = segment_factory.build()
+    grain = grain_models.Grain()
+    grain.add_segment(segment)
+
+    assert grain.get_center_of_gravity(web_distance=0.0)[0] == pytest.approx(
+        segment.get_center_of_gravity(web_distance=0.0)[0]
+    )
+
+
+@all_geometries
+def test_grain_origin_is_the_port_of_the_last_added_segment(segment_factory) -> None:
+    spacing = 7e-3
+    segment = segment_factory.build()
+    grain = grain_models.Grain(spacing=spacing)
+    for _ in range(2):
+        grain.add_segment(segment)
+
+    segment_cog = segment.get_center_of_gravity(web_distance=0.0)[0]
+    forward_segment_cog = segment.length + spacing + segment_cog
+
+    assert grain.get_center_of_gravity(web_distance=0.0)[0] == pytest.approx(
+        (segment_cog + forward_segment_cog) / 2
+    )

--- a/tests/test_simulations/test_solid_motor_simulation.py
+++ b/tests/test_simulations/test_solid_motor_simulation.py
@@ -314,3 +314,37 @@ def test_moment_of_inertia_is_guarded_past_burnout() -> None:
 
     np.testing.assert_array_equal(state.propellant_moi[-1], np.zeros((3, 3)))
     assert np.all(np.isnan(state.propellant_cog[-1]))
+
+
+def test_propellant_center_of_gravity_is_measured_from_the_nozzle_exit() -> None:
+    """The recorded center of gravity sits in the motor frame, not the grain frame."""
+    motor, params = motor_builders.build_apcp_motor()
+    state = solid_simulation.SolidMotorState(
+        motor=motor,
+        igniter_pressure=params.igniter_pressure,
+        external_pressure=params.external_pressure,
+    )
+
+    state.run_timestep(d_t=params.d_t, external_pressure=params.external_pressure)
+
+    assert state.propellant_cog[-1][0] == pytest.approx(
+        motor.grain.get_center_of_gravity(web_distance=0.0)[0]
+        + motor.thrust_chamber.nozzle_exit_to_grain_port_distance
+    )
+
+
+def test_propellant_moment_of_inertia_is_unchanged_by_the_nozzle_exit_offset() -> None:
+    """The offset must land after the parallel axis step, leaving inertia alone."""
+    tensors = []
+    for offset in (0.0, 0.25):
+        motor, params = motor_builders.build_apcp_motor()
+        motor.thrust_chamber.nozzle_exit_to_grain_port_distance = offset
+        state = solid_simulation.SolidMotorState(
+            motor=motor,
+            igniter_pressure=params.igniter_pressure,
+            external_pressure=params.external_pressure,
+        )
+        state.run_timestep(d_t=params.d_t, external_pressure=params.external_pressure)
+        tensors.append(state.propellant_moi[-1])
+
+    np.testing.assert_allclose(tensors[0], tensors[1])


### PR DESCRIPTION
Closes #484.

The grain reports its center of gravity from the grain port, while `DryMassProperties` and RocketPy both measure from the nozzle exit. Nothing read `nozzle_exit_to_grain_port_distance`, so the propellant sat too close to the nozzle by that distance, biasing the combined center of gravity and the stability margin in trajectory runs.

The segment and grain frames already matched the intended convention, verified across BATES, the two-dimensional fast marching method geometries, and the three-dimensional ones, so this only adds the motor-level offset and writes the convention down.

- `SolidMotorState.run_timestep` shifts the recorded center of gravity into the motor frame, after the parallel axis step that needs both centers in the grain frame.
- `RocketPySolidMotorAdapter` adds the offset to `grains_center_of_mass_position`, which reads the grain directly rather than the result. `center_of_propellant_mass` needs none, since the result now carries the motor frame.
- The three frames are documented in `docs/api/models/thrust_chamber.md`, and the abstract `get_center_of_gravity` docstring now states the segment origin as a requirement on implementations.

Tests cover the segment and grain origins for every geometry, the two adapter positions against the offset, and that the propellant inertia tensor is unchanged by it.