### PR TITLE
Convert the thrust chamber models to dataclasses

### DIFF
--- a/machwave/adapters/rocketpy/base.py
+++ b/machwave/adapters/rocketpy/base.py
@@ -74,8 +74,9 @@ class RocketPyMotorAdapter(abc.ABC, typing.Generic[R]):
 
         thrust_source = np.column_stack((time, thrust))
 
-        # 6DOF simulations need the dry mass properties
-        dry_mass_properties = thrust_chamber.require_dry_mass_properties()
+        dry_mass_properties = thrust_chamber.dry_mass_properties
+        if dry_mass_properties is None:
+            raise ValueError("RocketPy's 6DOF simulation requires dry mass properties")
 
         # Both machwave and RocketPy use nozzle exit as origin, positive toward the
         # bulkhead ("nozzle_to_combustion_chamber" orientation).

--- a/machwave/models/propellants/components.py
+++ b/machwave/models/propellants/components.py
@@ -18,7 +18,7 @@ class ComponentRole(enum.StrEnum):
     ADDITIVE = "additive"
 
 
-@dataclasses.dataclass(frozen=True, kw_only=True)
+@dataclasses.dataclass(kw_only=True)
 class PropellantComponent:
     """
     Chemical component of a propellant formulation.

--- a/machwave/models/thrust_chamber/base.py
+++ b/machwave/models/thrust_chamber/base.py
@@ -1,4 +1,5 @@
 import abc
+import dataclasses
 
 import machwave.common.mass_properties as mass_properties
 import machwave.models.thrust_chamber.combustion_chamber as combustion_chamber_models
@@ -6,113 +7,84 @@ import machwave.models.thrust_chamber.injector as injector_models
 import machwave.models.thrust_chamber.nozzle as nozzle_models
 
 
+@dataclasses.dataclass(kw_only=True)
 class ThrustChamber(abc.ABC):
-    """Thrust chamber assembly that ties nozzle, chamber, and injectors together."""
+    """
+    Base class for a thrust chamber assembly.
 
-    def __init__(
-        self,
-        nozzle: nozzle_models.Nozzle,
-        combustion_chamber: combustion_chamber_models.CombustionChamber,
-        dry_mass_properties: mass_properties.DryMassProperties | None = None,
-    ):
+    Attributes:
+        nozzle: Nozzle instance.
+        combustion_chamber: Combustion chamber instance.
+        dry_mass_properties: Mass, center of gravity, and inertia of the thrust
+            chamber. Optional, not used by the internal ballistics simulation.
+    """
+
+    nozzle: nozzle_models.Nozzle
+    combustion_chamber: combustion_chamber_models.CombustionChamber
+    dry_mass_properties: mass_properties.DryMassProperties | None = None
+
+    def __post_init__(self) -> None:
         """
-        Initialize a thrust chamber.
-
-        Args:
-            nozzle: Nozzle instance.
-            combustion_chamber: Combustion chamber instance.
-            dry_mass_properties: Dry mass properties of the assembly. Optional;
-                only consumed by the RocketPy trajectory adapter. Internal
-                ballistics simulations do not require it.
-        """
-        self.nozzle = nozzle
-        self.combustion_chamber = combustion_chamber
-        self.dry_mass_properties = dry_mass_properties
-
-        self._validate()
-
-    def _validate(self) -> None:
-        """
-        Validate that the components fit together.
+        Validate that the nozzle fits the combustion chamber.
 
         Raises:
