### PR TITLE
Carry the engine state, results and plots per propellant line

### DIFF
--- a/examples/1kn_biliquid_engine.py
+++ b/examples/1kn_biliquid_engine.py
@@ -108,12 +108,10 @@ def main():
     internal_ballistics_plots.thrust_pressure_plot(
         result.time, result.thrust, result.chamber_pressure
     ).show()
-    internal_ballistics_plots.plot_bipropellant_tank_profiles(
+    internal_ballistics_plots.plot_tank_profiles(
         result.time,
-        result.oxidizer_tank_pressure,
-        result.fuel_tank_pressure,
-        result.oxidizer_mass,
-        result.fuel_mass,
+        result.tank_pressure_per_line,
+        result.fluid_mass_per_line,
     ).show()
 
 

--- a/machwave/services/plots/internal_ballistics.py
+++ b/machwave/services/plots/internal_ballistics.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+
 import numpy as np
 import plotly.graph_objects as go
 import plotly.subplots
@@ -84,25 +86,21 @@ def mass_flux_plot(time: np.ndarray, mass_flux: np.ndarray) -> go.Figure:
     return figure
 
 
-def plot_bipropellant_tank_profiles(
+def plot_tank_profiles(
     time: np.ndarray,
-    oxidizer_tank_pressure: np.ndarray,
-    fuel_tank_pressure: np.ndarray,
-    oxidizer_tank_mass: np.ndarray,
-    fuel_tank_mass: np.ndarray,
+    tank_pressure_per_line: Mapping[str, np.ndarray],
+    fluid_mass_per_line: Mapping[str, np.ndarray],
 ) -> go.Figure:
     """
     Generate an interactive two-panel chart of tank pressures and masses.
 
-    Left subplot: oxidizer and fuel tank pressures [MPa] versus time. Right
-    subplot: oxidizer and fuel tank masses [kg] versus time.
+    Left subplot: tank pressure of every propellant line [MPa] versus time.
+    Right subplot: fluid mass of every propellant line [kg] versus time.
 
     Args:
         time: Time array [s].
-        oxidizer_tank_pressure: Oxidizer tank pressure array [Pa].
-        fuel_tank_pressure: Fuel tank pressure array [Pa].
-        oxidizer_tank_mass: Oxidizer tank mass array [kg].
-        fuel_tank_mass: Fuel tank mass array [kg].
+        tank_pressure_per_line: Tank pressure array [Pa], keyed by line name.
+        fluid_mass_per_line: Fluid mass array [kg], keyed by line name.
     """
     fig = plotly.subplots.make_subplots(
         rows=1,
@@ -111,34 +109,29 @@ def plot_bipropellant_tank_profiles(
         horizontal_spacing=0.1,
     )
 
-    fig.add_trace(
-        go.Scatter(
-            x=time,
-            y=oxidizer_tank_pressure * 1e-6,
-            mode="lines",
-            name="Oxidizer Pressure",
-        ),
-        row=1,
-        col=1,
-    )
-    fig.add_trace(
-        go.Scatter(
-            x=time, y=fuel_tank_pressure * 1e-6, mode="lines", name="Fuel Pressure"
-        ),
-        row=1,
-        col=1,
-    )
+    for name, tank_pressure in tank_pressure_per_line.items():
+        fig.add_trace(
+            go.Scatter(
+                x=time,
+                y=tank_pressure * 1e-6,
+                mode="lines",
+                name=f"{name.capitalize()} Pressure",
+            ),
+            row=1,
+            col=1,
+        )
 
-    fig.add_trace(
-        go.Scatter(x=time, y=oxidizer_tank_mass, mode="lines", name="Oxidizer Mass"),
-        row=1,
-        col=2,
-    )
-    fig.add_trace(
-        go.Scatter(x=time, y=fuel_tank_mass, mode="lines", name="Fuel Mass"),
-        row=1,
-        col=2,
-    )
+    for name, fluid_mass in fluid_mass_per_line.items():
+        fig.add_trace(
+            go.Scatter(
+                x=time,
+                y=fluid_mass,
+                mode="lines",
+                name=f"{name.capitalize()} Mass",
+            ),
+            row=1,
+            col=2,
+        )
 
     fig.update_xaxes(title_text="Time (s)", row=1, col=1)
     fig.update_yaxes(title_text="Pressure (MPa)", row=1, col=1)
@@ -146,7 +139,7 @@ def plot_bipropellant_tank_profiles(
     fig.update_yaxes(title_text="Mass (kg)", row=1, col=2)
 
     fig.update_layout(
-        title_text="<b>Bipropellant Tank Profiles</b>",
+        title_text="<b>Propellant Tank Profiles</b>",
         legend=dict(orientation="h", yanchor="bottom", y=-0.2, xanchor="center", x=0.5),
         margin=dict(l=50, r=50, t=80, b=50),
     )

--- a/machwave/simulation/biliquid/results.py
+++ b/machwave/simulation/biliquid/results.py
@@ -17,37 +17,39 @@ class BiliquidSimulationResult(
 ):
     """Simulation result for a biliquid engine run."""
 
-    oxidizer_mass: simulation_results.SimulationResultArray
-    fuel_mass: simulation_results.SimulationResultArray
-    fuel_tank_pressure: simulation_results.SimulationResultArray
-    oxidizer_tank_pressure: simulation_results.SimulationResultArray
+    fluid_mass_per_line: dict[str, simulation_results.SimulationResultArray]
+    tank_pressure_per_line: dict[str, simulation_results.SimulationResultArray]
     # Flat for an isothermal tank, decaying for one running an energy balance.
-    fuel_tank_temperature: simulation_results.SimulationResultArray
-    oxidizer_tank_temperature: simulation_results.SimulationResultArray
-    final_oxidizer_mass: float
-    final_fuel_mass: float
+    tank_temperature_per_line: dict[str, simulation_results.SimulationResultArray]
+    final_fluid_mass_per_line: dict[str, float]
 
     @classmethod
     def _collect_extra_fields(
         cls, state: "biliquid_states.BiliquidEngineState"
     ) -> dict[str, Any]:
-        oxidizer_mass = np.asarray(state.oxidizer_mass)
-        fuel_mass = np.asarray(state.fuel_mass)
+        fluid_mass_per_line = {
+            name: np.asarray(series)
+            for name, series in state.fluid_mass_per_line.items()
+        }
         return {
-            "oxidizer_mass": oxidizer_mass,
-            "fuel_mass": fuel_mass,
-            "fuel_tank_pressure": np.asarray(state.fuel_tank_pressure),
-            "oxidizer_tank_pressure": np.asarray(state.oxidizer_tank_pressure),
-            "fuel_tank_temperature": np.asarray(state.fuel_tank_temperature),
-            "oxidizer_tank_temperature": np.asarray(state.oxidizer_tank_temperature),
-            "final_oxidizer_mass": float(oxidizer_mass[-1]),
-            "final_fuel_mass": float(fuel_mass[-1]),
+            "fluid_mass_per_line": fluid_mass_per_line,
+            "tank_pressure_per_line": {
+                name: np.asarray(series)
+                for name, series in state.tank_pressure_per_line.items()
+            },
+            "tank_temperature_per_line": {
+                name: np.asarray(series)
+                for name, series in state.tank_temperature_per_line.items()
+            },
+            "final_fluid_mass_per_line": {
+                name: float(series[-1]) for name, series in fluid_mass_per_line.items()
+            },
         }
 
     def _extra_summary(self) -> dict[str, float]:
         return {
-            "final_oxidizer_mass": self.final_oxidizer_mass,
-            "final_fuel_mass": self.final_fuel_mass,
+            f"final_{name}_mass": mass
+            for name, mass in self.final_fluid_mass_per_line.items()
         }
 
     def _report_body(self, file: IO) -> None:
@@ -72,5 +74,8 @@ class BiliquidSimulationResult(
         self._report_nozzle_losses(file)
 
         print("\nPROPELLANT REMAINING (kg)", file=file)
-        print(f"  Oxidizer: {self.final_oxidizer_mass:.4f}", file=file)
-        print(f"  Fuel:     {self.final_fuel_mass:.4f}", file=file)
+        label_width = max(len(name) for name in self.final_fluid_mass_per_line)
+        for name, mass in self.final_fluid_mass_per_line.items():
+            print(
+                f"  {name.capitalize() + ':':<{label_width + 1}} {mass:.4f}", file=file
+            )

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -10,7 +10,6 @@ import machwave.common.fluid_state as fluid_state_models
 import machwave.core.mass_balance as mass_balance
 import machwave.core.performance as performance
 import machwave.core.solvers.rk4 as rk4
-import machwave.models.feed_systems.base as feed_system_base
 import machwave.models.feed_systems.lines as line_models
 import machwave.models.feed_systems.tank as tank_models
 import machwave.models.motors as motors
@@ -44,25 +43,6 @@ def get_injector_mass_flows(
     return {name: min(flow, line_masses[name] / d_t) for name, flow in flows.items()}
 
 
-def get_line_with_role(
-    feed_system: feed_system_base.FeedSystem,
-    role: propellant_components.ComponentRole,
-) -> line_models.PropellantLine:
-    """
-    The one line of the feed system carrying the given role.
-
-    Raises:
-        ValueError: If the feed system does not feed exactly one such line.
-    """
-    lines = feed_system.get_lines_with_role(role)
-    if len(lines) != 1:
-        raise ValueError(
-            f"a biliquid engine feeds exactly one {role} line, got "
-            f"{[line.name for line in lines]}"
-        )
-    return lines[0]
-
-
 def get_total_injector_mass_flow(
     chamber_pressure: float,
     *,
@@ -76,15 +56,11 @@ def get_total_injector_mass_flow(
 class BiliquidTimestepConditions(simulation_states.TimestepConditions):
     """Timestep conditions for a biliquid engine."""
 
-    fuel_mass: float
-    oxidizer_mass: float
-    fuel_mass_flow_rate: float
-    oxidizer_mass_flow_rate: float
+    fluid_mass_per_line: dict[str, float]
+    mass_flow_rate_per_line: dict[str, float]
     oxidizer_to_fuel_ratio: float
-    fuel_tank_pressure: float
-    oxidizer_tank_pressure: float
-    fuel_tank_temperature: float
-    oxidizer_tank_temperature: float
+    tank_pressure_per_line: dict[str, float]
+    tank_temperature_per_line: dict[str, float]
 
 
 class BiliquidEngineState(simulation_states.MotorState):
@@ -113,38 +89,42 @@ class BiliquidEngineState(simulation_states.MotorState):
             external_pressure=external_pressure,
         )
 
-        self.oxidizer_line = get_line_with_role(
-            motor.feed_system, propellant_components.ComponentRole.OXIDIZER
+        feed_system = motor.feed_system
+        self.lines: dict[str, line_models.PropellantLine] = feed_system.lines
+        self.oxidizer_line_names = tuple(
+            line.name
+            for line in feed_system.get_lines_with_role(
+                propellant_components.ComponentRole.OXIDIZER
+            )
         )
-        self.fuel_line = get_line_with_role(
-            motor.feed_system, propellant_components.ComponentRole.FUEL
+        self.fuel_line_names = tuple(
+            line.name
+            for line in feed_system.get_lines_with_role(
+                propellant_components.ComponentRole.FUEL
+            )
         )
-        oxidizer_tank = self.oxidizer_line.tank
-        fuel_tank = self.fuel_line.tank
 
-        self.oxidizer_mass: simulation_states.SimulationStateArray = [
-            oxidizer_tank.initial_fluid_mass
-        ]
-        self.fuel_mass: simulation_states.SimulationStateArray = [
-            fuel_tank.initial_fluid_mass
-        ]
+        initial_states = {name: line.initial_state for name, line in self.lines.items()}
+        self.fluid_mass_per_line: dict[str, simulation_states.SimulationStateArray] = {
+            name: [state.fluid_mass] for name, state in initial_states.items()
+        }
 
         # Second state variable of a tank running an energy balance, which the
         # integrator carries beside the mass. An isothermal tank has none.
-        self.oxidizer_internal_energy: float | None = (
-            None if oxidizer_tank.isothermal else oxidizer_tank.initial_internal_energy
-        )
-        self.fuel_internal_energy: float | None = (
-            None if fuel_tank.isothermal else fuel_tank.initial_internal_energy
-        )
+        self.internal_energy_per_line: dict[str, float | None] = {
+            name: state.internal_energy for name, state in initial_states.items()
+        }
 
-        self.fuel_mass_flow_rate: simulation_states.SimulationStateArray = []
-        self.oxidizer_mass_flow_rate: simulation_states.SimulationStateArray = []
+        self.mass_flow_rate_per_line: dict[
+            str, simulation_states.SimulationStateArray
+        ] = {name: [] for name in self.lines}
+        self.tank_pressure_per_line: dict[
+            str, simulation_states.SimulationStateArray
+        ] = {name: [] for name in self.lines}
+        self.tank_temperature_per_line: dict[
+            str, simulation_states.SimulationStateArray
+        ] = {name: [] for name in self.lines}
         self.oxidizer_to_fuel_ratio: simulation_states.SimulationStateArray = []
-        self.fuel_tank_pressure: simulation_states.SimulationStateArray = []
-        self.oxidizer_tank_pressure: simulation_states.SimulationStateArray = []
-        self.fuel_tank_temperature: simulation_states.SimulationStateArray = []
-        self.oxidizer_tank_temperature: simulation_states.SimulationStateArray = []
 
     def _evaluate_propellant_properties(
         self,
@@ -157,6 +137,21 @@ class BiliquidEngineState(simulation_states.MotorState):
             expansion_ratio=self.motor.thrust_chamber.nozzle.expansion_ratio,
             mixture_ratio=mixture_ratio,
         )
+
+    def _get_mixture_ratio(self, mass_flows: Mapping[str, float]) -> float | None:
+        """
+        Total oxidizer flow over total fuel flow.
+
+        None where the ratio has no meaning: a monoliquid, or an engine whose
+        lines have stopped flowing.
+        """
+        oxidizer_flow = sum(mass_flows[name] for name in self.oxidizer_line_names)
+        fuel_flow = sum(mass_flows[name] for name in self.fuel_line_names)
+
+        if oxidizer_flow <= 0.0 or fuel_flow <= 0.0:
+            return None
+
+        return oxidizer_flow / fuel_flow
 
     def run_timestep(
         self,
@@ -175,67 +170,50 @@ class BiliquidEngineState(simulation_states.MotorState):
 
         time = self.time[-1]
         chamber_pressure = self.chamber_pressure[-1]
-        fuel_mass = self.fuel_mass[-1]
-        oxidizer_mass = self.oxidizer_mass[-1]
-        fuel_internal_energy = self.fuel_internal_energy
-        oxidizer_internal_energy = self.oxidizer_internal_energy
+        fluid_masses = {
+            name: series[-1] for name, series in self.fluid_mass_per_line.items()
+        }
 
-        propellant_mass = fuel_mass + oxidizer_mass
+        propellant_mass = sum(fluid_masses.values())
         self.propellant_mass.append(propellant_mass)
 
         inlet_states = feed_system.get_inlet_states(
             {
-                self.fuel_line.name: line_models.LineState(
-                    fluid_mass=fuel_mass, internal_energy=fuel_internal_energy
-                ),
-                self.oxidizer_line.name: line_models.LineState(
-                    fluid_mass=oxidizer_mass, internal_energy=oxidizer_internal_energy
-                ),
+                name: line_models.LineState(
+                    fluid_mass=fluid_masses[name],
+                    internal_energy=self.internal_energy_per_line[name],
+                )
+                for name in self.lines
             }
         )
-        fuel_inlet = inlet_states[self.fuel_line.name]
-        oxidizer_inlet = inlet_states[self.oxidizer_line.name]
 
-        fuel_tank_pressure = fuel_inlet.pressure
-        self.fuel_tank_pressure.append(fuel_tank_pressure)
-        oxidizer_tank_pressure = oxidizer_inlet.pressure
-        self.oxidizer_tank_pressure.append(oxidizer_tank_pressure)
-
-        fuel_tank_temperature = fuel_inlet.temperature
-        self.fuel_tank_temperature.append(fuel_tank_temperature)
-        oxidizer_tank_temperature = oxidizer_inlet.temperature
-        self.oxidizer_tank_temperature.append(oxidizer_tank_temperature)
+        tank_pressures = {name: inlet.pressure for name, inlet in inlet_states.items()}
+        tank_temperatures = {
+            name: inlet.temperature for name, inlet in inlet_states.items()
+        }
+        for name in self.lines:
+            self.tank_pressure_per_line[name].append(tank_pressures[name])
+            self.tank_temperature_per_line[name].append(tank_temperatures[name])
 
         is_feeding = (
             not self.end_burn
-            and fuel_mass > 0
-            and oxidizer_mass > 0
-            and fuel_tank_pressure > chamber_pressure
-            and oxidizer_tank_pressure > chamber_pressure
+            and all(fluid_mass > 0 for fluid_mass in fluid_masses.values())
+            and all(pressure > chamber_pressure for pressure in tank_pressures.values())
         )
         injector_flows = functools.partial(
             get_injector_mass_flows,
             injector=self.motor.thrust_chamber.injector,
             inlet_states=inlet_states,
-            line_masses={
-                self.fuel_line.name: fuel_mass,
-                self.oxidizer_line.name: oxidizer_mass,
-            },
+            line_masses=fluid_masses,
             is_feeding=is_feeding,
             d_t=d_t,
         )
         mass_flows = injector_flows(chamber_pressure)
-        m_dot_fuel = mass_flows[self.fuel_line.name]
-        m_dot_ox = mass_flows[self.oxidizer_line.name]
-        self.fuel_mass_flow_rate.append(m_dot_fuel)
-        self.oxidizer_mass_flow_rate.append(m_dot_ox)
-        fuel_consumed = m_dot_fuel * d_t
-        oxidizer_consumed = m_dot_ox * d_t
+        for name, mass_flow in mass_flows.items():
+            self.mass_flow_rate_per_line[name].append(mass_flow)
+        mass_consumed = {name: flow * d_t for name, flow in mass_flows.items()}
 
-        # Without both flows strictly positive, the OF ratio is NaN
-        mixture_ratio = (
-            m_dot_ox / m_dot_fuel if m_dot_fuel > 0.0 and m_dot_ox > 0.0 else None
-        )
+        mixture_ratio = self._get_mixture_ratio(mass_flows)
         oxidizer_to_fuel_ratio = math.nan if mixture_ratio is None else mixture_ratio
         self.oxidizer_to_fuel_ratio.append(oxidizer_to_fuel_ratio)
 
@@ -263,18 +241,14 @@ class BiliquidEngineState(simulation_states.MotorState):
                 self.motor.thrust_chamber.combustion_chamber.internal_volume
             ),
             propellant_mass=propellant_mass,
-            propellant_mass_flow_rate=m_dot_fuel + m_dot_ox,
+            propellant_mass_flow_rate=sum(mass_flows.values()),
             nozzle=nozzle,
             propellant_properties=propellant_properties,
-            fuel_mass=fuel_mass,
-            oxidizer_mass=oxidizer_mass,
-            fuel_mass_flow_rate=m_dot_fuel,
-            oxidizer_mass_flow_rate=m_dot_ox,
+            fluid_mass_per_line=fluid_masses,
+            mass_flow_rate_per_line=mass_flows,
             oxidizer_to_fuel_ratio=oxidizer_to_fuel_ratio,
-            fuel_tank_pressure=fuel_tank_pressure,
-            oxidizer_tank_pressure=oxidizer_tank_pressure,
-            fuel_tank_temperature=fuel_tank_temperature,
-            oxidizer_tank_temperature=oxidizer_tank_temperature,
+            tank_pressure_per_line=tank_pressures,
+            tank_temperature_per_line=tank_temperatures,
         )
         self._apply_nozzle_losses(
             ideal_momentum_term,
@@ -285,8 +259,7 @@ class BiliquidEngineState(simulation_states.MotorState):
 
         if (
             not is_feeding
-            or fuel_consumed >= fuel_mass
-            or oxidizer_consumed >= oxidizer_mass
+            or any(mass_consumed[name] >= fluid_masses[name] for name in self.lines)
         ) and not self.end_burn:
             self.end_burn = True
             self._burn_time = time + d_t
@@ -321,21 +294,17 @@ class BiliquidEngineState(simulation_states.MotorState):
             nozzle_discharge_coefficient=nozzle.discharge_coefficient,
         )[0]
         self.chamber_pressure.append(new_chamber_pressure)
-        self.fuel_mass.append(fuel_mass - fuel_consumed)
-        self.oxidizer_mass.append(oxidizer_mass - oxidizer_consumed)
 
-        self.fuel_internal_energy = self._drain_internal_energy(
-            tank=self.fuel_line.tank,
-            internal_energy=fuel_internal_energy,
-            fluid_mass=fuel_mass,
-            mass_drained=fuel_consumed,
-        )
-        self.oxidizer_internal_energy = self._drain_internal_energy(
-            tank=self.oxidizer_line.tank,
-            internal_energy=oxidizer_internal_energy,
-            fluid_mass=oxidizer_mass,
-            mass_drained=oxidizer_consumed,
-        )
+        for name, line in self.lines.items():
+            self.fluid_mass_per_line[name].append(
+                fluid_masses[name] - mass_consumed[name]
+            )
+            self.internal_energy_per_line[name] = self._drain_internal_energy(
+                tank=line.tank,
+                internal_energy=self.internal_energy_per_line[name],
+                fluid_mass=fluid_masses[name],
+                mass_drained=mass_consumed[name],
+            )
 
     @staticmethod
     def _drain_internal_energy(

--- a/tests/test_simulations/test_biliquid_engine_simulation.py
+++ b/tests/test_simulations/test_biliquid_engine_simulation.py
@@ -69,16 +69,26 @@ def test_motor_is_re_runnable() -> None:
     second = run_simulation(motor, params)
 
     assert first.time.size == second.time.size
-    np.testing.assert_array_equal(first.oxidizer_mass, second.oxidizer_mass)
-    np.testing.assert_array_equal(first.fuel_mass, second.fuel_mass)
+    np.testing.assert_array_equal(
+        first.fluid_mass_per_line["oxidizer"], second.fluid_mass_per_line["oxidizer"]
+    )
+    np.testing.assert_array_equal(
+        first.fluid_mass_per_line["fuel"], second.fluid_mass_per_line["fuel"]
+    )
     np.testing.assert_array_equal(first.thrust, second.thrust)
 
 
 def test_propellant_masses_are_monotone_non_increasing(
     simulation_result: biliquid_simulation.BiliquidSimulationResult,
 ) -> None:
-    for series_name in ("fuel_mass", "oxidizer_mass", "propellant_mass"):
-        series = getattr(simulation_result, series_name)
+    series_by_name = {
+        **{
+            f"{name} mass": series
+            for name, series in simulation_result.fluid_mass_per_line.items()
+        },
+        "propellant_mass": simulation_result.propellant_mass,
+    }
+    for series_name, series in series_by_name.items():
         diffs = np.diff(series)
         assert (diffs <= 1e-9).all(), (
             f"{series_name} increased between steps; max delta={diffs.max():.3e}"
@@ -190,7 +200,7 @@ def _build_state_for_burnout_test() -> biliquid_simulation.BiliquidEngineState:
 
 def test_run_timestep_sets_end_burn_when_fuel_exhausts() -> None:
     state = _build_state_for_burnout_test()
-    state.fuel_mass[-1] = 1e-9
+    state.fluid_mass_per_line["fuel"][-1] = 1e-9
 
     state.run_timestep(d_t=1e-4, external_pressure=1e5)
 
@@ -200,7 +210,7 @@ def test_run_timestep_sets_end_burn_when_fuel_exhausts() -> None:
 
 def test_run_timestep_sets_end_burn_when_oxidizer_exhausts() -> None:
     state = _build_state_for_burnout_test()
-    state.oxidizer_mass[-1] = 1e-9
+    state.fluid_mass_per_line["oxidizer"][-1] = 1e-9
 
     state.run_timestep(d_t=1e-4, external_pressure=1e5)
 
@@ -211,37 +221,37 @@ def test_run_timestep_sets_end_burn_when_oxidizer_exhausts() -> None:
 def test_flows_stop_after_fuel_exhausts() -> None:
     """The oxidizer is not burned on its own once the fuel is gone."""
     state = _build_state_for_burnout_test()
-    state.fuel_mass[-1] = 1e-9
+    state.fluid_mass_per_line["fuel"][-1] = 1e-9
 
     state.run_timestep(d_t=1e-4, external_pressure=1e5)
     assert state.end_burn is True
-    oxidizer_mass_at_burnout = state.oxidizer_mass[-1]
+    oxidizer_mass_at_burnout = state.fluid_mass_per_line["oxidizer"][-1]
     assert oxidizer_mass_at_burnout > 0.0
 
     state.run_timestep(d_t=1e-4, external_pressure=1e5)
 
-    assert state.fuel_mass_flow_rate[-1] == 0.0
-    assert state.oxidizer_mass_flow_rate[-1] == 0.0
+    assert state.mass_flow_rate_per_line["fuel"][-1] == 0.0
+    assert state.mass_flow_rate_per_line["oxidizer"][-1] == 0.0
     assert np.isnan(state.oxidizer_to_fuel_ratio[-1])
-    assert state.oxidizer_mass[-1] == oxidizer_mass_at_burnout
+    assert state.fluid_mass_per_line["oxidizer"][-1] == oxidizer_mass_at_burnout
 
 
 def test_flows_stop_after_oxidizer_exhausts() -> None:
     """The fuel is not burned on its own once the oxidizer is gone."""
     state = _build_state_for_burnout_test()
-    state.oxidizer_mass[-1] = 1e-9
+    state.fluid_mass_per_line["oxidizer"][-1] = 1e-9
 
     state.run_timestep(d_t=1e-4, external_pressure=1e5)
     assert state.end_burn is True
-    fuel_mass_at_burnout = state.fuel_mass[-1]
+    fuel_mass_at_burnout = state.fluid_mass_per_line["fuel"][-1]
     assert fuel_mass_at_burnout > 0.0
 
     state.run_timestep(d_t=1e-4, external_pressure=1e5)
 
-    assert state.fuel_mass_flow_rate[-1] == 0.0
-    assert state.oxidizer_mass_flow_rate[-1] == 0.0
+    assert state.mass_flow_rate_per_line["fuel"][-1] == 0.0
+    assert state.mass_flow_rate_per_line["oxidizer"][-1] == 0.0
     assert np.isnan(state.oxidizer_to_fuel_ratio[-1])
-    assert state.fuel_mass[-1] == fuel_mass_at_burnout
+    assert state.fluid_mass_per_line["fuel"][-1] == fuel_mass_at_burnout
 
 
 def test_surviving_propellant_stops_draining_after_burnout(
@@ -252,15 +262,15 @@ def test_surviving_propellant_stops_draining_after_burnout(
     after_burnout = simulation_result.time >= simulation_result.burn_time
     assert after_burnout.sum() > 1, "run ended at burnout, tail-off not exercised"
 
-    for series_name in ("fuel_mass", "oxidizer_mass"):
-        series = getattr(simulation_result, series_name)[after_burnout]
+    for series_name, full_series in simulation_result.fluid_mass_per_line.items():
+        series = full_series[after_burnout]
         assert (series == series[0]).all(), f"{series_name} kept draining after burnout"
 
 
 def test_tail_off_terminates_thrust_against_zero_ambient_pressure() -> None:
     """Against zero ambient pressure the nozzle stays choked, so tail-off ends it."""
     state = _build_state_for_burnout_test()
-    state.fuel_mass[-1] = 1e-9
+    state.fluid_mass_per_line["fuel"][-1] = 1e-9
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
@@ -312,7 +322,7 @@ def test_live_mixture_ratio_drives_cea() -> None:
         warnings.simplefilter("ignore", UserWarning)
         while not state.end_thrust:
             state.run_timestep(params.d_t, params.external_pressure)
-            if state.fuel_mass_flow_rate[-1] <= 0.0:
+            if state.mass_flow_rate_per_line["fuel"][-1] <= 0.0:
                 continue
             live_ratio = state.oxidizer_to_fuel_ratio[-1]
             if abs(live_ratio - design_ratio) > 1e-6:

--- a/tests/test_simulations/test_biliquid_line_bookkeeping.py
+++ b/tests/test_simulations/test_biliquid_line_bookkeeping.py
@@ -1,0 +1,177 @@
+"""The engine state, results and report carry one series per propellant line.
+
+The third line here drains and is accounted for like any other, but nothing
+evaluates the mixture it makes: blending a third propellant through the
+thermochemical service is separate work. These cover the bookkeeping.
+"""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pytest
+
+import machwave.models.feed_systems as feed_systems_models
+import machwave.models.feed_systems.tank as tank_models
+import machwave.models.propellants as propellants_models
+import machwave.models.thrust_chamber as thrust_chamber_models
+import machwave.simulation.biliquid as biliquid_simulation
+from tests.test_simulations import motor_builders
+from tests.test_simulations.conftest import (
+    assert_recorded_arrays_aligned,
+    run_simulation,
+)
+
+DILUENT_LINE_NAME = "diluent"
+
+
+def build_engine_with_a_diluent_line():
+    """The 1 kN engine with a third line stacked below the piston."""
+    motor, params = motor_builders.build_1kn_biliquid_engine()
+    feed_system = motor.feed_system
+
+    diluent_line = feed_systems_models.PropellantLine(
+        name=DILUENT_LINE_NAME,
+        role=propellants_models.ComponentRole.ADDITIVE,
+        tank=tank_models.Tank(
+            fluid_name="Water",
+            volume=1.0e-3,
+            temperature=300.0,
+            initial_fluid_mass=0.5,
+        ),
+    )
+    motor.feed_system = feed_systems_models.StackedTankPressureFedFeedSystem(
+        lines=[*feed_system.lines.values(), diluent_line],
+        pressurizing_line="oxidizer",
+        piston_loss=feed_system.piston_loss,
+        line_losses={**feed_system.line_losses, DILUENT_LINE_NAME: 2e5},
+    )
+    motor.thrust_chamber.injector = thrust_chamber_models.Injector(
+        elements={
+            **motor.thrust_chamber.injector.elements,
+            DILUENT_LINE_NAME: thrust_chamber_models.InjectorElement(
+                discharge_coefficient=0.48, area=2.0e-6 / 0.48
+            ),
+        }
+    )
+    return motor, params
+
+
+@pytest.fixture(scope="module")
+def state_after_one_timestep():
+    motor, params = build_engine_with_a_diluent_line()
+    state = biliquid_simulation.BiliquidEngineState(
+        motor=motor,
+        igniter_pressure=params.igniter_pressure,
+        external_pressure=params.external_pressure,
+    )
+    state.run_timestep(params.d_t, params.external_pressure)
+    return state
+
+
+class TestStatePerLine:
+    def test_every_series_is_keyed_by_line_name(self, state_after_one_timestep):
+        state = state_after_one_timestep
+        expected = {"oxidizer", "fuel", DILUENT_LINE_NAME}
+
+        assert set(state.fluid_mass_per_line) == expected
+        assert set(state.mass_flow_rate_per_line) == expected
+        assert set(state.tank_pressure_per_line) == expected
+        assert set(state.tank_temperature_per_line) == expected
+        assert set(state.internal_energy_per_line) == expected
+
+    def test_a_line_starts_at_its_tank_loading(self, state_after_one_timestep):
+        state = state_after_one_timestep
+
+        assert state.fluid_mass_per_line[DILUENT_LINE_NAME][0] == pytest.approx(0.5)
+
+    def test_a_third_line_drains_like_any_other(self, state_after_one_timestep):
+        state = state_after_one_timestep
+
+        assert state.mass_flow_rate_per_line[DILUENT_LINE_NAME][-1] > 0.0
+        assert (
+            state.fluid_mass_per_line[DILUENT_LINE_NAME][-1]
+            < state.fluid_mass_per_line[DILUENT_LINE_NAME][0]
+        )
+
+    def test_the_propellant_mass_adds_up_every_line(self, state_after_one_timestep):
+        state = state_after_one_timestep
+
+        assert state.propellant_mass[0] == pytest.approx(
+            sum(series[0] for series in state.fluid_mass_per_line.values())
+        )
+
+
+class TestMixtureRatio:
+    def test_is_the_oxidizer_total_over_the_fuel_total(self, state_after_one_timestep):
+        state = state_after_one_timestep
+
+        ratio = state._get_mixture_ratio(
+            {"oxidizer": 3.0, "fuel": 1.0, DILUENT_LINE_NAME: 5.0}
+        )
+
+        assert ratio == pytest.approx(3.0)
+
+    def test_an_additive_line_stays_out_of_the_ratio(self, state_after_one_timestep):
+        state = state_after_one_timestep
+        flows = {"oxidizer": 3.0, "fuel": 1.0}
+
+        assert state._get_mixture_ratio(
+            {**flows, DILUENT_LINE_NAME: 5.0}
+        ) == state._get_mixture_ratio({**flows, DILUENT_LINE_NAME: 0.0})
+
+    @pytest.mark.parametrize(
+        "flows",
+        [
+            {"oxidizer": 0.0, "fuel": 1.0},
+            {"oxidizer": 3.0, "fuel": 0.0},
+        ],
+    )
+    def test_a_side_that_stopped_flowing_leaves_no_ratio(
+        self, state_after_one_timestep, flows
+    ):
+        state = state_after_one_timestep
+
+        assert state._get_mixture_ratio({**flows, DILUENT_LINE_NAME: 1.0}) is None
+
+
+class TestResultPerLine:
+    @pytest.fixture(scope="class")
+    def result(self):
+        return run_simulation(*build_engine_with_a_diluent_line())
+
+    def test_every_series_is_keyed_by_line_name(self, result):
+        expected = {"oxidizer", "fuel", DILUENT_LINE_NAME}
+
+        assert set(result.fluid_mass_per_line) == expected
+        assert set(result.tank_pressure_per_line) == expected
+        assert set(result.tank_temperature_per_line) == expected
+        assert set(result.final_fluid_mass_per_line) == expected
+
+    def test_the_final_mass_is_where_the_series_ended(self, result):
+        for name, series in result.fluid_mass_per_line.items():
+            assert result.final_fluid_mass_per_line[name] == pytest.approx(series[-1])
+
+    def test_recorded_arrays_stay_aligned(self, result):
+        assert_recorded_arrays_aligned(result)
+
+    def test_the_report_lists_every_line(self, result):
+        file = io.StringIO()
+
+        result.report(file=file)
+
+        report = file.getvalue()
+        assert "PROPELLANT REMAINING (kg)" in report
+        for name in result.final_fluid_mass_per_line:
+            assert name.capitalize() in report
+
+    def test_the_summary_carries_a_final_mass_per_line(self, result):
+        summary = result.summary()
+
+        for name in result.final_fluid_mass_per_line:
+            assert f"final_{name}_mass" in summary
+
+    def test_the_masses_never_grow(self, result):
+        for name, series in result.fluid_mass_per_line.items():
+            assert (np.diff(series) <= 1e-9).all(), f"{name} mass increased"

--- a/tests/test_simulations/test_biliquid_tank_energy_balance.py
+++ b/tests/test_simulations/test_biliquid_tank_energy_balance.py
@@ -50,13 +50,13 @@ def results():
 
 
 def test_the_tank_pressure_decays_over_the_burn(results):
-    pressure = results[False].oxidizer_tank_pressure
+    pressure = results[False].tank_pressure_per_line["oxidizer"]
 
     assert pressure[-1] < 0.5 * pressure[0]
 
 
 def test_the_tank_cools_over_the_burn(results):
-    temperature = results[False].oxidizer_tank_temperature
+    temperature = results[False].tank_temperature_per_line["oxidizer"]
 
     assert temperature[0] == pytest.approx(OXIDIZER_TANK["temperature"])
     assert temperature[-1] < temperature[0]
@@ -69,16 +69,19 @@ def test_the_decay_is_monotonic_while_the_tank_holds_liquid(results):
     # the vapor fill it started at holds liquid at any temperature it reaches.
     # Past that the outflow enthalpy steps by the latent heat as the last of
     # the liquid goes, and the decay picks up a jitter on the way out.
-    two_phase = result.oxidizer_mass > tank.saturated_vapor_density * tank.volume
-    temperature = result.oxidizer_tank_temperature[two_phase]
+    two_phase = (
+        result.fluid_mass_per_line["oxidizer"]
+        > tank.saturated_vapor_density * tank.volume
+    )
+    temperature = result.tank_temperature_per_line["oxidizer"][two_phase]
 
     assert two_phase.sum() > 1
     assert np.all(np.diff(temperature) <= 0.0)
-    assert np.all(np.diff(result.oxidizer_tank_pressure[two_phase]) <= 0.0)
+    assert np.all(np.diff(result.tank_pressure_per_line["oxidizer"][two_phase]) <= 0.0)
 
 
 def test_an_isothermal_tank_holds_its_temperature(results):
-    temperature = results[True].oxidizer_tank_temperature
+    temperature = results[True].tank_temperature_per_line["oxidizer"]
 
     assert np.all(temperature == OXIDIZER_TANK["temperature"])
 
@@ -107,8 +110,8 @@ def test_the_state_carries_the_energy_only_for_an_energy_balance():
         external_pressure=params.external_pressure,
     )
 
-    assert isothermal_state.oxidizer_internal_energy is None
-    assert energy_balance_state.oxidizer_internal_energy == pytest.approx(
+    assert isothermal_state.internal_energy_per_line["oxidizer"] is None
+    assert energy_balance_state.internal_energy_per_line["oxidizer"] == pytest.approx(
         energy_balance_motor.feed_system.lines["oxidizer"].tank.initial_internal_energy
     )
 
@@ -121,15 +124,15 @@ def test_draining_takes_the_outflow_enthalpy_out():
         external_pressure=params.external_pressure,
     )
     tank = motor.feed_system.lines["oxidizer"].tank
-    internal_energy_before = state.oxidizer_internal_energy
+    internal_energy_before = state.internal_energy_per_line["oxidizer"]
     assert internal_energy_before is not None
-    oxidizer_mass_before = state.oxidizer_mass[-1]
+    oxidizer_mass_before = state.fluid_mass_per_line["oxidizer"][-1]
 
     state.run_timestep(params.d_t, params.external_pressure)
 
-    mass_drained = oxidizer_mass_before - state.oxidizer_mass[-1]
+    mass_drained = oxidizer_mass_before - state.fluid_mass_per_line["oxidizer"][-1]
     assert mass_drained > 0.0
-    assert state.oxidizer_internal_energy == pytest.approx(
+    assert state.internal_energy_per_line["oxidizer"] == pytest.approx(
         internal_energy_before
         - mass_drained
         * tank.get_outflow_specific_enthalpy(


### PR DESCRIPTION
Closes #495. Stacked on #500.

`BiliquidEngineState` kept a separate attribute per side for fluid mass, internal energy, mass flow rate, tank pressure and tank temperature, and computed the mixture ratio as one oxidizer-over-fuel division. `BiliquidSimulationResult` and the tank profile plot hardcoded the same two series.

- The state carries `fluid_mass_per_line`, `internal_energy_per_line`, `mass_flow_rate_per_line`, `tank_pressure_per_line` and `tank_temperature_per_line`, all keyed by line name, and drains the internal energy in a loop over the lines.
- The mixture ratio is the total oxidizer flow over the total fuel flow, taken by line role: no ratio for a monoliquid, and room for a hybrid grain to contribute to the fuel total.
- `BiliquidSimulationResult` exposes `fluid_mass_per_line`, `tank_pressure_per_line`, `tank_temperature_per_line` and `final_fluid_mass_per_line`; the report lists every line.
- `plot_bipropellant_tank_profiles` gives way to `plot_tank_profiles`, which draws one trace per line.
- New end-to-end coverage runs the 1 kN engine with a third line stacked below the piston and checks the bookkeeping holds.