### PR TITLE
Rewrite the quick start as a tutorial

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,11 +1,11 @@
 # Quick Start
 
-This guide shows how to simulate a Solid Rocket Motor with a BATES grain geometry using Machwave.
+In this tutorial we will simulate a 3-segment BATES grain solid rocket motor.
 
 ## 1. Choose a propellant
 
-Machwave ships with several pre-defined solid propellant formulations.
-Here we use KNDX (65% potassium nitrate and 35% dextrose):
+Machwave ships with several pre-defined solid formulations. We will use KNDX,
+65% potassium nitrate and 35% dextrose:
 
 ```python
 from machwave import formulations
@@ -13,60 +13,60 @@ from machwave import formulations
 propellant = formulations.solid.KNDX
 ```
 
-For a full list of available solid propellants, see the
-[formulations page](api/models/propellants/formulations.md).
-
 ## 2. Define the grain geometry
 
-Create a `Grain` and add one or more segments.
+We stack three identical BATES segments, 10 mm apart:
 
 ```python
 from machwave import grain as grain_models
 
-grain = grain_models.Grain(spacing=10e-3)  # 10 mm spacing between segments
+grain = grain_models.Grain(spacing=10e-3)
 
 bates_segment = grain_models.geometries.BatesSegment(
-    outer_diameter=41e-3,   # 41 mm
-    core_diameter=15e-3,    # 15 mm
-    length=67.5e-3,         # 67.5 mm
+    outer_diameter=65e-3,
+    core_diameter=22e-3,
+    length=100e-3,
 )
 
-for _ in range(4):
+for _ in range(3):
     grain.add_segment(bates_segment)
 ```
 
 ## 3. Build the thrust chamber
 
-The thrust chamber is composed of a **nozzle** and a **combustion chamber**:
+Next comes the thrust chamber, composed of a **nozzle** and a **combustion
+chamber**:
 
 ```python
 from machwave import thrust_chamber as thrust_chamber_models
 
 nozzle = thrust_chamber_models.Nozzle(
-    inlet_diameter=43e-3,
-    throat_diameter=9.5e-3,
-    divergent_angle=12,     # degrees
-    convergent_angle=40,    # degrees
+    inlet_diameter=65e-3,
+    throat_diameter=14e-3,
+    divergent_angle=12,
+    convergent_angle=40,
     expansion_ratio=8,
 )
 
 combustion_chamber = thrust_chamber_models.CombustionChamber(
-    casing_inner_diameter=44.5e-3,
-    casing_outer_diameter=50.8e-3,
-    thermal_liner_thickness=1e-3,
+    casing_inner_diameter=69.85e-3,
+    casing_outer_diameter=76.2e-3,
+    thermal_liner_thickness=2e-3,
     internal_length=grain.total_length + 10e-3,
 )
 
 thrust_chamber = thrust_chamber_models.SolidMotorThrustChamber(
     nozzle=nozzle,
     combustion_chamber=combustion_chamber,
-    nozzle_exit_to_grain_port_distance=0.01,
+    nozzle_exit_to_grain_port_distance=1e-2,
 )
 ```
 
+The 2 mm liner leaves a 65.85 mm bore, just wide enough for our 65 mm grain.
+
 ## 4. Assemble the motor
 
-Combine the grain, propellant, and thrust chamber into a `SolidMotor`:
+`SolidMotor` combines the grain, the propellant, and the thrust chamber:
 
 ```python
 from machwave import motors
@@ -78,28 +78,30 @@ motor = motors.SolidMotor(
 )
 ```
 
-## 5. Configure and run the simulation
+## 5. Run the simulation
 