-            ValueError: If the nozzle inlet does not fit within the combustion
-                chamber bore.
+            ValueError: If the nozzle inlet diameter is larger than the combustion
+                chamber casing inner diameter.
         """
         if self.nozzle.inlet_diameter > self.combustion_chamber.casing_inner_diameter:
             raise ValueError(
-                f"nozzle inlet_diameter ({self.nozzle.inlet_diameter}) does not fit "
+                f"Nozzle inlet diameter ({self.nozzle.inlet_diameter}) does not fit "
                 "within combustion chamber casing_inner_diameter "
                 f"({self.combustion_chamber.casing_inner_diameter})"
             )
 
-    def require_dry_mass_properties(self) -> mass_properties.DryMassProperties:
+
+@dataclasses.dataclass(kw_only=True)
+class SolidMotorThrustChamber(ThrustChamber):
+    """
+    Thrust chamber assembly specialized for solid rocket motors.
+
+    Attributes:
+        nozzle: Nozzle instance.
+        combustion_chamber: Combustion chamber instance.
+        nozzle_exit_to_grain_port_distance: Axial distance from the nozzle exit
+            plane to the grain port [m]. Shifts grain mass properties into the motor
+            frame, whose origin is the nozzle exit.
+        dry_mass_properties: Mass, center of gravity, and inertia of the thrust
+            chamber. Optional, not used by the internal ballistics simulation.
+    """
+
+    nozzle_exit_to_grain_port_distance: float
+
+    def __post_init__(self) -> None:
         """
-        Return the dry mass properties, raising if they are not defined.
+        Validate the assembly geometry.
 
         Raises:
-            ValueError: If the dry mass properties were not provided.
+            ValueError: If the nozzle inlet diameter is larger than the combustion
+                chamber casing inner diameter, or if the nozzle exit to grain port
+                distance is negative.
         """
-        if self.dry_mass_properties is None:
-            raise ValueError(
-                "Dry mass properties are not defined for this thrust chamber"
-            )
-        return self.dry_mass_properties
+        super().__post_init__()
 
-
-class SolidMotorThrustChamber(ThrustChamber):
-    """Thrust chamber assembly specialized for solid rocket motors."""
-
-    def __init__(
-        self,
-        nozzle: nozzle_models.Nozzle,
-        combustion_chamber: combustion_chamber_models.CombustionChamber,
-        nozzle_exit_to_grain_port_distance: float,
-        dry_mass_properties: mass_properties.DryMassProperties | None = None,
-    ):
-        """
-        Initialize a solid motor thrust chamber.
-
-        Args:
-            nozzle: Nozzle instance.
-            combustion_chamber: Combustion chamber instance.
-            nozzle_exit_to_grain_port_distance: Axial distance from the nozzle
-                exit plane to the grain port [m]. Shifts grain mass properties
-                into the motor frame, whose origin is the nozzle exit.
-            dry_mass_properties: Dry mass properties of the assembly. Optional;
-                only consumed by the RocketPy trajectory adapter. Internal
-                ballistics simulations do not require it.
-        """
-        super().__init__(nozzle, combustion_chamber, dry_mass_properties)
-        self.nozzle_exit_to_grain_port_distance = nozzle_exit_to_grain_port_distance
-
-        if nozzle_exit_to_grain_port_distance < 0.0:
+        if self.nozzle_exit_to_grain_port_distance < 0.0:
             raise ValueError(
                 "nozzle_exit_to_grain_port_distance must be non-negative, got "
-                f"{nozzle_exit_to_grain_port_distance}"
+                f"{self.nozzle_exit_to_grain_port_distance}"
             )
 
 
+@dataclasses.dataclass(kw_only=True)
 class BiliquidEngineThrustChamber(ThrustChamber):
-    """Thrust chamber assembly specialized for biliquid rocket engines."""
+    """
+    Thrust chamber assembly specialized for biliquid rocket engines.
 
-    def __init__(
-        self,
-        nozzle: nozzle_models.Nozzle,
-        injector: injector_models.BipropellantInjector,
-        combustion_chamber: combustion_chamber_models.CombustionChamber,
-        dry_mass_properties: mass_properties.DryMassProperties | None = None,
-    ):
-        """
-        Initialize a biliquid engine thrust chamber.
+    Attributes:
+        nozzle: Nozzle instance.
+        injector: Bipropellant injector instance.
+        combustion_chamber: Combustion chamber instance.
+        dry_mass_properties: Mass, center of gravity, and inertia of the thrust
+            chamber. Optional, not used by the internal ballistics simulation.
+    """
 
