### PR TITLE
Add a single-line pressure-fed feed system

### DIFF
--- a/docs/api/models/feed_systems/cycles.md
+++ b/docs/api/models/feed_systems/cycles.md
@@ -5,6 +5,7 @@ Concrete feed-system cycle implementations. A *cycle* is the topology that deter
 ## Available cycles
 
 - [`StackedTankPressureFedFeedSystem`](#stackedtankpressurefedfeedsystem) — Pressure-fed engine with the oxidizer tank stacked directly above a piston-separated fuel tank. Tank pressure provides both propellants' driving head.
+- [`SingleLinePressureFedFeedSystem`](#singlelinepressurefedfeedsystem) — Pressure-fed engine feeding one line, which the tank pressurizes itself. The one-line case of the contract: an oxidizer-only hybrid feed or a monoliquid.
 
 Additional cycles are under active development as separate work items: electric-pump, gas-generator, expander, and staged-combustion. When they land, they will reuse the dataclasses in [`feed_systems.components`](components.md) to describe their pumps, turbines, gas generators, and regenerative jackets.
 
@@ -78,6 +79,26 @@ feed_system = StackedTankPressureFedFeedSystem(
 - **HEM** (homogeneous-equilibrium two-phase) — `get_homogeneous_equilibrium_mass_flux` in [`machwave.core.two_phase_flow`](../../core.md), required for self-pressurized propellants such as nitrous oxide where the upstream saturated liquid flashes across the orifice and the flow can choke on the two-phase sound speed. The injector multiplies the returned mass flux by $C_d \cdot A$.
 
 Feedline pressure drop is stated for the design flow through `line_losses` rather than computed from the flow and the line geometry.
+
+---
+
+## `SingleLinePressureFedFeedSystem`
+
+One propellant line, pressurized by its own tank: a self-pressurized propellant rides its vapor pressure while liquid remains, then blows down on the real-gas equation of state. What reaches the injector is that pressure less `line_loss`. An empty tank delivers nothing, which stops the flow at the injector element.
+
+**Construction**
+
+```python
+from machwave.models.feed_systems import SingleLinePressureFedFeedSystem
+from machwave.models.feed_systems.tank import Tank
+
+feed_system = SingleLinePressureFedFeedSystem.from_oxidizer_tank(
+    oxidizer_tank=Tank("N2O", volume=0.010, temperature=298.0, initial_fluid_mass=5.0),
+    line_loss=2e5,  # Pa
+)
+```
+
+A monoliquid names its own line and role instead, through the `PropellantLine` constructor.
 
 ---
 

--- a/machwave/models/feed_systems/__init__.py
+++ b/machwave/models/feed_systems/__init__.py
@@ -1,5 +1,8 @@
 from machwave.models.feed_systems import components
 from machwave.models.feed_systems.base import FeedSystem
+from machwave.models.feed_systems.cycles.single_line_pressure_fed import (
+    SingleLinePressureFedFeedSystem,
+)
 from machwave.models.feed_systems.cycles.stacked_tank_pressure_fed import (
     StackedTankPressureFedFeedSystem,
 )
@@ -9,6 +12,7 @@ __all__ = [
     "FeedSystem",
     "LineState",
     "PropellantLine",
+    "SingleLinePressureFedFeedSystem",
     "StackedTankPressureFedFeedSystem",
     "components",
 ]

--- a/machwave/models/feed_systems/cycles/__init__.py
+++ b/machwave/models/feed_systems/cycles/__init__.py
@@ -7,10 +7,14 @@ the shared component specifications in `machwave.models.feed_systems.components`
 and conform to the `machwave.models.feed_systems.base.FeedSystem` contract.
 """
 
+from machwave.models.feed_systems.cycles.single_line_pressure_fed import (
+    SingleLinePressureFedFeedSystem,
+)
 from machwave.models.feed_systems.cycles.stacked_tank_pressure_fed import (
     StackedTankPressureFedFeedSystem,
 )
 
 __all__ = [
+    "SingleLinePressureFedFeedSystem",
     "StackedTankPressureFedFeedSystem",
 ]

--- a/machwave/models/feed_systems/cycles/single_line_pressure_fed.py
+++ b/machwave/models/feed_systems/cycles/single_line_pressure_fed.py
@@ -1,0 +1,88 @@
+from collections.abc import Mapping
+
+import machwave.models.feed_systems.base as feed_system_base
+import machwave.models.feed_systems.lines as line_models
+import machwave.models.feed_systems.tank as tank
+import machwave.models.propellants.components as propellant_components
+
+
+class SingleLinePressureFedFeedSystem(feed_system_base.FeedSystem):
+    """
+    Pressure-fed feed system delivering a single propellant line.
+
+    The tank pressurizes itself: a self-pressurized propellant rides its own
+    vapor pressure while liquid remains, and blows down on the real-gas
+    equation of state once none does. This is the one-line case of the feed
+    system contract, which an oxidizer-only hybrid feed and a monoliquid engine
+    both run on.
+    """
+
+    def __init__(
+        self,
+        line: line_models.PropellantLine,
+        line_loss: float = 0.0,
+    ):
+        """
+        Initialize the SingleLinePressureFedFeedSystem.
+
+        Args:
+            line: The propellant line the system feeds.
+            line_loss: Pressure loss along the feedline [Pa], stated for the
+                design flow rather than computed from it.
+
+        Raises:
+            ValueError: If the pressure loss is negative.
+        """
+        super().__init__([line])
+
+        self.line_loss = line_loss
+
+        if line_loss < 0.0:
+            raise ValueError(f"line_loss must be non-negative, got {line_loss}")
+
+    @classmethod
+    def from_oxidizer_tank(
+        cls,
+        *,
+        oxidizer_tank: tank.Tank,
+        line_loss: float = 0.0,
+    ) -> "SingleLinePressureFedFeedSystem":
+        """
+        Build the oxidizer-only system a hybrid motor runs on.
+
+        Args:
+            oxidizer_tank: Tank the oxidizer line draws from.
+            line_loss: Pressure loss along the feedline [Pa].
+        """
+        return cls(
+            line=line_models.PropellantLine(
+                name="oxidizer",
+                role=propellant_components.ComponentRole.OXIDIZER,
+                tank=oxidizer_tank,
+            ),
+            line_loss=line_loss,
+        )
+
+    @property
+    def line(self) -> line_models.PropellantLine:
+        """The one line the system feeds."""
+        return next(iter(self.lines.values()))
+
+    def get_inlet_pressures(
+        self, line_states: Mapping[str, line_models.LineState]
+    ) -> dict[str, float]:
+        """
+        Return the tank pressure less the feedline loss [Pa], keyed by line name.
+
+        Args:
+            line_states: Fluid mass and internal energy of the line, keyed by
+                line name.
+        """
+        line_state = line_states[self.line.name]
+
+        return {
+            self.line.name: self.line.tank.get_pressure(
+                line_state.fluid_mass, line_state.internal_energy
+            )
+            - self.line_loss
+        }

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -7,6 +7,7 @@ layer.
 from tests.factories.common import FluidStateFactory
 from tests.factories.feed_systems import (
     PropellantLineFactory,
+    SingleLinePressureFedFeedSystemFactory,
     StackedTankPressureFedFeedSystemFactory,
     TankFactory,
 )
@@ -59,6 +60,7 @@ __all__ = [
     "OxidizerComponentFactory",
     "PropellantLineFactory",
     "RodAndTubeGrainSegmentFactory",
+    "SingleLinePressureFedFeedSystemFactory",
     "SolidMotorFactory",
     "SolidMotorThrustChamberFactory",
     "SolidPropellantPropertiesFactory",

--- a/tests/factories/feed_systems.py
+++ b/tests/factories/feed_systems.py
@@ -33,6 +33,17 @@ class PropellantLineFactory:
         return feed_systems_models.PropellantLine(**kwargs)
 
 
+class SingleLinePressureFedFeedSystemFactory:
+    @classmethod
+    def build(
+        cls, **overrides: Any
+    ) -> feed_systems_models.SingleLinePressureFedFeedSystem:
+        line = overrides.pop("line", None) or PropellantLineFactory.build()
+        kwargs: dict[str, Any] = dict(line=line)
+        kwargs.update(overrides)
+        return feed_systems_models.SingleLinePressureFedFeedSystem(**kwargs)
+
+
 class StackedTankPressureFedFeedSystemFactory:
     @classmethod
     def build(

--- a/tests/test_models/test_propulsion/test_feed_systems/test_single_line_pressure_fed.py
+++ b/tests/test_models/test_propulsion/test_feed_systems/test_single_line_pressure_fed.py
@@ -1,0 +1,141 @@
+import pytest
+
+import machwave.models.feed_systems as feed_systems_models
+import machwave.models.propellants as propellants_models
+import machwave.simulation.biliquid.states as biliquid_states
+from machwave.models.feed_systems.lines import LineState
+from tests.factories import (
+    InjectorElementFactory,
+    InjectorFactory,
+    PropellantLineFactory,
+    SingleLinePressureFedFeedSystemFactory,
+    TankFactory,
+)
+
+
+def line_states(feed_system):
+    return {name: line.initial_state for name, line in feed_system.lines.items()}
+
+
+class TestInletState:
+    def test_the_inlet_reads_the_tank(self):
+        tank = TankFactory.build(fluid_name="N2O", initial_fluid_mass=5.0)
+        feed_system = SingleLinePressureFedFeedSystemFactory.build(
+            line=PropellantLineFactory.build(tank=tank)
+        )
+
+        inlet = feed_system.get_inlet_states(line_states(feed_system))["oxidizer"]
+
+        assert inlet.fluid_name == "N2O"
+        assert inlet.pressure == pytest.approx(tank.get_pressure(5.0))
+        assert inlet.temperature == pytest.approx(tank.get_temperature(5.0))
+        assert inlet.density == pytest.approx(tank.get_density(5.0))
+
+    def test_the_feedline_comes_off_the_tank_pressure(self):
+        feed_system = SingleLinePressureFedFeedSystemFactory.build(line_loss=3e5)
+        tank = feed_system.line.tank
+
+        pressures = feed_system.get_inlet_pressures(line_states(feed_system))
+
+        assert pressures["oxidizer"] == pytest.approx(
+            tank.get_pressure(tank.initial_fluid_mass) - 3e5
+        )
+
+    def test_an_empty_tank_delivers_no_pressure(self):
+        feed_system = SingleLinePressureFedFeedSystemFactory.build()
+
+        pressures = feed_system.get_inlet_pressures(
+            {"oxidizer": LineState(fluid_mass=0.0)}
+        )
+
+        assert pressures["oxidizer"] == 0.0
+
+    def test_the_tank_blows_down_as_it_drains(self):
+        feed_system = SingleLinePressureFedFeedSystemFactory.build(
+            line=PropellantLineFactory.build(
+                tank=TankFactory.build(fluid_name="N2O", initial_fluid_mass=5.0)
+            )
+        )
+
+        pressures = [
+            feed_system.get_inlet_pressures({"oxidizer": LineState(fluid_mass=mass)})[
+                "oxidizer"
+            ]
+            for mass in (5.0, 0.5, 0.05)
+        ]
+
+        assert pressures[0] >= pressures[1] > pressures[2]
+
+
+class TestSingleLineContract:
+    def test_the_system_feeds_exactly_one_line(self):
+        feed_system = SingleLinePressureFedFeedSystemFactory.build()
+
+        assert list(feed_system.lines) == ["oxidizer"]
+        assert feed_system.line is feed_system.lines["oxidizer"]
+
+    def test_the_initial_propellant_mass_is_the_one_tank_loading(self):
+        feed_system = SingleLinePressureFedFeedSystemFactory.build()
+
+        assert feed_system.get_initial_propellant_mass() == pytest.approx(
+            feed_system.line.tank.initial_fluid_mass
+        )
+
+    def test_a_monoliquid_line_carries_the_fuel_role(self):
+        feed_system = SingleLinePressureFedFeedSystemFactory.build(
+            line=PropellantLineFactory.build(name="propellant", role="fuel")
+        )
+
+        assert feed_system.get_lines_with_role(
+            propellants_models.ComponentRole.FUEL
+        ) == (feed_system.line,)
+        assert (
+            feed_system.get_lines_with_role(propellants_models.ComponentRole.OXIDIZER)
+            == ()
+        )
+
+    def test_one_line_feeds_one_injector_element(self):
+        """The simulation-facing flow helper holds below two lines."""
+        feed_system = SingleLinePressureFedFeedSystemFactory.build()
+        injector = InjectorFactory.build(
+            elements={"oxidizer": InjectorElementFactory.build()}
+        )
+
+        flows = biliquid_states.get_injector_mass_flows(
+            20e5,
+            injector=injector,
+            inlet_states=feed_system.get_inlet_states(line_states(feed_system)),
+            line_masses={"oxidizer": feed_system.line.tank.initial_fluid_mass},
+            is_feeding=True,
+            d_t=1e-4,
+        )
+
+        assert list(flows) == ["oxidizer"]
+        assert flows["oxidizer"] > 0.0
+
+
+class TestOxidizerTankConstructor:
+    def test_names_the_line_oxidizer(self):
+        feed_system = (
+            feed_systems_models.SingleLinePressureFedFeedSystem.from_oxidizer_tank(
+                oxidizer_tank=TankFactory.build()
+            )
+        )
+
+        assert feed_system.line.name == "oxidizer"
+        assert feed_system.line.role is propellants_models.ComponentRole.OXIDIZER
+
+    def test_carries_the_feedline_loss(self):
+        feed_system = (
+            feed_systems_models.SingleLinePressureFedFeedSystem.from_oxidizer_tank(
+                oxidizer_tank=TankFactory.build(), line_loss=2e5
+            )
+        )
+
+        assert feed_system.line_loss == 2e5
+
+
+class TestValidation:
+    def test_rejects_a_negative_line_loss(self):
+        with pytest.raises(ValueError, match="line_loss"):
+            SingleLinePressureFedFeedSystemFactory.build(line_loss=-1.0)


### PR DESCRIPTION
Closes #496. Stacked on #501.

An oxidizer-only hybrid feed and a monoliquid feed are both the one-line case of the feed system contract, but no cycle exercised that case and nothing proved the contract held below two lines.

- `SingleLinePressureFedFeedSystem` delivers one line, pressurized by its own tank, less the feedline loss. `from_oxidizer_tank` builds the hybrid case; a monoliquid names its own line and role.
- Tests cover the inlet state, the blowdown as the tank drains, the empty tank, the role lookup for a monoliquid line, and one line feeding one injector element through the simulation flow helper.

On the `OxidizerFeedSystem` sibling abstraction proposed in #237: it is no longer needed. #237 rejected promoting `FeedSystem` to a generic N-line container as too invasive, which is exactly what this milestone did; the hybrid feed is now the one-line case of the shared contract rather than a parallel hierarchy. Recommend closing #237 as superseded.