-Set up the simulation parameters and run it. `run()` returns a frozen
-`SimulationResult` containing all ballistic time-series and derived metrics:
+Every simulation needs a set of input parameters defined in `InternalBallisticsSimulationParams`.
+The timestep `d_t` needs to be small enough for the simulation to converge: usually 1 ms is a safe choice.
+The igniter pressure is the initial chamber pressure, and the external pressure is the ambient pressure.
 
 ```python
 from machwave import simulation
 
 params = simulation.InternalBallisticsSimulationParams(
-    d_t=0.01,                # time step [s]
-    igniter_pressure=1e6,    # 1 MPa
-    external_pressure=1e5,   # 1 atm
+    d_t=1e-3,
+    igniter_pressure=1e6,
+    external_pressure=1e5,
 )
 
-sim = simulation.InternalBallisticsSimulation(motor=motor, params=params)
-result = sim.run()
+simulation = simulation.InternalBallisticsSimulation(motor=motor, params=params)
+result = simulation.run()
 ```
 
-## 6. View results
+`run()` marches through the burn and returns a frozen `SimulationResult`.
 
-Print a summary of key performance metrics and plot the thrust and chamber
-pressure curves:
+## 6. Read the results
+
+We print the summary and plot thrust against chamber pressure:
 
 ```python
 from machwave.services.plots import internal_ballistics as ib_plots
@@ -109,9 +111,41 @@ result.report()
 ib_plots.thrust_pressure_plot(result.time, result.thrust, result.chamber_pressure).show()
 ```
 
-`result.report()` outputs initial propellant mass, max/average chamber pressure,
-burn time, max/average thrust, specific impulse, and total impulse.
+```text
+INTERNAL BALLISTICS SIMULATION RESULTS
 
-For more complete examples, including coupled trajectory simulations and Monte
-Carlo analyses, see the
-[examples directory](https://github.com/felipebogaertsm/machwave/tree/main/examples).
+BURN REGRESSION
+ Propellant initial mass 1.647 kg
+ Initial propellant volume: 881.452 cm^3
+ Initial burn area: 383.636 cm^2
+ Peak burn area: 432.896 cm^2
+ Mean Kn: 264.80
+ Max Kn: 281.21
+ Initial to final Kn ratio: 1.098
+ Volumetric efficiency: 78.430%
+ Burn profile: regressive
+ Max initial mass flux: 1855.148 kg/s-m-m or 2.639 lb/s-in-in
+
+CHAMBER PRESSURE
+ Maximum, average chamber pressure: 6.090, 5.144 MPa
+
+THRUST AND IMPULSE
+ Maximum, average thrust: 1357.313, 1134.445 N
+ Total, specific impulses: 2099.769 N-s, 130.039 s
+ Burnout time: 1.789 s, thrust time: 1.850 s
+
+NOZZLE
+  Average nozzle efficiency: 86.517%
+  Average divergent nozzle loss fraction: 1.093%
+  Average kinetics loss fraction: 0.107%
+  Average boundary layer loss fraction: 3.326%
+  Average two-phase flow loss fraction: 3.974%
+  Average other losses fraction: 5.000%
+```
+
+## Congratulations!
+
+We have just simulated a solid rocket motor with Machwave. The
+[examples directory](https://github.com/felipebogaertsm/machwave/tree/main/examples)
+picks up from here, running these same steps with finocyl and star grains, a
+RocketPy trajectory, and a Monte Carlo analysis.


### PR DESCRIPTION
Closes #486.

The guide passed `dry_mass` to `SolidMotorThrustChamber`, which raised a `TypeError` since #441 replaced it with the optional `dry_mass_properties`. Internal ballistics never reads those properties, so the argument is dropped rather than replaced.

The motor is now a three-segment BATES grain, 65 mm outer diameter and 22 mm core, in a 69.85 mm casing. The old motor put a 43 mm nozzle inlet inside a 42.5 mm lined bore; the new one leaves a 65.85 mm bore around a 65 mm grain.

The prose is reworked as a tutorial rather than a how-to guide: it opens with what we are building, holds one voice across all six steps, and ends with the simulation output the reader should see. Every figure quoted comes from running the guide as written.