-        Args:
-            nozzle: Nozzle instance.
-            injector: Bipropellant injector instance.
-            combustion_chamber: Combustion chamber instance.
-            dry_mass_properties: Dry mass properties of the assembly. Optional;
-                only consumed by the RocketPy trajectory adapter. Internal
-                ballistics simulations do not require it.
-        """
-        super().__init__(nozzle, combustion_chamber, dry_mass_properties)
-        self.injector = injector
+    injector: injector_models.BipropellantInjector

--- a/machwave/models/thrust_chamber/combustion_chamber.py
+++ b/machwave/models/thrust_chamber/combustion_chamber.py
@@ -1,35 +1,26 @@
+import dataclasses
+
 import numpy as np
 
 
+@dataclasses.dataclass(kw_only=True)
 class CombustionChamber:
-    """Geometry model of a cylindrical combustion-chamber."""
+    """
+    Represents a cylindrical combustion chamber.
 
-    def __init__(
-        self,
-        casing_inner_diameter: float,
-        casing_outer_diameter: float,
-        internal_length: float,
-        thermal_liner_thickness: float = 0.0,
-    ) -> None:
-        """
-        Create a new CombustionChamber instance.
+    Attributes:
+        casing_inner_diameter: Internal diameter [m].
+        casing_outer_diameter: Outer diameter [m].
+        internal_length: Distance from combustion chamber inlet to nozzle inlet [m].
+        thermal_liner_thickness: Thermal liner thickness [m]. Defaults to 0.0.
+    """
 
-        Args:
-            casing_inner_diameter: Internal diameter [m].
-            casing_outer_diameter: Outer diameter [m].
-            internal_length: Distance from combustion chamber inlet to
-                nozzle inlet [m].
-            thermal_liner_thickness: Thermal liner thickness [m].
-                Defaults to 0.0.
-        """
-        self.casing_inner_diameter = casing_inner_diameter
-        self.casing_outer_diameter = casing_outer_diameter
-        self.internal_length = internal_length
-        self.thermal_liner_thickness = thermal_liner_thickness
+    casing_inner_diameter: float
+    casing_outer_diameter: float
+    internal_length: float
+    thermal_liner_thickness: float = 0.0
 
-        self._validate()
-
-    def _validate(self) -> None:
+    def __post_init__(self) -> None:
         """
         Validate the combustion chamber geometry.
 

--- a/machwave/models/thrust_chamber/nozzle.py
+++ b/machwave/models/thrust_chamber/nozzle.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 import numpy as np
 
 import machwave.core.geometric as geometric
@@ -5,43 +7,31 @@ import machwave.core.geometric as geometric
 DEFAULT_SEPARATION_PRESSURE_RATIO = 0.4  # typically between 0.3 and 0.4
 
 
+@dataclasses.dataclass(kw_only=True)
 class Nozzle:
-    """Converging-diverging nozzle geometry."""
+    """
+    Converging-diverging nozzle geometry.
 
-    def __init__(
-        self,
-        inlet_diameter: float,
-        throat_diameter: float,
-        divergent_angle: float,
-        convergent_angle: float,
-        expansion_ratio: float,
-        discharge_coefficient: float = 1.0,
-        separation_pressure_ratio: float = DEFAULT_SEPARATION_PRESSURE_RATIO,
-    ) -> None:
-        """
-        Initialize a nozzle.
+    Attributes:
+        inlet_diameter: Inlet diameter [m].
+        throat_diameter: Throat diameter [m].
+        divergent_angle: Divergent half-angle [deg].
+        convergent_angle: Convergent half-angle [deg].
+        expansion_ratio: Area ratio of exit to throat.
+        discharge_coefficient: Throat discharge coefficient.
+        separation_pressure_ratio: Pressure ratio at which the overexpanded flow
+            separates from the nozzle wall (Summerfield criterion).
+    """
 
-        Args:
-            inlet_diameter: Inlet diameter [m].
-            throat_diameter: Throat diameter [m].
-            divergent_angle: Divergent half-angle [deg].
-            convergent_angle: Convergent half-angle [deg].
-            expansion_ratio: Area ratio of exit to throat.
-            discharge_coefficient: Throat discharge coefficient.
-            separation_pressure_ratio: Pressure ratio at which the overexpanded flow
-                separates from the nozzle wall (Summerfield criterion).
-        """
-        self.inlet_diameter = inlet_diameter
-        self.throat_diameter = throat_diameter
-        self.divergent_angle = divergent_angle
-        self.convergent_angle = convergent_angle
-        self.expansion_ratio = expansion_ratio
-        self.discharge_coefficient = discharge_coefficient
-        self.separation_pressure_ratio = separation_pressure_ratio
+    inlet_diameter: float
+    throat_diameter: float
+    divergent_angle: float
+    convergent_angle: float
+    expansion_ratio: float
+    discharge_coefficient: float = 1.0
+    separation_pressure_ratio: float = DEFAULT_SEPARATION_PRESSURE_RATIO
 
-        self._validate()
-
-    def _validate(self) -> None:
+    def __post_init__(self) -> None:
         """
         Validate the nozzle geometry.
 

--- a/tests/test_adapters/test_rocketpy_solid_motor.py
+++ b/tests/test_adapters/test_rocketpy_solid_motor.py
@@ -89,7 +89,7 @@ def test_missing_dry_mass_properties_raises_value_error() -> None:
     motor = SolidMotorFactory.build(thrust_chamber=thrust_chamber)
     adapter = _build_adapter_without_init(motor)
 
-    with pytest.raises(ValueError, match="Dry mass properties are not defined"):
+    with pytest.raises(ValueError, match="requires dry mass properties"):
         adapter._get_rocketpy_attributes()
 
 

--- a/tests/test_models/test_propulsion/test_thrust_chamber.py
+++ b/tests/test_models/test_propulsion/test_thrust_chamber.py
@@ -42,11 +42,6 @@ class TestThrustChamberValidation:
         thrust_chamber = SolidMotorThrustChamberFactory.build(dry_mass_properties=None)
         assert thrust_chamber.dry_mass_properties is None
 
-    def test_require_dry_mass_properties_raises_when_absent(self):
-        thrust_chamber = SolidMotorThrustChamberFactory.build(dry_mass_properties=None)
-        with pytest.raises(ValueError, match="Dry mass properties are not defined"):
-            thrust_chamber.require_dry_mass_properties()
-
 
 class TestDryMassProperties:
     @pytest.mark.parametrize("dry_mass", [0.0, -1.0])


### PR DESCRIPTION
Closes #488.

`Nozzle`, `CombustionChamber` and the three `ThrustChamber` classes are now dataclasses. Their `__init__` did nothing but assign attributes and call `_validate`, which `__post_init__` covers, so the parameter documentation moved from `Args` to `Attributes` and the models lost 49 lines.

They are `kw_only` because `SolidMotorThrustChamber` adds a required field on top of the base class default, which is otherwise a dataclass inheritance error. Every construction site already passed keywords, so no call site changed.

### Mutability

The models stay mutable. The Monte Carlo engine randomizes attributes in place while walking the object graph, so freezing them raises `FrozenInstanceError` as soon as a `MonteCarloParameter` lands on a nozzle or chamber dimension. `PropellantComponent` is unfrozen for the same reason, since its density is a plausible target.

Computed values keep `frozen=True`: `ThermochemicalProperties`, `TankFluidState`, `NozzleLossEvaluationResult`, the feed system component specifications, and `InhibitedSurfaces`.

### Dry mass properties

`ThrustChamber.require_dry_mass_properties` is gone. Its only caller was the RocketPy adapter, so the model carried a precondition that belonged downstream. The adapter now reads the optional field and raises on its own behalf, naming what actually needs it. The docstrings no longer describe the field by which consumer reads it.

### Verification

1132 tests pass, `make check` is clean, and `mkdocs build --strict` renders each class with a full `Attributes` table including inherited fields.